### PR TITLE
feat: add telemetry instrumentation for key resume events

### DIFF
--- a/docs/telemetry-rollout.md
+++ b/docs/telemetry-rollout.md
@@ -1,0 +1,71 @@
+# Telemetry Rollout Plan
+
+This document explains how to activate the new instrumentation safely, moving from
+shadow collection to limited enablement while maintaining observability.
+
+## Feature Flags
+
+Telemetry is guarded by environment variables consumed in `src/lib/telemetry/index.ts`:
+
+- `TELEMETRY_ENABLED` – when `true`, events are written to `public.events`.
+- `TELEMETRY_SHADOW` – when `true`, events are collected but annotated as
+  `shadow: true` in the payload while keeping the user experience unchanged.
+- `TELEMETRY_NAMESPACE` – optional, defaults to `resume_builder_ai`; useful for
+  segregating events when multiple environments share a Supabase project.
+
+`TELEMETRY_ENABLED` has priority. If it is `false` and `TELEMETRY_SHADOW` is
+`true`, telemetry runs in shadow mode. When both are `false`, all telemetry calls
+become no-ops and API handlers continue without failure.
+
+## Rollout Steps
+
+1. **Shadow mode (safe observation)**
+   - Deploy with `TELEMETRY_ENABLED=false` and `TELEMETRY_SHADOW=true`.
+   - Verify payloads contain `shadow: true` inside `payload_data`.
+   - Attach a monitor (see below) to confirm handlers are being invoked without
+     adding user-facing latency or errors.
+
+2. **Limited enablement (partial traffic)**
+   - Flip `TELEMETRY_ENABLED=true` for a small percentage of traffic or a single
+     environment (e.g., staging or a subset of production pods).
+   - Keep `TELEMETRY_SHADOW=true` during this phase so payloads retain the
+     rollout metadata.
+   - Watch Supabase row counts, latency metrics, and API error rates. Roll back
+     by setting `TELEMETRY_ENABLED=false` if anomalies appear.
+
+3. **General availability**
+   - Once metrics look healthy, disable shadow mode with
+     `TELEMETRY_SHADOW=false`. Continue monitoring to ensure sustained health.
+
+## Monitoring Hooks
+
+`recordTelemetryEvent` accepts an optional monitor callback via
+`setTelemetryMonitor`:
+
+```ts
+import { setTelemetryMonitor } from '@/lib/telemetry';
+
+setTelemetryMonitor((result) => {
+  if (!result.recorded) {
+    console.warn('Telemetry skipped', result);
+  }
+});
+```
+
+Use this to export metrics to Datadog, Prometheus, or console logs during the
+rollout. The monitor fires for both successes and failures, and any exceptions
+thrown by the monitor are caught so that API handlers stay resilient.
+
+## Event Coverage
+
+- **proposal_acceptance** – triggered after successful application of proposed
+  resume changes.
+- **ats_delta** – captures baseline vs. post-change ATS scores plus keyword
+  counts.
+- **language_distribution** – records detected language metadata for optimized
+  resumes.
+- **undo_usage** – emitted whenever the undo history endpoint successfully
+  restores a previous revision.
+
+These events all respect the feature flags above and fail open when telemetry is
+disabled, ensuring a safe rollout across environments.

--- a/src/lib/telemetry/index.ts
+++ b/src/lib/telemetry/index.ts
@@ -1,0 +1,106 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { log } from '@/lib/logger';
+import type { Database } from '@/types/database';
+
+const TELEMETRY_ENABLED = process.env.TELEMETRY_ENABLED === 'true';
+const TELEMETRY_SHADOW = process.env.TELEMETRY_SHADOW === 'true';
+const TELEMETRY_NAMESPACE = process.env.TELEMETRY_NAMESPACE ?? 'resume_builder_ai';
+
+export interface TelemetryEvent {
+  name: string;
+  userId: string;
+  payload?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}
+
+export interface TelemetryResult {
+  recorded: boolean;
+  event: TelemetryEvent;
+  reason?: 'disabled' | 'error';
+  error?: unknown;
+}
+
+export type TelemetryMonitor = (result: TelemetryResult) => void;
+
+type TelemetryClient = SupabaseClient<Database>;
+
+let monitor: TelemetryMonitor | null = null;
+
+function emit(result: TelemetryResult) {
+  if (monitor) {
+    try {
+      monitor(result);
+    } catch (error) {
+      log.warn('[telemetry] monitor callback failed', {
+        error: error instanceof Error ? error.message : error,
+      });
+    }
+  }
+}
+
+export function setTelemetryMonitor(handler: TelemetryMonitor | null) {
+  monitor = handler;
+}
+
+export function getTelemetryFlags() {
+  return {
+    enabled: TELEMETRY_ENABLED,
+    shadow: TELEMETRY_SHADOW,
+  } as const;
+}
+
+export function isTelemetryActive() {
+  return TELEMETRY_ENABLED || TELEMETRY_SHADOW;
+}
+
+export function isTelemetryShadowMode() {
+  return TELEMETRY_SHADOW && !TELEMETRY_ENABLED;
+}
+
+export async function recordTelemetryEvent(
+  client: TelemetryClient,
+  event: TelemetryEvent
+): Promise<TelemetryResult> {
+  if (!isTelemetryActive()) {
+    const result: TelemetryResult = { recorded: false, event, reason: 'disabled' };
+    emit(result);
+    return result;
+  }
+
+  const payload = {
+    ...event.payload,
+    context: event.context,
+    namespace: TELEMETRY_NAMESPACE,
+    shadow: isTelemetryShadowMode(),
+    timestamp: new Date().toISOString(),
+  } satisfies Record<string, unknown>;
+
+  try {
+    await client.from('events').insert([
+      {
+        user_id: event.userId,
+        type: event.name,
+        payload_data: payload,
+      },
+    ]);
+
+    const result: TelemetryResult = { recorded: true, event };
+    emit(result);
+    return result;
+  } catch (error) {
+    log.warn('[telemetry] failed to record event', {
+      event: event.name,
+      userId: event.userId,
+      error: error instanceof Error ? error.message : error,
+    });
+
+    const result: TelemetryResult = {
+      recorded: false,
+      event,
+      reason: 'error',
+      error,
+    };
+    emit(result);
+    return result;
+  }
+}


### PR DESCRIPTION
## Summary
- add a feature-flagged telemetry utility with optional monitoring hooks
- instrument resume apply and undo handlers to emit proposal, ATS, language, and history events
- document the telemetry rollout path from shadow mode through limited enablement

## Testing
- npm run lint *(fails: pre-existing lint violations across the repository)*

------
https://chatgpt.com/codex/tasks/task_e_690b4b1183e4832abeb4f89ada5a4c06