### PR TITLE
fix(upload-resume): catch pdf-parse XRef errors and return user-friendly 422

### DIFF
--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -115,7 +115,17 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const pdfData = await parsePdf(fileBuffer);
+    let pdfData: { text: string; numpages: number; info: any };
+    try {
+      pdfData = await parsePdf(fileBuffer);
+    } catch (pdfErr) {
+      const msg = pdfErr instanceof Error ? pdfErr.message : String(pdfErr);
+      logger.warn('PDF parse failed', { fileName: resumeFile.name, error: msg });
+      return NextResponse.json(
+        { error: "Could not read your PDF. Please re-export it directly from your word processor (File → Save As PDF) and try again." },
+        { status: 422 }
+      );
+    }
 
     const resumeInsert = supabase
       .from("resumes")


### PR DESCRIPTION
## Summary

`pdf-parse` throws `"bad XRef entry"` for PDFs with non-standard cross-reference tables (common with print-to-PDF outputs or certain export tools). The raw library error was propagating uncaught to the outer `catch` block and being returned verbatim as a 500.

**Fix**: Wrap `parsePdf(fileBuffer)` in its own try-catch. On failure return a 422 with a message that tells the user to re-export their PDF from their word processor.

## Test plan

- [ ] Upload a valid PDF → optimization proceeds normally
- [ ] Upload a malformed/print-to-PDF → returns 422 with readable message instead of 500 `bad XRef entry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)