### PR TITLE
Tighten expert output contracts

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -5,6 +5,9 @@ import { checkRateLimit, getRateLimitHeaders, RATE_LIMITS } from "@/lib/utils/ra
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
 
+export const runtime = 'nodejs';
+export const maxDuration = 60;
+
 export async function POST(req: NextRequest) {
   const supabase = await createRouteHandlerClient(req);
   const { data: { user } } = await supabase.auth.getUser();

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -191,6 +191,7 @@ export async function POST(req: NextRequest) {
         success: true,
         resumeId: resumeData.id,
         jobDescriptionId: jdData.id,
+        reviewId: null,
         nextStep: "optimize",
         matchScore: null,
         keyImprovements: [],

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -55,6 +55,7 @@ export async function POST(req: NextRequest) {
     const resumeFile = formData.get("resume") as File;
     const jobDescription = formData.get("jobDescription") as string;
     const jobDescriptionUrl = formData.get("jobDescriptionUrl") as string;
+    const deferOptimization = formData.get("deferOptimization") === "true";
     const resumeTextFallback = normalizeResumeTextFallback(formData.get("resumeText"));
 
     if (!resumeFile) {
@@ -183,6 +184,18 @@ export async function POST(req: NextRequest) {
 
     if (!jdData) {
       throw new Error("Failed to create job description record - no data returned");
+    }
+
+    if (deferOptimization) {
+      return NextResponse.json({
+        success: true,
+        resumeId: resumeData.id,
+        jobDescriptionId: jdData.id,
+        nextStep: "optimize",
+        matchScore: null,
+        keyImprovements: [],
+        missingKeywords: [],
+      });
     }
 
     // Optimize resume using AI

--- a/src/app/api/v1/expert-workflows/runs/[id]/apply/route.ts
+++ b/src/app/api/v1/expert-workflows/runs/[id]/apply/route.ts
@@ -14,6 +14,9 @@ export async function POST(
   const selectedIndices = Array.isArray(body.selected_indices)
     ? body.selected_indices.filter((value: unknown) => typeof value === 'number')
     : undefined;
+  const selectedFields = Array.isArray(body.selected_fields)
+    ? body.selected_fields.filter((value: unknown) => typeof value === 'string')
+    : undefined;
 
   const supabase = await createRouteHandlerClient();
   const {
@@ -51,6 +54,7 @@ export async function POST(
       applyMode,
       selectionIndex,
       selectedIndices,
+      selectedFields,
     });
 
     await captureServerEvent(user.id, 'expert_mode_apply_completed', {

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -39,6 +39,7 @@ type ApplyWorkflowParams = {
   applyMode?: string;
   selectionIndex?: number;
   selectedIndices?: number[];
+  selectedFields?: string[];
 };
 
 type RunRow = {
@@ -497,6 +498,43 @@ function applyATSReportOutput(
   updatedFields.push('skills.technical');
 }
 
+const FULL_REWRITE_FIELDS = new Set([
+  'summary',
+  'skills',
+  'experience',
+  'education',
+  'certifications',
+  'contact',
+]);
+
+function applyFullRewriteOutput(
+  currentResume: OptimizedResume,
+  output: Record<string, unknown>,
+  selectedFields: string[] | undefined,
+  updatedFields: string[]
+): OptimizedResume {
+  if (!isRecord(output.rewritten_resume)) return currentResume;
+  const rewritten = output.rewritten_resume as unknown as OptimizedResume;
+  const cleanFields = Array.isArray(selectedFields)
+    ? selectedFields.filter((field) => FULL_REWRITE_FIELDS.has(field))
+    : [];
+
+  if (cleanFields.length === 0) {
+    updatedFields.push('entire_resume');
+    return rewritten;
+  }
+
+  const nextResume = { ...currentResume } as Record<string, unknown>;
+  const rewrittenRecord = rewritten as unknown as Record<string, unknown>;
+  for (const field of cleanFields) {
+    if (rewrittenRecord[field] !== undefined) {
+      nextResume[field] = rewrittenRecord[field];
+      updatedFields.push(field);
+    }
+  }
+  return nextResume as unknown as OptimizedResume;
+}
+
 function resolveCurrentResume(rewriteData: unknown): OptimizedResume {
   if (isRecord(rewriteData)) {
     return rewriteData as unknown as OptimizedResume;
@@ -564,10 +602,7 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
   const appliedAssets: string[] = [];
 
   if (runRow.workflow_type === 'full_resume_rewrite') {
-    if (isRecord(output.rewritten_resume)) {
-      updatedResume = output.rewritten_resume as unknown as OptimizedResume;
-      updatedFields.push('entire_resume');
-    }
+    updatedResume = applyFullRewriteOutput(updatedResume, output, params.selectedFields, updatedFields);
   } else if (runRow.workflow_type === 'achievement_quantifier') {
     applyQuantifierOutput(updatedResume, output, updatedFields);
   } else if (runRow.workflow_type === 'professional_summary_lab') {

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -518,6 +518,11 @@ function applyFullRewriteOutput(
   const cleanFields = Array.isArray(selectedFields)
     ? selectedFields.filter((field) => FULL_REWRITE_FIELDS.has(field))
     : [];
+  if (Array.isArray(selectedFields) && selectedFields.length > 0 && cleanFields.length === 0) {
+    throw new Error(
+      `Invalid selectedFields: ${selectedFields.join(', ')}. Allowed fields: ${Array.from(FULL_REWRITE_FIELDS).join(', ')}`
+    );
+  }
 
   if (cleanFields.length === 0) {
     updatedFields.push('entire_resume');

--- a/src/lib/expert-workflows/prompts/ats-report.ts
+++ b/src/lib/expert-workflows/prompts/ats-report.ts
@@ -5,6 +5,9 @@ export function buildATSReportPrompt(context: ExpertWorkflowContext): PromptBund
     'You are an ATS optimization analyst.',
     'You must produce practical ATS-focused guidance without exaggeration.',
     'Do not claim certainty about proprietary ATS internals.',
+    'Recommend only keywords that are present in the job description and truthful for the candidate evidence.',
+    'Keep recommended_keywords_to_add unique and at most 20 items.',
+    'Every keyword_match_analysis row must explain where the keyword is present or where it should be placed.',
     'Return ONLY valid JSON with this shape:',
     '{',
     '  "ats_report": {',
@@ -52,6 +55,7 @@ export function buildATSReportPrompt(context: ExpertWorkflowContext): PromptBund
     '',
     'Generate a recruiter-readable ATS optimization report with concrete actions.',
     'Focus on what changed, why it matters for screening, and what to verify.',
+    'Do not recommend keyword stuffing. Prefer natural placement in Summary, Skills, or relevant Experience bullets.',
   ].join('\n');
 
   return {

--- a/src/lib/expert-workflows/prompts/cover-letter.ts
+++ b/src/lib/expert-workflows/prompts/cover-letter.ts
@@ -5,6 +5,8 @@ export function buildCoverLetterPrompt(context: ExpertWorkflowContext): PromptBu
     'You are a senior cover letter strategist.',
     'Generate truthful, role-targeted letters based only on provided resume and job description evidence.',
     'Never fabricate achievements, tools, metrics, dates, or responsibilities.',
+    'Each variant rationale must state the positioning difference and evidence used.',
+    'Keep letters concise: 3 to 5 short paragraphs, no generic filler, no keyword stuffing.',
     'Return ONLY valid JSON with this shape:',
     '{',
     '  "cover_letter_variants": [',
@@ -58,6 +60,7 @@ export function buildCoverLetterPrompt(context: ExpertWorkflowContext): PromptBu
     context.job_description_text,
     '',
     'Write recruiter-ready letters with clear fit and concrete evidence.',
+    'Do not introduce accomplishments, tools, or motivations that are not supported by the resume evidence.',
   ].join('\n');
 
   return {

--- a/src/lib/expert-workflows/prompts/quantifier.ts
+++ b/src/lib/expert-workflows/prompts/quantifier.ts
@@ -32,6 +32,9 @@ export function buildQuantifierPrompt(context: ExpertWorkflowContext): PromptBun
     'You are a strict truth-first resume quantification assistant.',
     'Never invent numbers, percentages, dollars, team sizes, rankings, or dates.',
     'If missing data blocks quantification, provide a non-numeric stronger rewrite and ask a concise evidence question.',
+    'Each optimized bullet must include evidence_used values copied or paraphrased from provided evidence; use an empty array only for non-numeric wording improvements.',
+    'If a rewrite would benefit from a metric that is not provided, add a specific missing_evidence_questions item instead of guessing.',
+    'Keep optimized bullets under 45 words and preserve the original claim scope.',
     'Use direct, business-like language.',
     'Return ONLY valid JSON with this shape:',
     '{',
@@ -72,6 +75,7 @@ export function buildQuantifierPrompt(context: ExpertWorkflowContext): PromptBun
     '',
     'Rewrite only bullets that can be made materially stronger.',
     'Preserve truthful claims.',
+    'Do not add a numeric result unless the same number appears in the original bullet or Additional evidence.',
   ].join('\n');
 
   return {

--- a/src/lib/expert-workflows/prompts/rewrite.ts
+++ b/src/lib/expert-workflows/prompts/rewrite.ts
@@ -5,6 +5,9 @@ export function buildRewritePrompt(context: ExpertWorkflowContext): PromptBundle
     'You are an expert resume rewriting assistant for ATS + recruiter readability.',
     'Never fabricate facts, metrics, dates, employers, titles, tools, or outcomes.',
     'If a metric is missing, keep the statement non-numeric and concrete.',
+    'Every rewritten claim must be traceable to the current resume, job description, or explicit user evidence.',
+    'Preserve all original resume sections and do not drop experience, education, contact, or skills data.',
+    'Keep the summary under 120 words and avoid keyword stuffing or repeated buzzwords.',
     'Prioritize action-first, result-oriented bullets with STAR-like clarity.',
     'Keep output ATS-safe and professional.',
     'Write polished, concise report language for busy recruiters.',
@@ -43,6 +46,8 @@ export function buildRewritePrompt(context: ExpertWorkflowContext): PromptBundle
     '- Use strong action verbs.',
     '- Embed relevant keywords naturally.',
     '- Keep content truthful and ATS-safe.',
+    '- Preserve all original roles, companies, dates, education, and skills unless the source resume omits them.',
+    '- Do not add new tools, credentials, industries, employers, degrees, or metrics unless present in the provided evidence.',
     '- Keep tone confident and readable without hype.',
     '- Return complete rewritten resume JSON (same overall schema).',
   ].join('\n');

--- a/src/lib/expert-workflows/prompts/screening-answers.ts
+++ b/src/lib/expert-workflows/prompts/screening-answers.ts
@@ -5,6 +5,8 @@ export function buildScreeningAnswersPrompt(context: ExpertWorkflowContext): Pro
     'You are an interview screening answer coach.',
     'Create concise, truthful answers to common screening questions for this role.',
     'Never invent missing facts. If evidence is weak, keep claims conservative and note confidence.',
+    'Every answer must include evidence_used entries from the resume evidence or explain low confidence in confidence_note.',
+    'Keep answers concise and interview-ready; avoid unverifiable claims and keyword stuffing.',
     'Return ONLY valid JSON with this shape:',
     '{',
     '  "screening_answers": [',
@@ -55,6 +57,7 @@ export function buildScreeningAnswersPrompt(context: ExpertWorkflowContext): Pro
     context.job_description_text,
     '',
     'Prioritize common screening topics: role fit, impact, collaboration, tools, motivation, logistics.',
+    'Do not answer salary, authorization, relocation, or availability with invented personal facts.',
   ].join('\n');
 
   return {

--- a/src/lib/expert-workflows/prompts/summary-lab.ts
+++ b/src/lib/expert-workflows/prompts/summary-lab.ts
@@ -5,6 +5,8 @@ export function buildSummaryLabPrompt(context: ExpertWorkflowContext): PromptBun
     'You are a professional summary specialist for resumes.',
     'Create concise, role-targeted summaries that are truthful and ATS-friendly.',
     'Never invent achievements or metrics.',
+    'Each summary must be under 80 words and must avoid repeated keywords or hype phrases.',
+    'Each rationale must name the evidence or role-fit reason for that option.',
     'Return ONLY valid JSON with this shape:',
     '{',
     '  "summary_options": [',
@@ -49,6 +51,9 @@ export function buildSummaryLabPrompt(context: ExpertWorkflowContext): PromptBun
     '',
     'Job Description:',
     context.job_description_text,
+    '',
+    'Use only the provided summary, experience bullets, and job description as evidence.',
+    'Do not invent seniority, certifications, metrics, or industries.',
   ].join('\n');
 
   return {

--- a/src/lib/expert-workflows/validators.ts
+++ b/src/lib/expert-workflows/validators.ts
@@ -43,6 +43,19 @@ function hasTruthyObject(value: unknown): boolean {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function wordCount(value: string): number {
+  return value.trim().split(/\s+/).filter(Boolean).length;
+}
+
+function hasDuplicateStrings(values: string[]): boolean {
+  const normalized = values.map((value) => value.trim().toLowerCase()).filter(Boolean);
+  return new Set(normalized).size !== normalized.length;
+}
+
+function hasRequiredString(record: Record<string, unknown>, key: string): boolean {
+  return typeof record[key] === 'string' && String(record[key]).trim().length > 0;
+}
+
 function validateReportEnvelope(parsed: Record<string, unknown>): string | null {
   if (!hasTruthyObject(parsed.report)) {
     return 'report is required';
@@ -94,6 +107,22 @@ export function validateWorkflowOutput(
     if (!hasTruthyObject(parsed.rewritten_resume)) {
       return { valid: false, error: 'rewritten_resume is required', missingEvidence };
     }
+    const resume = parsed.rewritten_resume as Record<string, unknown>;
+    if (!hasRequiredString(resume, 'summary')) {
+      return { valid: false, error: 'rewritten_resume.summary is required', missingEvidence };
+    }
+    if (wordCount(String(resume.summary)) > 120) {
+      return { valid: false, error: 'rewritten_resume.summary is too long', missingEvidence };
+    }
+    if (!Array.isArray(resume.experience)) {
+      return { valid: false, error: 'rewritten_resume.experience must be an array', missingEvidence };
+    }
+    if (!Array.isArray(resume.education)) {
+      return { valid: false, error: 'rewritten_resume.education must be an array', missingEvidence };
+    }
+    if (!hasTruthyObject(resume.skills)) {
+      return { valid: false, error: 'rewritten_resume.skills is required', missingEvidence };
+    }
     return { valid: true, missingEvidence };
   }
 
@@ -109,11 +138,24 @@ export function validateWorkflowOutput(
       const original = String(rewrite.original_bullet || '');
       const optimized = String(rewrite.optimized_bullet || '');
       const evidence = getStringArray(rewrite.evidence_used);
+      const questions = getStringArray(rewrite.missing_evidence_questions);
       if (!original || !optimized) {
         return { valid: false, error: 'original_bullet and optimized_bullet are required', missingEvidence };
       }
+      if (!Array.isArray(rewrite.evidence_used)) {
+        return { valid: false, error: 'evidence_used must be an array', missingEvidence };
+      }
+      if (!Array.isArray(rewrite.missing_evidence_questions)) {
+        return { valid: false, error: 'missing_evidence_questions must be an array', missingEvidence };
+      }
+      if (wordCount(optimized) > 45) {
+        return { valid: false, error: 'optimized_bullet is too long', missingEvidence };
+      }
       if (detectPotentialFabrication(original, optimized, evidence)) {
         return { valid: false, error: 'Potential fabricated metric detected', missingEvidence };
+      }
+      if (questions.length > 4) {
+        return { valid: false, error: 'too many missing evidence questions', missingEvidence };
       }
     }
 
@@ -124,6 +166,31 @@ export function validateWorkflowOutput(
     if (!hasTruthyObject(parsed.ats_report)) {
       return { valid: false, error: 'ats_report is required', missingEvidence };
     }
+    const report = parsed.ats_report as Record<string, unknown>;
+    const matches = Array.isArray(report.keyword_match_analysis) ? report.keyword_match_analysis : [];
+    const recommended = getStringArray(report.recommended_keywords_to_add);
+    if (!Array.isArray(report.keyword_match_analysis)) {
+      return { valid: false, error: 'keyword_match_analysis must be an array', missingEvidence };
+    }
+    if (!Array.isArray(report.recommended_keywords_to_add)) {
+      return { valid: false, error: 'recommended_keywords_to_add must be an array', missingEvidence };
+    }
+    if (recommended.length > 20 || hasDuplicateStrings(recommended)) {
+      return { valid: false, error: 'recommended keywords must be unique and at most 20', missingEvidence };
+    }
+    for (const row of matches) {
+      if (!hasTruthyObject(row)) {
+        return { valid: false, error: 'keyword_match_analysis rows must be objects', missingEvidence };
+      }
+      const item = row as Record<string, unknown>;
+      if (!hasRequiredString(item, 'keyword') || typeof item.present !== 'boolean') {
+        return { valid: false, error: 'keyword_match_analysis rows require keyword and present', missingEvidence };
+      }
+      const placement = String(item.suggested_placement || '');
+      if (placement && !['summary', 'skills', 'experience', 'education'].includes(placement)) {
+        return { valid: false, error: 'suggested_placement is invalid', missingEvidence };
+      }
+    }
     return { valid: true, missingEvidence };
   }
 
@@ -131,11 +198,23 @@ export function validateWorkflowOutput(
     const options = Array.isArray(parsed.summary_options) ? parsed.summary_options : [];
     const recommendedIndex = Number(parsed.recommended_index);
 
-    if (options.length < 3) {
-      return { valid: false, error: 'summary_options must include at least 3 options', missingEvidence };
+    if (options.length !== 5) {
+      return { valid: false, error: 'summary_options must include exactly 5 options', missingEvidence };
     }
     if (Number.isNaN(recommendedIndex) || recommendedIndex < 0 || recommendedIndex >= options.length) {
       return { valid: false, error: 'recommended_index is invalid', missingEvidence };
+    }
+    for (const option of options) {
+      if (!hasTruthyObject(option)) {
+        return { valid: false, error: 'summary_options rows must be objects', missingEvidence };
+      }
+      const row = option as Record<string, unknown>;
+      if (!hasRequiredString(row, 'angle') || !hasRequiredString(row, 'summary') || !hasRequiredString(row, 'rationale')) {
+        return { valid: false, error: 'summary_options rows require angle, summary, and rationale', missingEvidence };
+      }
+      if (wordCount(String(row.summary)) > 80) {
+        return { valid: false, error: 'summary option is too long', missingEvidence };
+      }
     }
     return { valid: true, missingEvidence };
   }
@@ -148,6 +227,21 @@ export function validateWorkflowOutput(
     }
     if (Number.isNaN(recommendedIndex) || recommendedIndex < 0 || recommendedIndex >= variants.length) {
       return { valid: false, error: 'recommended_index is invalid', missingEvidence };
+    }
+    for (const variant of variants) {
+      if (!hasTruthyObject(variant)) {
+        return { valid: false, error: 'cover letter variants must be objects', missingEvidence };
+      }
+      const row = variant as Record<string, unknown>;
+      if (
+        !hasRequiredString(row, 'angle') ||
+        !hasRequiredString(row, 'title') ||
+        !hasRequiredString(row, 'opening_paragraph') ||
+        !hasRequiredString(row, 'letter') ||
+        !hasRequiredString(row, 'rationale')
+      ) {
+        return { valid: false, error: 'cover letter variants require all contract fields', missingEvidence };
+      }
     }
     return { valid: true, missingEvidence };
   }
@@ -164,6 +258,9 @@ export function validateWorkflowOutput(
       const answer = String(item.answer || '').trim();
       if (!question || !answer) {
         return { valid: false, error: 'screening answers require question and answer', missingEvidence };
+      }
+      if (!Array.isArray(item.evidence_used) || !hasRequiredString(item, 'confidence_note')) {
+        return { valid: false, error: 'screening answers require evidence_used and confidence_note', missingEvidence };
       }
     }
     return { valid: true, missingEvidence };

--- a/src/lib/expert-workflows/validators.ts
+++ b/src/lib/expert-workflows/validators.ts
@@ -39,6 +39,10 @@ function getStringArray(value: unknown): string[] {
   return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
 }
 
+function isNonEmptyStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string' && item.trim().length > 0);
+}
+
 function hasTruthyObject(value: unknown): boolean {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
@@ -142,10 +146,10 @@ export function validateWorkflowOutput(
       if (!original || !optimized) {
         return { valid: false, error: 'original_bullet and optimized_bullet are required', missingEvidence };
       }
-      if (!Array.isArray(rewrite.evidence_used)) {
+      if (!isNonEmptyStringArray(rewrite.evidence_used)) {
         return { valid: false, error: 'evidence_used must be an array', missingEvidence };
       }
-      if (!Array.isArray(rewrite.missing_evidence_questions)) {
+      if (!isNonEmptyStringArray(rewrite.missing_evidence_questions)) {
         return { valid: false, error: 'missing_evidence_questions must be an array', missingEvidence };
       }
       if (wordCount(optimized) > 45) {
@@ -172,7 +176,7 @@ export function validateWorkflowOutput(
     if (!Array.isArray(report.keyword_match_analysis)) {
       return { valid: false, error: 'keyword_match_analysis must be an array', missingEvidence };
     }
-    if (!Array.isArray(report.recommended_keywords_to_add)) {
+    if (!isNonEmptyStringArray(report.recommended_keywords_to_add)) {
       return { valid: false, error: 'recommended_keywords_to_add must be an array', missingEvidence };
     }
     if (recommended.length > 20 || hasDuplicateStrings(recommended)) {
@@ -183,8 +187,8 @@ export function validateWorkflowOutput(
         return { valid: false, error: 'keyword_match_analysis rows must be objects', missingEvidence };
       }
       const item = row as Record<string, unknown>;
-      if (!hasRequiredString(item, 'keyword') || typeof item.present !== 'boolean') {
-        return { valid: false, error: 'keyword_match_analysis rows require keyword and present', missingEvidence };
+      if (!hasRequiredString(item, 'keyword') || typeof item.present !== 'boolean' || !hasRequiredString(item, 'note')) {
+        return { valid: false, error: 'keyword_match_analysis rows require keyword, present, and note', missingEvidence };
       }
       const placement = String(item.suggested_placement || '');
       if (placement && !['summary', 'skills', 'experience', 'education'].includes(placement)) {
@@ -203,6 +207,9 @@ export function validateWorkflowOutput(
     }
     if (Number.isNaN(recommendedIndex) || recommendedIndex < 0 || recommendedIndex >= options.length) {
       return { valid: false, error: 'recommended_index is invalid', missingEvidence };
+    }
+    if (!hasRequiredString(parsed, 'recommended_reason')) {
+      return { valid: false, error: 'recommended_reason is required when a recommended_index is set', missingEvidence };
     }
     for (const option of options) {
       if (!hasTruthyObject(option)) {
@@ -227,6 +234,9 @@ export function validateWorkflowOutput(
     }
     if (Number.isNaN(recommendedIndex) || recommendedIndex < 0 || recommendedIndex >= variants.length) {
       return { valid: false, error: 'recommended_index is invalid', missingEvidence };
+    }
+    if (!hasRequiredString(parsed, 'recommended_reason')) {
+      return { valid: false, error: 'recommended_reason is required when a recommended_index is set', missingEvidence };
     }
     for (const variant of variants) {
       if (!hasTruthyObject(variant)) {
@@ -259,7 +269,7 @@ export function validateWorkflowOutput(
       if (!question || !answer) {
         return { valid: false, error: 'screening answers require question and answer', missingEvidence };
       }
-      if (!Array.isArray(item.evidence_used) || !hasRequiredString(item, 'confidence_note')) {
+      if (!isNonEmptyStringArray(item.evidence_used) || !hasRequiredString(item, 'confidence_note')) {
         return { valid: false, error: 'screening answers require evidence_used and confidence_note', missingEvidence };
       }
     }

--- a/src/lib/job-scraper.ts
+++ b/src/lib/job-scraper.ts
@@ -8,6 +8,7 @@ export async function scrapeJobDescription(url: string): Promise<string> {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
       },
+      signal: AbortSignal.timeout(12_000),
     });
 
     if (!response.ok) {

--- a/src/lib/scraper/jobExtractor.ts
+++ b/src/lib/scraper/jobExtractor.ts
@@ -348,7 +348,8 @@ export async function extractJob(url: string): Promise<ExtractedJobData> {
     method: 'GET',
     headers: {
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-    }
+    },
+    signal: AbortSignal.timeout(12_000),
   });
 
   if (!res.ok) {
@@ -362,7 +363,6 @@ export async function extractJob(url: string): Promise<ExtractedJobData> {
   }
   return extractGeneric(html, finalUrl);
 }
-
 
 
 

--- a/tests/contracts/expert-output-golden-fixtures.test.ts
+++ b/tests/contracts/expert-output-golden-fixtures.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from '@jest/globals';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const fixtureRoot = path.join(process.cwd(), 'tests/fixtures/expert-golden');
+
+describe('Expert output golden fixtures', () => {
+  it.each(['mobile-platform', 'customer-success'])('%s has a repeatable resume/job pair', (name) => {
+    const resumePath = path.join(fixtureRoot, name, 'resume.json');
+    const jobPath = path.join(fixtureRoot, name, 'job.txt');
+
+    const resume = JSON.parse(fs.readFileSync(resumePath, 'utf8')) as Record<string, unknown>;
+    const job = fs.readFileSync(jobPath, 'utf8');
+
+    expect(typeof resume.summary).toBe('string');
+    expect(Array.isArray(resume.experience)).toBe(true);
+    expect(Array.isArray(resume.education)).toBe(true);
+    expect(typeof job).toBe('string');
+    expect(job.trim().length).toBeGreaterThan(80);
+  });
+});

--- a/tests/contracts/expert-workflow-apply-behavior.test.ts
+++ b/tests/contracts/expert-workflow-apply-behavior.test.ts
@@ -276,4 +276,87 @@ describe('expert workflow apply behavior', () => {
     });
     expect(scoreOptimization).not.toHaveBeenCalled();
   });
+
+  it('applies only selected full rewrite sections when requested', async () => {
+    const { applyExpertWorkflowRun, scoreOptimization } = loadApplyHarness();
+    scoreOptimization.mockResolvedValue({
+      ats_score_original: 58,
+      ats_score_optimized: 70,
+      subscores: {},
+      subscores_original: {},
+      suggestions: [],
+      confidence: 'medium',
+    });
+
+    const currentResume = {
+      summary: 'Old summary',
+      contact: { name: 'Ada', email: 'ada@example.com', phone: '', location: '' },
+      skills: { technical: ['Swift'], soft: [] },
+      experience: [{ title: 'Engineer', company: 'OldCo', achievements: ['Old bullet'] }],
+      education: [],
+      matchScore: 62,
+      keyImprovements: [],
+      missingKeywords: [],
+    };
+
+    const rewrittenResume = {
+      ...currentResume,
+      summary: 'New summary',
+      skills: { technical: ['Swift', 'Partnerships'], soft: [] },
+      experience: [{ title: 'Engineer', company: 'OldCo', achievements: ['New bullet'] }],
+    };
+
+    const supabase = buildSupabaseMock({
+      runResult: {
+        data: {
+          id: 'run-selected',
+          user_id: 'user-1',
+          optimization_id: 'opt-1',
+          workflow_type: 'full_resume_rewrite',
+          output_json: {
+            rewritten_resume: rewrittenResume,
+          },
+        },
+        error: null,
+      },
+      optimizationResult: {
+        data: {
+          id: 'opt-1',
+          rewrite_data: currentResume,
+          resume_id: 'resume-1',
+          jd_id: 'jd-1',
+          ats_score_optimized: 62,
+          match_score: 62,
+        },
+        error: null,
+      },
+      resumeResult: {
+        data: { raw_text: 'Original resume text' },
+        error: null,
+      },
+      jobDescriptionResult: {
+        data: { raw_text: 'JD raw', clean_text: 'JD clean', title: 'Engineer' },
+        error: null,
+      },
+    });
+
+    const result = await applyExpertWorkflowRun({
+      supabase,
+      userId: 'user-1',
+      runId: 'run-selected',
+      selectedFields: ['summary', 'skills'],
+    });
+
+    expect(result.updated_fields).toEqual(['summary', 'skills']);
+    expect((supabase as any).getOptimizationUpdates()[0]).toEqual({
+      rewrite_data: {
+        ...currentResume,
+        summary: 'New summary',
+        skills: { technical: ['Swift', 'Partnerships'], soft: [] },
+      },
+    });
+    expect((supabase as any).getRunUpdates()[0]).toMatchObject({
+      updated_fields_json: ['summary', 'skills'],
+    });
+  });
 });

--- a/tests/contracts/expert-workflow-apply-behavior.test.ts
+++ b/tests/contracts/expert-workflow-apply-behavior.test.ts
@@ -359,4 +359,59 @@ describe('expert workflow apply behavior', () => {
       updated_fields_json: ['summary', 'skills'],
     });
   });
+
+  it('rejects invalid selected full rewrite fields instead of applying the whole resume', async () => {
+    const { applyExpertWorkflowRun } = loadApplyHarness();
+
+    const supabase = buildSupabaseMock({
+      runResult: {
+        data: {
+          id: 'run-invalid',
+          user_id: 'user-1',
+          optimization_id: 'opt-1',
+          workflow_type: 'full_resume_rewrite',
+          output_json: {
+            rewritten_resume: {
+              summary: 'New summary',
+              skills: { technical: ['Swift'], soft: [] },
+              experience: [],
+              education: [],
+            },
+          },
+        },
+        error: null,
+      },
+      optimizationResult: {
+        data: {
+          id: 'opt-1',
+          rewrite_data: { summary: 'Old summary' },
+          resume_id: 'resume-1',
+          jd_id: 'jd-1',
+          ats_score_optimized: 62,
+          match_score: 62,
+        },
+        error: null,
+      },
+      resumeResult: {
+        data: { raw_text: 'Original resume text' },
+        error: null,
+      },
+      jobDescriptionResult: {
+        data: { raw_text: 'JD raw', clean_text: 'JD clean', title: 'Engineer' },
+        error: null,
+      },
+    });
+
+    await expect(
+      applyExpertWorkflowRun({
+        supabase,
+        userId: 'user-1',
+        runId: 'run-invalid',
+        selectedFields: ['projects'],
+      })
+    ).rejects.toThrow('Invalid selectedFields');
+
+    expect((supabase as any).getOptimizationUpdates()).toHaveLength(0);
+    expect((supabase as any).getRunUpdates()).toHaveLength(0);
+  });
 });

--- a/tests/contracts/expert-workflow-run-route.test.ts
+++ b/tests/contracts/expert-workflow-run-route.test.ts
@@ -102,8 +102,8 @@ describe('POST /api/v1/expert-workflows/run', () => {
     createRouteHandlerClient.mockResolvedValue(buildSupabaseClient({}));
 
     const request = jsonRequest({
-        optimization_id: 'opt-1',
-        workflow_type: 'recruiter_outreach_kit',
+      optimization_id: 'opt-1',
+      workflow_type: 'recruiter_outreach_kit',
     });
 
     const response = await POST(request);
@@ -133,8 +133,8 @@ describe('POST /api/v1/expert-workflows/run', () => {
     );
 
     const request = jsonRequest({
-        optimization_id: 'opt-1',
-        workflow_type: 'cover_letter_architect',
+      optimization_id: 'opt-1',
+      workflow_type: 'cover_letter_architect',
     });
 
     const response = await POST(request);
@@ -171,11 +171,11 @@ describe('POST /api/v1/expert-workflows/run', () => {
     });
 
     const request = jsonRequest({
-        optimization_id: 'opt-1',
-        workflow_type: 'professional_summary_lab',
-        evidence_inputs: {
-          user_context: 'Reduced crash rate by 35%.',
-        },
+      optimization_id: 'opt-1',
+      workflow_type: 'professional_summary_lab',
+      evidence_inputs: {
+        user_context: 'Reduced crash rate by 35%.',
+      },
     });
 
     const response = await POST(request);

--- a/tests/contracts/expert-workflows-validators.test.ts
+++ b/tests/contracts/expert-workflows-validators.test.ts
@@ -138,6 +138,24 @@ describe('Expert workflow validators', () => {
     expect(result.error).toContain('evidence_used');
   });
 
+  it('rejects quantifier output with non-string evidence metadata', () => {
+    const result = validateWorkflowOutput('achievement_quantifier', {
+      bullet_rewrites: [
+        {
+          original_bullet: 'Improved onboarding process',
+          optimized_bullet: 'Improved onboarding process',
+          evidence_used: [42],
+          missing_evidence_questions: ['What was baseline cycle time?'],
+        },
+      ],
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('evidence_used');
+  });
+
   it('accepts ATS optimization report output with live contract fields', () => {
     const result = validateWorkflowOutput('ats_optimization_report', {
       ats_report: {
@@ -182,6 +200,26 @@ describe('Expert workflow validators', () => {
     expect(result.error).toContain('unique');
   });
 
+  it('rejects ATS keyword rows without notes', () => {
+    const result = validateWorkflowOutput('ats_optimization_report', {
+      ats_report: {
+        keyword_match_analysis: [
+          {
+            keyword: 'SwiftUI',
+            present: true,
+            suggested_placement: 'experience',
+          },
+        ],
+        recommended_keywords_to_add: [],
+      },
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('note');
+  });
+
   it('accepts summary lab output with exactly five valid options', () => {
     const result = validateWorkflowOutput('professional_summary_lab', {
       summary_options: [
@@ -217,6 +255,24 @@ describe('Expert workflow validators', () => {
     expect(result.error).toContain('exactly 5');
   });
 
+  it('rejects summary lab output without recommended reason', () => {
+    const result = validateWorkflowOutput('professional_summary_lab', {
+      summary_options: [
+        { angle: 'leadership', summary: 'A leader in iOS delivery.', rationale: 'Leadership evidence.' },
+        { angle: 'technical', summary: 'A SwiftUI specialist.', rationale: 'Technical evidence.' },
+        { angle: 'results', summary: 'A delivery-focused engineer.', rationale: 'Results evidence.' },
+        { angle: 'industry', summary: 'A mobile product engineer.', rationale: 'Industry evidence.' },
+        { angle: 'vision', summary: 'A platform-minded iOS engineer.', rationale: 'Vision evidence.' },
+      ],
+      recommended_index: 1,
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('recommended_reason');
+  });
+
   it('accepts cover letter output with exactly three complete variants', () => {
     const result = validateWorkflowOutput('cover_letter_architect', {
       cover_letter_variants: [
@@ -243,6 +299,7 @@ describe('Expert workflow validators', () => {
         },
       ],
       recommended_index: 1,
+      recommended_reason: 'Best fit',
       report,
       missing_evidence: [],
     });
@@ -258,12 +315,47 @@ describe('Expert workflow validators', () => {
         { angle: 'impact', title: 'Impact', opening_paragraph: 'C', letter: 'C', rationale: 'C' },
       ],
       recommended_index: 1,
+      recommended_reason: 'Best fit',
       report,
       missing_evidence: [],
     });
 
     expect(result.valid).toBe(false);
     expect(result.error).toContain('contract fields');
+  });
+
+  it('rejects cover letter output without recommended reason', () => {
+    const result = validateWorkflowOutput('cover_letter_architect', {
+      cover_letter_variants: [
+        {
+          angle: 'concise',
+          title: 'Concise',
+          opening_paragraph: 'I am excited to apply.',
+          letter: 'I am excited to apply.',
+          rationale: 'Best for direct applications.',
+        },
+        {
+          angle: 'narrative',
+          title: 'Narrative',
+          opening_paragraph: 'Your team caught my attention.',
+          letter: 'Your team caught my attention.',
+          rationale: 'Best when motivation matters.',
+        },
+        {
+          angle: 'impact',
+          title: 'Impact',
+          opening_paragraph: 'I can help improve mobile reliability.',
+          letter: 'I can help improve mobile reliability.',
+          rationale: 'Best for outcomes.',
+        },
+      ],
+      recommended_index: 1,
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('recommended_reason');
   });
 
   it('accepts screening answer output with evidence and confidence notes', () => {

--- a/tests/contracts/expert-workflows-validators.test.ts
+++ b/tests/contracts/expert-workflows-validators.test.ts
@@ -15,10 +15,93 @@ describe('Expert workflow validators', () => {
     },
   };
 
+  const rewrittenResume = {
+    summary: 'Senior iOS engineer focused on reliable mobile workflows and measurable delivery.',
+    contact: { name: 'Ada Lovelace', email: 'ada@example.com', phone: '', location: '' },
+    skills: { technical: ['Swift', 'SwiftUI'], soft: ['Mentoring'] },
+    experience: [
+      {
+        title: 'Senior iOS Engineer',
+        company: 'ExampleCo',
+        achievements: ['Led SwiftUI migration for the mobile checkout flow.'],
+      },
+    ],
+    education: [{ school: 'Example University', degree: 'BS Computer Science' }],
+    matchScore: 71,
+    keyImprovements: [],
+    missingKeywords: [],
+  };
+
   it('parses JSON object safely', () => {
     const parsed = safeJsonObjectParse('{"rewritten_resume":{"summary":"ok"}}');
     expect(parsed).not.toBeNull();
     expect(parsed?.rewritten_resume).toBeDefined();
+  });
+
+  it('rejects output when report envelope is missing', () => {
+    const result = validateWorkflowOutput('full_resume_rewrite', {
+      rewritten_resume: rewrittenResume,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('report');
+  });
+
+  it('accepts full resume rewrite output with complete resume payload', () => {
+    const result = validateWorkflowOutput('full_resume_rewrite', {
+      rewritten_resume: rewrittenResume,
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects full resume rewrite output when sections are missing', () => {
+    const result = validateWorkflowOutput('full_resume_rewrite', {
+      rewritten_resume: {
+        summary: 'Updated summary',
+      },
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('experience');
+  });
+
+  it('rejects full resume rewrite output with a bloated summary', () => {
+    const result = validateWorkflowOutput('full_resume_rewrite', {
+      rewritten_resume: {
+        ...rewrittenResume,
+        summary: Array.from({ length: 121 }, () => 'word').join(' '),
+      },
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('summary is too long');
+  });
+
+  it('accepts achievement quantifier output with evidence provenance', () => {
+    const result = validateWorkflowOutput('achievement_quantifier', {
+      bullet_rewrites: [
+        {
+          experience_index: 0,
+          bullet_index: 0,
+          original_bullet: 'Led SwiftUI migration for mobile checkout flow',
+          optimized_bullet: 'Led SwiftUI migration for the mobile checkout flow, improving delivery reliability',
+          evidence_used: ['SwiftUI migration', 'mobile checkout flow'],
+          missing_evidence_questions: ['What was the release cycle or crash-rate impact?'],
+        },
+      ],
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(true);
   });
 
   it('rejects quantifier output with potential fabricated metrics', () => {
@@ -39,7 +122,85 @@ describe('Expert workflow validators', () => {
     expect(result.error).toContain('Potential fabricated metric');
   });
 
-  it('accepts summary lab output with valid recommended index', () => {
+  it('rejects quantifier output without evidence arrays', () => {
+    const result = validateWorkflowOutput('achievement_quantifier', {
+      bullet_rewrites: [
+        {
+          original_bullet: 'Improved onboarding process',
+          optimized_bullet: 'Improved onboarding process',
+        },
+      ],
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('evidence_used');
+  });
+
+  it('accepts ATS optimization report output with live contract fields', () => {
+    const result = validateWorkflowOutput('ats_optimization_report', {
+      ats_report: {
+        keyword_match_analysis: [
+          {
+            keyword: 'SwiftUI',
+            present: true,
+            suggested_placement: 'experience',
+            note: 'Already present in recent project evidence.',
+          },
+          {
+            keyword: 'CI/CD',
+            present: false,
+            suggested_placement: 'skills',
+            note: 'Add only if it reflects the candidate workflow.',
+          },
+        ],
+        section_heading_compliance: ['Use standard Experience and Education headings.'],
+        format_guidance: ['Avoid tables in exported resume.'],
+        acronym_coverage: ['Spell out CI/CD once if added.'],
+        score_estimate: { before: 62, after: 71 },
+        recommended_keywords_to_add: ['CI/CD'],
+      },
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects ATS optimization report with duplicate keyword stuffing recommendations', () => {
+    const result = validateWorkflowOutput('ats_optimization_report', {
+      ats_report: {
+        keyword_match_analysis: [],
+        recommended_keywords_to_add: ['SwiftUI', 'swiftui'],
+      },
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('unique');
+  });
+
+  it('accepts summary lab output with exactly five valid options', () => {
+    const result = validateWorkflowOutput('professional_summary_lab', {
+      summary_options: [
+        { angle: 'leadership', summary: 'A leader in iOS delivery.', rationale: 'Leadership evidence.' },
+        { angle: 'technical', summary: 'A SwiftUI specialist.', rationale: 'Technical evidence.' },
+        { angle: 'results', summary: 'A delivery-focused engineer.', rationale: 'Results evidence.' },
+        { angle: 'industry', summary: 'A mobile product engineer.', rationale: 'Industry evidence.' },
+        { angle: 'vision', summary: 'A platform-minded iOS engineer.', rationale: 'Vision evidence.' },
+      ],
+      recommended_index: 1,
+      recommended_reason: 'Best fit',
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects summary lab output with fewer than five options', () => {
     const result = validateWorkflowOutput('professional_summary_lab', {
       summary_options: [
         { angle: 'leadership', summary: 'A', rationale: 'A' },
@@ -52,69 +213,33 @@ describe('Expert workflow validators', () => {
       missing_evidence: [],
     });
 
-    expect(result.valid).toBe(true);
-  });
-
-  it('rejects output when report envelope is missing', () => {
-    const result = validateWorkflowOutput('full_resume_rewrite', {
-      rewritten_resume: {
-        summary: 'Updated',
-      },
-      missing_evidence: [],
-    });
-
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('report');
+    expect(result.error).toContain('exactly 5');
   });
 
-  it('accepts full resume rewrite output with rewritten_resume payload', () => {
-    const result = validateWorkflowOutput('full_resume_rewrite', {
-      rewritten_resume: {
-        summary: 'Updated summary',
-      },
-      report,
-      missing_evidence: [],
-    });
-
-    expect(result.valid).toBe(true);
-  });
-
-  it('accepts ATS optimization report output with ats_report payload', () => {
-    const result = validateWorkflowOutput('ats_optimization_report', {
-      ats_report: {
-        keyword_coverage: ['TypeScript'],
-        formatting_risks: [],
-      },
-      report,
-      missing_evidence: [],
-    });
-
-    expect(result.valid).toBe(true);
-  });
-
-  it('accepts cover letter output with exactly 3 variants', () => {
+  it('accepts cover letter output with exactly three complete variants', () => {
     const result = validateWorkflowOutput('cover_letter_architect', {
       cover_letter_variants: [
         {
           angle: 'concise',
           title: 'Concise',
-          opening_paragraph: 'A',
-          letter: 'A',
-          rationale: 'A',
+          opening_paragraph: 'I am excited to apply.',
+          letter: 'I am excited to apply.\nMy SwiftUI work aligns with the role.',
+          rationale: 'Best for direct applications.',
         },
         {
           angle: 'narrative',
           title: 'Narrative',
-          opening_paragraph: 'B',
-          letter: 'B',
-          rationale: 'B',
+          opening_paragraph: 'Your team caught my attention.',
+          letter: 'Your team caught my attention.\nMy recent work maps to your priorities.',
+          rationale: 'Best when motivation matters.',
         },
         {
           angle: 'impact',
           title: 'Impact',
-          opening_paragraph: 'C',
-          letter: 'C',
-          rationale: 'C',
+          opening_paragraph: 'I can help improve mobile reliability.',
+          letter: 'I can help improve mobile reliability.\nMy migration experience is relevant.',
+          rationale: 'Best for outcomes.',
         },
       ],
       recommended_index: 1,
@@ -125,17 +250,52 @@ describe('Expert workflow validators', () => {
     expect(result.valid).toBe(true);
   });
 
-  it('rejects screening answer output with fewer than 5 rows', () => {
-    const result = validateWorkflowOutput('screening_answer_studio', {
-      screening_answers: [
-        { question: 'Q1', answer: 'A1', evidence_used: [], confidence_note: 'high' },
-        { question: 'Q2', answer: 'A2', evidence_used: [], confidence_note: 'high' },
+  it('rejects incomplete cover letter variants', () => {
+    const result = validateWorkflowOutput('cover_letter_architect', {
+      cover_letter_variants: [
+        { angle: 'concise', title: 'Concise', letter: 'A', rationale: 'A' },
+        { angle: 'narrative', title: 'Narrative', opening_paragraph: 'B', letter: 'B', rationale: 'B' },
+        { angle: 'impact', title: 'Impact', opening_paragraph: 'C', letter: 'C', rationale: 'C' },
       ],
+      recommended_index: 1,
       report,
       missing_evidence: [],
     });
 
     expect(result.valid).toBe(false);
-    expect(result.error).toContain('at least 5');
+    expect(result.error).toContain('contract fields');
+  });
+
+  it('accepts screening answer output with evidence and confidence notes', () => {
+    const answers = Array.from({ length: 5 }, (_, index) => ({
+      question: `Question ${index + 1}`,
+      answer: `Answer ${index + 1} grounded in SwiftUI delivery evidence.`,
+      evidence_used: ['SwiftUI delivery evidence'],
+      confidence_note: 'High confidence from resume evidence.',
+    }));
+
+    const result = validateWorkflowOutput('screening_answer_studio', {
+      screening_answers: answers,
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects screening answer output without evidence metadata', () => {
+    const answers = Array.from({ length: 5 }, (_, index) => ({
+      question: `Question ${index + 1}`,
+      answer: `Answer ${index + 1}`,
+    }));
+
+    const result = validateWorkflowOutput('screening_answer_studio', {
+      screening_answers: answers,
+      report,
+      missing_evidence: [],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('evidence_used');
   });
 });

--- a/tests/fixtures/expert-golden/customer-success/job.txt
+++ b/tests/fixtures/expert-golden/customer-success/job.txt
@@ -1,0 +1,3 @@
+Customer Success Manager
+
+The role owns onboarding, product adoption, renewal risk, stakeholder communication, and feedback loops with Product. Strong candidates have experience with executive business reviews, Salesforce or Gainsight, retention planning, and customer training.

--- a/tests/fixtures/expert-golden/customer-success/resume.json
+++ b/tests/fixtures/expert-golden/customer-success/resume.json
@@ -1,0 +1,33 @@
+{
+  "summary": "Customer success manager with experience onboarding enterprise customers, improving retention workflows, and translating customer feedback into product improvements.",
+  "contact": {
+    "name": "Jordan Lee",
+    "email": "jordan@example.com",
+    "phone": "",
+    "location": "Austin, TX"
+  },
+  "skills": {
+    "technical": ["Salesforce", "HubSpot", "Gainsight", "SQL basics"],
+    "soft": ["Executive communication", "Renewal planning", "Customer training"]
+  },
+  "experience": [
+    {
+      "title": "Customer Success Manager",
+      "company": "Beacon Software",
+      "achievements": [
+        "Managed a portfolio of 42 mid-market accounts across onboarding, adoption, and renewal planning.",
+        "Raised quarterly business review attendance from 58% to 81% by redesigning stakeholder outreach.",
+        "Partnered with product managers to prioritize recurring customer feedback themes."
+      ]
+    }
+  ],
+  "education": [
+    {
+      "school": "Example State University",
+      "degree": "BA Communications"
+    }
+  ],
+  "matchScore": 68,
+  "keyImprovements": [],
+  "missingKeywords": []
+}

--- a/tests/fixtures/expert-golden/mobile-platform/job.txt
+++ b/tests/fixtures/expert-golden/mobile-platform/job.txt
@@ -1,0 +1,3 @@
+Senior iOS Engineer
+
+We need a product-minded iOS engineer to lead SwiftUI development, improve mobile reliability, mentor engineers, and partner with design and backend teams. Experience with Swift concurrency, XCTest, CI/CD, and crash-rate reduction is preferred.

--- a/tests/fixtures/expert-golden/mobile-platform/resume.json
+++ b/tests/fixtures/expert-golden/mobile-platform/resume.json
@@ -1,0 +1,33 @@
+{
+  "summary": "Senior iOS engineer with experience leading SwiftUI migrations, improving mobile reliability, and mentoring product-focused engineering teams.",
+  "contact": {
+    "name": "Ada Lovelace",
+    "email": "ada@example.com",
+    "phone": "",
+    "location": "New York, NY"
+  },
+  "skills": {
+    "technical": ["Swift", "SwiftUI", "UIKit", "XCTest", "CI/CD"],
+    "soft": ["Mentoring", "Cross-functional collaboration"]
+  },
+  "experience": [
+    {
+      "title": "Senior iOS Engineer",
+      "company": "Northstar Apps",
+      "achievements": [
+        "Led a SwiftUI migration for a checkout flow used by 250k monthly active users.",
+        "Reduced crash rate by 35% by improving async state handling and test coverage.",
+        "Mentored 4 engineers on Swift concurrency and release quality practices."
+      ]
+    }
+  ],
+  "education": [
+    {
+      "school": "Example University",
+      "degree": "BS Computer Science"
+    }
+  ],
+  "matchScore": 74,
+  "keyImprovements": [],
+  "missingKeywords": []
+}


### PR DESCRIPTION
## Summary
- strengthen expert workflow prompts with evidence, concision, and anti-keyword-stuffing guidance
- tighten validators for backend-real output shapes across rewrite, quantifier, ATS report, summary lab, cover letter, and screening answers
- add golden resume/job fixture pairs for repeatable expert output review
- make expert route tests independent of a real NextResponse/Request runtime

## Tests
- `NODE_PATH='../new-ResumeBuilder-ai-/node_modules' ../new-ResumeBuilder-ai-/node_modules/.bin/jest --runTestsByPath tests/contracts/expert-workflows-validators.test.ts tests/contracts/expert-output-golden-fixtures.test.ts tests/contracts/expert-workflow-run-route.test.ts tests/contracts/expert-workflow-apply-behavior.test.ts`

Note: this worktree does not have its own node_modules, so the command reuses the dependency install from the existing backend checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Resume uploads can now defer AI optimization for later
  * Full resume rewrites can apply changes to selected sections only

* **Improvements**
  * Enhanced AI recommendations across ATS optimization, cover letter generation, summaries, and screening answers with stricter evidence validation
  * Job description retrieval now includes timeout protection for better reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nadavyigal/new-ResumeBuilder-ai-/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->