### PR TITLE
feat: implement agent apply pipeline

### DIFF
--- a/src/app/api/agent/apply/route.ts
+++ b/src/app/api/agent/apply/route.ts
@@ -1,20 +1,153 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
+import { safeParseATSReport, safeParseOptimizedResume, ProposedChangeSchema } from "@/lib/agent/validators";
+import { ResumeWriter } from "@/lib/agent/tools/resume-writer";
+import { DesignOps } from "@/lib/agent/tools/design-ops";
+import { LayoutEngine } from "@/lib/agent/tools/layout-engine";
+import { ATS } from "@/lib/agent/tools/ats";
 import { HistoryStore } from "@/lib/agent/tools/history-store";
+import { Versioning } from "@/lib/agent/tools/versioning";
+import { detectLanguage } from "@/lib/agent/utils/language";
+import { extractResumeText } from "@/lib/ats";
+import type { ThemeOptions } from "@/lib/agent/types";
+import { getFallbackATS, getFallbackArtifacts } from "@/lib/agent/runtime/fallbacks";
+
+const ThemeSchema = z
+  .object({
+    font_family: z.string().optional(),
+    color_hex: z.string().optional(),
+    spacing: z.string().optional(),
+    density: z.enum(["compact", "cozy"]).optional(),
+    layout: z.string().optional(),
+    direction: z.enum(["ltr", "rtl"]).optional(),
+  })
+  .partial();
+
+const ApplySchema = z.object({
+  resume_json: z.any(),
+  proposed_changes: z.array(ProposedChangeSchema).min(1, "proposed_changes must include at least one change"),
+  job_text: z.string().optional(),
+  design: ThemeSchema.optional(),
+  baseline_scores: z
+    .object({
+      ats: z.number().min(0).max(100).nullable().optional(),
+    })
+    .optional(),
+});
+
+export const runtime = "nodejs";
 
 export async function POST(req: NextRequest) {
   const supabase = await createRouteHandlerClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
+  let body: unknown;
   try {
-    const { history_id, apply_date } = await req.json();
-    if (!history_id) return NextResponse.json({ error: "history_id is required" }, { status: 400 });
-    const date = apply_date || new Date().toISOString();
-    const updated = await HistoryStore.linkApply({ history_id, apply_date: date });
-    return NextResponse.json({ id: updated.id, apply_date: updated.apply_date });
-  } catch (e: any) {
-    return NextResponse.json({ error: e?.message || "Apply error" }, { status: 500 });
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const parsed = ApplySchema.safeParse(body);
+  if (!parsed.success) {
+    const formatted = parsed.error.flatten();
+    return NextResponse.json(
+      {
+        error: "Invalid request payload",
+        details: formatted.fieldErrors,
+      },
+      { status: 400 }
+    );
+  }
+
+  const { resume_json, proposed_changes, job_text, design, baseline_scores } = parsed.data;
+
+  try {
+    const originalResume = safeParseOptimizedResume(resume_json) as OptimizedResume;
+    const appliedResume = ResumeWriter.applyProposedChanges(originalResume, proposed_changes);
+
+    let resumeText = "";
+    try {
+      resumeText = extractResumeText(appliedResume as any);
+    } catch {
+      resumeText = JSON.stringify({ summary: appliedResume.summary ?? "" });
+    }
+
+    let language = { lang: "en", confidence: 0.5, rtl: false, source: "heuristic" as const };
+    try {
+      language = await detectLanguage(resumeText);
+    } catch {
+      // keep fallback language
+    }
+
+    const normalizedResume = safeParseOptimizedResume({
+      ...(appliedResume as any),
+      language,
+    }) as OptimizedResume;
+
+    const themeOptions: ThemeOptions = {
+      ...(design ?? {}),
+      language: language.lang,
+      rtl: language.rtl,
+    } as ThemeOptions;
+    const theme = DesignOps.theme(themeOptions);
+
+    let previewPath: string | undefined;
+    try {
+      const rendered = await LayoutEngine.render(normalizedResume, theme);
+      previewPath = rendered.preview_pdf_path;
+    } catch (error) {
+      const fallback = getFallbackArtifacts();
+      previewPath = fallback.preview_pdf_path ?? undefined;
+    }
+
+    let atsReport = safeParseATSReport(getFallbackATS());
+    try {
+      const scored = await ATS.score({ resume_json: normalizedResume as any, job_text });
+      atsReport = safeParseATSReport(scored);
+    } catch {
+      atsReport = safeParseATSReport(getFallbackATS());
+    }
+
+    const beforeScore = baseline_scores?.ats ?? null;
+    const afterScore = atsReport.score ?? 0;
+    const delta = typeof beforeScore === "number" ? afterScore - beforeScore : null;
+
+    const version = await Versioning.commit(user.id, normalizedResume as any);
+    const history = await HistoryStore.save({
+      user_id: user.id,
+      resume_version_id: version.resume_version_id,
+      ats_score: afterScore,
+      artifacts: previewPath ? [{ type: "pdf", path: previewPath }] : [],
+      proposed_changes,
+    });
+
+    return NextResponse.json({
+      resume_json: normalizedResume,
+      preview_url: previewPath ?? null,
+      after_scores: {
+        ats: {
+          score: afterScore,
+          before: beforeScore,
+          delta,
+          missing_keywords: atsReport.missing_keywords ?? [],
+          recommendations: atsReport.recommendations ?? [],
+          languages: atsReport.languages ?? {},
+        },
+      },
+      history_entry_id: history.id,
+      language,
+    });
+  } catch (error: any) {
+    return NextResponse.json(
+      { error: "Failed to apply changes", message: error?.message ?? "Unexpected error" },
+      { status: 500 }
+    );
   }
 }
 

--- a/tests/contract/test_agent_apply.spec.ts
+++ b/tests/contract/test_agent_apply.spec.ts
@@ -1,0 +1,207 @@
+/** @jest-environment node */
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import type { NextRequest } from 'next/server';
+
+const mockAuthGetUser = jest.fn();
+const mockRender = jest.fn();
+const mockATSScore = jest.fn();
+const mockHistorySave = jest.fn();
+const mockVersioningCommit = jest.fn();
+const mockDetectLanguage = jest.fn();
+const mockExtractResumeText = jest.fn();
+const mockCookies = jest.fn();
+
+jest.mock('@/lib/supabase-server', () => ({
+  __esModule: true,
+  createRouteHandlerClient: () => Promise.resolve({ auth: { getUser: mockAuthGetUser } }),
+}));
+
+jest.mock('next/headers', () => ({
+  cookies: () => mockCookies(),
+}));
+
+jest.mock('@/lib/agent/tools/layout-engine', () => ({
+  LayoutEngine: {
+    render: (...args: any[]) => mockRender(...args),
+  },
+}));
+
+jest.mock('@/lib/agent/tools/ats', () => ({
+  ATS: {
+    score: (...args: any[]) => mockATSScore(...args),
+  },
+}));
+
+jest.mock('@/lib/agent/tools/history-store', () => ({
+  HistoryStore: {
+    save: (...args: any[]) => mockHistorySave(...args),
+  },
+}));
+
+jest.mock('@/lib/agent/tools/versioning', () => ({
+  Versioning: {
+    commit: (...args: any[]) => mockVersioningCommit(...args),
+  },
+}));
+
+jest.mock('@/lib/agent/utils/language', () => ({
+  detectLanguage: (...args: any[]) => mockDetectLanguage(...args),
+  RTL_LANGUAGE_CODES: new Set(['ar', 'he', 'fa', 'ur']),
+}));
+
+jest.mock('@/lib/ats', () => ({
+  extractResumeText: (...args: any[]) => mockExtractResumeText(...args),
+}));
+
+type PostHandler = typeof import('@/app/api/agent/apply/route')['POST'];
+let postHandler: PostHandler;
+
+const baseResume = {
+  summary: 'Experienced engineer',
+  contact: { name: 'Taylor Dev', email: 'taylor@example.com', phone: '555-0000', location: 'Remote' },
+  skills: { technical: ['TypeScript'], soft: ['Leadership'] },
+  experience: [],
+  education: [],
+};
+
+function createRequest(body: Record<string, any>): NextRequest {
+  return {
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+beforeAll(async () => {
+  ({ POST: postHandler } = await import('@/app/api/agent/apply/route'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+
+  mockCookies.mockResolvedValue({
+    get: jest.fn(),
+    set: jest.fn(),
+  });
+  mockAuthGetUser.mockResolvedValue({ data: { user: { id: 'user-123' } } });
+
+  mockRender.mockResolvedValue({ html: '<html></html>', preview_pdf_path: 'artifacts/new-preview.pdf' });
+  mockATSScore.mockResolvedValue({ score: 88, missing_keywords: ['GraphQL'], recommendations: ['Add GraphQL'], languages: {} });
+  mockHistorySave.mockResolvedValue({ id: 'history-123' });
+  mockVersioningCommit.mockResolvedValue({ resume_version_id: 'version-1', created_at: '2024-01-01T00:00:00Z' });
+  mockDetectLanguage.mockResolvedValue({ lang: 'en', confidence: 0.9, rtl: false, source: 'heuristic' });
+  mockExtractResumeText.mockReturnValue('Sample resume text');
+});
+
+describe('POST /api/agent/apply - contract', () => {
+  it('applies proposed change batch and returns updated resume JSON', async () => {
+    const payload = {
+      resume_json: baseResume,
+      proposed_changes: [
+        {
+          id: 'change-1',
+          summary: 'Update summary',
+          scope: 'paragraph',
+          category: 'content',
+          confidence: 'high',
+          before: 'Experienced engineer',
+          after: 'Updated engineering summary',
+          metadata: { pointer: '/summary' },
+        },
+      ],
+      baseline_scores: { ats: 72 },
+    };
+
+    const res = await postHandler(createRequest(payload));
+    expect(res.status).toBe(200);
+
+    const data = await res.json();
+    expect(data.resume_json.summary).toBe('Updated engineering summary');
+    expect(mockRender).toHaveBeenCalledTimes(1);
+    expect(mockATSScore).toHaveBeenCalledWith({ resume_json: expect.any(Object), job_text: undefined });
+  });
+
+  it('regenerates preview with normalized RTL-aware theme', async () => {
+    mockDetectLanguage.mockResolvedValueOnce({ lang: 'ar', confidence: 0.96, rtl: true, source: 'heuristic' });
+    mockRender.mockResolvedValueOnce({ html: '<html dir="rtl"></html>', preview_pdf_path: 'artifacts/rtl.pdf' });
+
+    const payload = {
+      resume_json: { ...baseResume, summary: 'مرحبا بالعالم' },
+      proposed_changes: [
+        {
+          id: 'change-rtl',
+          summary: 'RTL summary update',
+          scope: 'paragraph',
+          category: 'content',
+          confidence: 'medium',
+          before: 'مرحبا بالعالم',
+          after: 'مرحبا بكم',
+          metadata: { pointer: '/summary' },
+        },
+      ],
+    };
+
+    const res = await postHandler(createRequest(payload));
+    const data = await res.json();
+
+    expect(data.preview_url).toBe('artifacts/rtl.pdf');
+    const [, themeArg] = mockRender.mock.calls[0];
+    expect(themeArg.direction).toBe('rtl');
+    expect(data.language.rtl).toBe(true);
+  });
+
+  it('computes ATS delta from provided baseline score', async () => {
+    mockATSScore.mockResolvedValueOnce({ score: 90, missing_keywords: [], recommendations: [], languages: {} });
+
+    const payload = {
+      resume_json: baseResume,
+      proposed_changes: [
+        {
+          id: 'change-ats',
+          summary: 'Boost ATS',
+          scope: 'paragraph',
+          category: 'content',
+          confidence: 'medium',
+          before: 'Experienced engineer',
+          after: 'Experienced engineer with React and GraphQL expertise',
+          metadata: { pointer: '/summary' },
+        },
+      ],
+      baseline_scores: { ats: 60 },
+    };
+
+    const res = await postHandler(createRequest(payload));
+    const data = await res.json();
+
+    expect(data.after_scores.ats.score).toBe(90);
+    expect(data.after_scores.ats.before).toBe(60);
+    expect(data.after_scores.ats.delta).toBe(30);
+  });
+
+  it('logs history entry with proposed changes included', async () => {
+    const payload = {
+      resume_json: baseResume,
+      proposed_changes: [
+        {
+          id: 'change-history',
+          summary: 'Record history',
+          scope: 'paragraph',
+          category: 'content',
+          confidence: 'low',
+          before: 'Experienced engineer',
+          after: 'Experienced engineer and mentor',
+          metadata: { pointer: '/summary' },
+        },
+      ],
+    };
+
+    const res = await postHandler(createRequest(payload));
+    const data = await res.json();
+
+    expect(data.history_entry_id).toBe('history-123');
+    expect(mockHistorySave).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: 'user-123',
+      resume_version_id: 'version-1',
+      proposed_changes: payload.proposed_changes,
+    }));
+    expect(mockVersioningCommit).toHaveBeenCalledWith('user-123', expect.any(Object));
+  });
+});


### PR DESCRIPTION
## Summary
- implement the /api/agent/apply route to validate payloads, apply proposed changes, normalize layout, render a preview, rescore ATS, and persist history entries
- auto-detect resume language to drive RTL-aware themes and include resume JSON, preview URL, after-scores, and history identifiers in the response
- add contract coverage that exercises change application, preview regeneration, ATS delta calculation, and history logging via mocked dependencies

## Testing
- npm test -- --env node --no-haste --runTestsByPath tests/contract/test_agent_apply.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_690b091e36cc832abedca85402577bad