### PR TITLE
feat: add agent language heuristics and coaching payload types

### DIFF
--- a/src/lib/agent/config.ts
+++ b/src/lib/agent/config.ts
@@ -2,9 +2,17 @@
  * Agent SDK feature flags and model selection.
  * These allow safe rollout and shadow traffic without impacting production.
  */
-export const agentFlags = {
-  enabled: process.env.AGENT_SDK_ENABLED === 'true',
-  shadow: process.env.AGENT_SDK_SHADOW === 'true',
-  model: process.env.AGENT_SDK_MODEL ?? 'gpt-4o-mini',
-};
+export const AGENT_SDK_MODEL_DEFAULT = "gpt-4o-mini";
+
+export const AGENT_SDK_ENABLED = process.env.AGENT_SDK_ENABLED === "true";
+export const AGENT_SDK_SHADOW = process.env.AGENT_SDK_SHADOW === "true";
+export const AGENT_SDK_MODEL = process.env.AGENT_SDK_MODEL ?? AGENT_SDK_MODEL_DEFAULT;
+
+export const agentFlags = Object.freeze({
+  enabled: AGENT_SDK_ENABLED,
+  shadow: AGENT_SDK_SHADOW,
+  model: AGENT_SDK_MODEL,
+});
+
+export type AgentFlags = typeof agentFlags;
 

