### PR TITLE
Hydrate design assignment on optimization page

### DIFF
--- a/src/app/dashboard/optimizations/[id]/page.tsx
+++ b/src/app/dashboard/optimizations/[id]/page.tsx
@@ -297,11 +297,8 @@ export default function OptimizationPage() {
 
         if (response.ok) {
           const data = await response.json();
-          // IMPORTANT: Only apply design if user explicitly selected one
-          // For now, we'll show natural design by default and let user choose
-          // Comment out to disable auto-loading of previously assigned designs:
-          // setCurrentDesignAssignment(data.assignment);
-          setCurrentDesignAssignment(null); // Always start with natural design
+          // Hydrate previously saved design assignment (template + customization)
+          setCurrentDesignAssignment(data.assignment ? JSON.parse(JSON.stringify(data.assignment)) : null);
         } else if (response.status === 404) {
           // No design assigned yet - show natural design
           setCurrentDesignAssignment(null);


### PR DESCRIPTION
## Summary
- hydrate design assignment from the design API so saved templates and customizations load with the optimization view
- keep the natural fallback when no assignment exists and continue forwarding customization into the renderer

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f0b144568832a980558ec6644e256)