--- a/src/lib/agent/types.ts
+++ b/src/lib/agent/types.ts
@@ -1,5 +1,62 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 
+export type ConfidenceLevel = "low" | "medium" | "high";
+
+export enum ProposedChangeCategory {
+  Content = "content",
+  Structure = "structure",
+  Formatting = "formatting",
+  DataQuality = "data_quality",
+  Compliance = "compliance",
+}
+
+export enum CoachingTone {
+  Supportive = "supportive",
+  Direct = "direct",
+  Analytical = "analytical",
+}
+
+export enum CoachingFocusArea {
+  Language = "language",
+  Skills = "skills",
+  Metrics = "metrics",
+  Design = "design",
+  Ats = "ats",
+}
+
+export interface LanguageDetection {
+  lang: string;
+  confidence: number;
+  rtl: boolean;
+  source?: "heuristic" | "model";
+}
+
+export interface ProposedChange {
+  id: string;
+  summary: string;
+  scope: DiffScope;
+  category: ProposedChangeCategory;
+  confidence: ConfidenceLevel;
+  rationale?: string;
+  before?: string;
+  after?: string;
+  requires_human_review?: boolean;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface CoachingPayload {
+  headline?: string;
+  focus: CoachingFocusArea[];
+  tone?: CoachingTone;
+  guidance: string[];
+  proposed_changes?: ProposedChange[];
+  blockers?: string[];
+  follow_up_questions?: string[];
+  language?: LanguageDetection;
+  metadata?: Record<string, unknown>;
+}
+
 export type Intent =
   | "rewrite"
   | "add_skills"
@@ -34,6 +91,9 @@ export interface AgentResult {
     notes?: string;
   };
   ui_prompts?: string[];
+  proposed_changes?: ProposedChange[];
+  coaching?: CoachingPayload;
+  language?: LanguageDetection;
 }
 
 export interface RunInput {

--- a/src/lib/agent/utils/language.ts
+++ b/src/lib/agent/utils/language.ts
@@ -1,0 +1,190 @@
+import { LanguageDetection } from "../types";
+
+export interface DetectLanguageModelResult {
+  lang?: string;
+  confidence?: number;
+  rtl?: boolean;
+}
+
+export type DetectLanguageModel = (input: {
+  text: string;
+  signal?: AbortSignal;
+}) => Promise<DetectLanguageModelResult | null>;
+
+export interface DetectLanguageOptions {
+  callModel?: DetectLanguageModel;
+  preferModel?: boolean;
+  minConfidenceForModel?: number;
+  defaultLanguage?: string;
+  signal?: AbortSignal;
+}
+
+const DEFAULT_LANGUAGE = "en";
+
+const RTL_LANGUAGE_CODES = new Set(["ar", "he", "fa", "ur"]);
+
+const LANGUAGE_RULES: Array<{
+  code: string;
+  pattern: RegExp;
+  rtl?: boolean;
+}> = [
+  { code: "he", pattern: /[\u0590-\u05FF]/g, rtl: true },
+  { code: "ar", pattern: /[\u0600-\u06FF]/g, rtl: true },
+  { code: "fa", pattern: /[\u0750-\u077F\u08A0-\u08FF]/g, rtl: true },
+  { code: "ru", pattern: /[\u0400-\u04FF]/g },
+  { code: "es", pattern: /[áéíóúñüÁÉÍÓÚÑÜ]/g },
+  { code: "en", pattern: /[A-Za-z]/g },
+];
+
+function countMatches(text: string, pattern: RegExp): number {
+  const matches = text.match(pattern);
+  return matches ? matches.length : 0;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function heuristicDetection(
+  text: string,
+  defaultLanguage: string
+): LanguageDetection {
+  const sanitized = text.trim();
+  if (!sanitized) {
+    return {
+      lang: defaultLanguage,
+      confidence: 0,
+      rtl: RTL_LANGUAGE_CODES.has(defaultLanguage),
+      source: "heuristic",
+    };
+  }
+
+  const letterMatches = sanitized.match(/[A-Za-z\u00C0-\u024F\u0400-\u04FF\u0590-\u05FF\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF]/g);
+  const totalLetters = letterMatches ? letterMatches.length : 0;
+
+  if (!totalLetters) {
+    return {
+      lang: defaultLanguage,
+      confidence: 0.2,
+      rtl: RTL_LANGUAGE_CODES.has(defaultLanguage),
+      source: "heuristic",
+    };
+  }
+
+  const counts = new Map<string, number>();
+  for (const rule of LANGUAGE_RULES) {
+    const count = countMatches(sanitized, rule.pattern);
+    if (count > 0) {
+      counts.set(rule.code, count);
+    }
+  }
+
+  if (!counts.size) {
+    return {
+      lang: defaultLanguage,
+      confidence: 0.25,
+      rtl: RTL_LANGUAGE_CODES.has(defaultLanguage),
+      source: "heuristic",
+    };
+  }
+
+  const ranked = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  const [primaryCode, primaryCount] = ranked[0];
+  const primaryRatio = primaryCount / totalLetters;
+  const secondEntry = ranked[1];
+  const secondaryRatio = secondEntry ? secondEntry[1] / totalLetters : 0;
+
+  const likelyMixed =
+    secondEntry &&
+    secondaryRatio >= 0.25 &&
+    Math.abs(primaryRatio - secondaryRatio) <= 0.2;
+
+  let lang = likelyMixed ? "mixed" : primaryCode;
+  let rtl =
+    likelyMixed
+      ? ranked
+          .slice(0, 2)
+          .some(([code]) => RTL_LANGUAGE_CODES.has(code))
+      : RTL_LANGUAGE_CODES.has(primaryCode);
+
+  let confidence: number;
+  if (likelyMixed) {
+    confidence = clamp((primaryRatio + secondaryRatio) / 1.5, 0.4, 0.65);
+  } else if (primaryRatio >= 0.75) {
+    confidence = 0.92;
+  } else if (primaryRatio >= 0.55) {
+    confidence = 0.78;
+  } else if (primaryRatio >= 0.35) {
+    confidence = 0.62;
+  } else {
+    confidence = 0.45;
+  }
+
+  if (totalLetters < 6) {
+    confidence = Math.min(confidence, 0.6);
+  }
+
+  return {
+    lang,
+    confidence,
+    rtl,
+    source: "heuristic",
+  };
+}
+
+export async function detectLanguage(
+  rawText: string,
+  options: DetectLanguageOptions = {}
+): Promise<LanguageDetection> {
+  const text = rawText ?? "";
+  const defaultLanguage = options.defaultLanguage ?? DEFAULT_LANGUAGE;
+  const heuristic = heuristicDetection(text, defaultLanguage);
+
+  if (!options.callModel) {
+    return heuristic;
+  }
+
+  const threshold = clamp(
+    options.minConfidenceForModel ?? 0.75,
+    0,
+    1
+  );
+  const shouldCallModel = options.preferModel || heuristic.confidence < threshold;
+
+  if (!shouldCallModel) {
+    return heuristic;
+  }
+
+  try {
+    const modelResult = await options.callModel({
+      text,
+      signal: options.signal,
+    });
+    if (modelResult && modelResult.lang) {
+      const lang = modelResult.lang.toLowerCase();
+      const confidence = clamp(
+        modelResult.confidence ?? heuristic.confidence,
+        heuristic.confidence,
+        1
+      );
+      const rtl =
+        typeof modelResult.rtl === "boolean"
+          ? modelResult.rtl
+          : RTL_LANGUAGE_CODES.has(lang);
+      return {
+        lang,
+        confidence,
+        rtl,
+        source: "model",
+      };
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("detectLanguage model call failed", error);
+    }
+  }
+
+  return heuristic;
+}
+
+export { RTL_LANGUAGE_CODES };

--- a/tests/agent/language-detection.test.ts
+++ b/tests/agent/language-detection.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { detectLanguage } from "@/lib/agent/utils/language";
+
+describe("detectLanguage", () => {
+  it("detects Hebrew text with high confidence", async () => {
+    const result = await detectLanguage("שלום עולם, אני כותב בעברית מלאה.");
+    expect(result.lang).toBe("he");
+    expect(result.rtl).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0.6);
+  });
+
+  it("marks mixed Hebrew and English content", async () => {
+    const result = await detectLanguage("שלום לצוות, this resume mixes English עם עברית.");
+    expect(result.lang).toBe("mixed");
+    expect(result.rtl).toBe(true);
+    expect(result.confidence).toBeGreaterThan(0.4);
+    expect(result.confidence).toBeLessThanOrEqual(0.65);
+  });
+
+  it("propagates rtl flag from model results when requested", async () => {
+    const callModel = jest.fn().mockResolvedValue({
+      lang: "ar",
+      confidence: 0.9,
+      rtl: true,
+    });
+    const result = await detectLanguage("مرحبا بالعالم", {
+      callModel,
+      preferModel: true,
+    });
+    expect(callModel).toHaveBeenCalled();
+    expect(result.lang).toBe("ar");
+    expect(result.rtl).toBe(true);
+    expect(result.confidence).toBeGreaterThanOrEqual(0.9);
+  });
+});


### PR DESCRIPTION
## Summary
- extend agent types with ProposedChange, CoachingPayload, and language detection metadata to support richer coaching flows
- implement a heuristic-driven `detectLanguage` utility with optional model override and expose feature flag constants for the agent SDK
- add focused Jest coverage for Hebrew detection, mixed language heuristics, and RTL propagation

## Testing
- npm run test -- --env=node language-detection *(fails: Cannot find module '@testing-library/jest-dom' from jest.setup.js)*

------
https://chatgpt.com/codex/tasks/task_e_690af4ad0c24832aa8f3d631146125cc