### PR TITLE
feat: MarkItDown document conversion service + DOCX upload support

### DIFF
--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -3,7 +3,8 @@ import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { extractJob } from "@/lib/scraper/jobExtractor";
 import { scrapeJobDescription } from "@/lib/job-scraper";
 import { isSupportedResumeFile } from "@/lib/utils/file-validation";
-import { convertResumeFile } from "@/lib/markitdown-client";
+import { convertResumeBuffer } from "@/lib/markitdown-client";
+import path from "path";
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
 
@@ -116,9 +117,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    // Sanitize filename — strip any directory components before storing
+    const safeFileName = path.basename(resumeFile.name);
+
     let resumeMarkdown: string;
     try {
-      const conversion = await convertResumeFile(resumeFile);
+      const conversion = await convertResumeBuffer(fileBuffer, safeFileName);
       resumeMarkdown = conversion.markdown;
       if (!resumeMarkdown || resumeMarkdown.trim().length === 0) {
         throw new Error("Conversion produced empty output");
@@ -136,8 +140,8 @@ export async function POST(req: NextRequest) {
       .from("resumes")
       .insert({
         user_id: user.id,
-        filename: resumeFile.name,
-        storage_path: `resumes/${user.id}/${Date.now()}_${resumeFile.name}`,
+        filename: safeFileName,
+        storage_path: `resumes/${user.id}/${Date.now()}_${safeFileName}`,
         raw_text: resumeMarkdown,
         canonical_data: {}, // Will be populated later during optimization
       })
@@ -282,7 +286,6 @@ export async function POST(req: NextRequest) {
 
   } catch (error: unknown) {
     logger.error('Error uploading resume', { userId: user?.id ?? null }, error);
-    const errorMessage = error instanceof Error ? error.message : "Something went wrong";
-    return NextResponse.json({ error: errorMessage }, { status: 500 });
+    return NextResponse.json({ error: "Something went wrong. Please try again." }, { status: 500 });
   }
 }

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -1,15 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
-import { parsePdf } from "@/lib/pdf-parser";
 import { extractJob } from "@/lib/scraper/jobExtractor";
 import { scrapeJobDescription } from "@/lib/job-scraper";
-import { isPdfUpload } from "@/lib/utils/pdf-validation";
+import { isSupportedResumeFile } from "@/lib/utils/file-validation";
+import { convertResumeFile } from "@/lib/markitdown-client";
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
-import {
-  normalizeResumeTextFallback,
-  resolvePdfDataWithResumeTextFallback,
-} from "@/lib/resume/resume-text-fallback";
 
 // Ensure Node.js runtime for Buffer and outbound fetch
 export const runtime = 'nodejs';
@@ -56,7 +52,6 @@ export async function POST(req: NextRequest) {
     const jobDescription = formData.get("jobDescription") as string;
     const jobDescriptionUrl = formData.get("jobDescriptionUrl") as string;
     const deferOptimization = formData.get("deferOptimization") === "true";
-    const resumeTextFallback = normalizeResumeTextFallback(formData.get("resumeText"));
 
     if (!resumeFile) {
       return NextResponse.json({ error: "Resume file is required." }, { status: 400 });
@@ -111,30 +106,28 @@ export async function POST(req: NextRequest) {
     }
 
     const fileBuffer = Buffer.from(await resumeFile.arrayBuffer());
-    if (!isPdfUpload(resumeFile, fileBuffer)) {
+    if (!isSupportedResumeFile(resumeFile, fileBuffer)) {
       return NextResponse.json(
         {
           error: 'Invalid file type',
-          message: 'Only PDF files are currently supported. DOC/DOCX support coming soon.'
+          message: 'Only PDF and DOCX files are supported.'
         },
         { status: 400 }
       );
     }
 
-    let pdfData: { text: string; numpages: number; info: any };
+    let resumeMarkdown: string;
     try {
-      pdfData = await resolvePdfDataWithResumeTextFallback({
-        fileBuffer,
-        fileName: resumeFile.name,
-        resumeTextFallback,
-        parsePdf,
-        warn: (message, metadata) => logger.warn(message, metadata),
-      });
-    } catch (pdfErr) {
-      const msg = pdfErr instanceof Error ? pdfErr.message : String(pdfErr);
-      logger.warn('PDF parse failed', { fileName: resumeFile.name, error: msg });
+      const conversion = await convertResumeFile(resumeFile);
+      resumeMarkdown = conversion.markdown;
+      if (!resumeMarkdown || resumeMarkdown.trim().length === 0) {
+        throw new Error("Conversion produced empty output");
+      }
+    } catch (convErr) {
+      const msg = convErr instanceof Error ? convErr.message : String(convErr);
+      logger.warn('MarkItDown conversion failed', { fileName: resumeFile.name, error: msg });
       return NextResponse.json(
-        { error: "Could not read your PDF. Please re-export it directly from your word processor (File → Save As PDF) and try again." },
+        { error: "Could not read your file. Please ensure it is a valid PDF or DOCX and try again." },
         { status: 422 }
       );
     }
@@ -145,7 +138,7 @@ export async function POST(req: NextRequest) {
         user_id: user.id,
         filename: resumeFile.name,
         storage_path: `resumes/${user.id}/${Date.now()}_${resumeFile.name}`,
-        raw_text: pdfData.text,
+        raw_text: resumeMarkdown,
         canonical_data: {}, // Will be populated later during optimization
       })
       .select()
@@ -205,7 +198,7 @@ export async function POST(req: NextRequest) {
       resumeId: resumeData.id,
       jobDescriptionId: jdData.id,
     });
-    const optimizationResult = await optimizeResume(pdfData.text, jobDescriptionText);
+    const optimizationResult = await optimizeResume(resumeMarkdown, jobDescriptionText);
 
     if (!optimizationResult.success) {
       logger.error('AI optimization failed', {
@@ -254,7 +247,7 @@ export async function POST(req: NextRequest) {
       userId: user.id,
       resumeId: resumeData.id,
       jobDescriptionId: jdData.id,
-      resumeRawText: pdfData.text,
+      resumeRawText: resumeMarkdown,
       jobDescriptionText,
       jobTitle: extractedTitle || jdData.title,
       optimizedResume,

--- a/src/lib/markitdown-client.ts
+++ b/src/lib/markitdown-client.ts
@@ -1,0 +1,45 @@
+const MARKITDOWN_URL = process.env.MARKITDOWN_SERVICE_URL;
+
+export interface ConversionResult {
+  markdown: string;
+  format: "pdf" | "docx";
+  char_count: number;
+}
+
+export async function convertResumeFile(file: File): Promise<ConversionResult> {
+  if (!MARKITDOWN_URL) {
+    throw new Error(
+      "MARKITDOWN_SERVICE_URL is not configured. Add it to your environment variables."
+    );
+  }
+
+  const form = new FormData();
+  form.append("file", file);
+
+  let res: Response;
+  try {
+    res = await fetch(`${MARKITDOWN_URL}/convert`, {
+      method: "POST",
+      body: form,
+      signal: AbortSignal.timeout(30_000),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`MarkItDown service unreachable: ${msg}`);
+  }
+
+  if (!res.ok) {
+    let detail = "";
+    try {
+      const body = await res.json();
+      detail = body?.detail || body?.error || "";
+    } catch {
+      // ignore parse error
+    }
+    throw new Error(
+      `MarkItDown conversion failed (${res.status})${detail ? `: ${detail}` : ""}`
+    );
+  }
+
+  return res.json() as Promise<ConversionResult>;
+}

--- a/src/lib/markitdown-client.ts
+++ b/src/lib/markitdown-client.ts
@@ -1,4 +1,5 @@
 const MARKITDOWN_URL = process.env.MARKITDOWN_SERVICE_URL;
+const INTERNAL_TOKEN = process.env.MARKITDOWN_INTERNAL_TOKEN;
 
 export interface ConversionResult {
   markdown: string;
@@ -6,7 +7,15 @@ export interface ConversionResult {
   char_count: number;
 }
 
-export async function convertResumeFile(file: File): Promise<ConversionResult> {
+/**
+ * Convert a resume file buffer to structured Markdown via the MarkItDown service.
+ * Accepts a Buffer (already read for magic-byte validation) + filename to avoid
+ * double-consuming the File stream in the request handler.
+ */
+export async function convertResumeBuffer(
+  fileBuffer: Buffer,
+  fileName: string
+): Promise<ConversionResult> {
   if (!MARKITDOWN_URL) {
     throw new Error(
       "MARKITDOWN_SERVICE_URL is not configured. Add it to your environment variables."
@@ -14,13 +23,20 @@ export async function convertResumeFile(file: File): Promise<ConversionResult> {
   }
 
   const form = new FormData();
-  form.append("file", file);
+  // Reconstruct a Blob from the already-read buffer — avoids double-consuming the File stream.
+  form.append("file", new Blob([fileBuffer]), fileName);
+
+  const headers: Record<string, string> = {};
+  if (INTERNAL_TOKEN) {
+    headers["X-Internal-Token"] = INTERNAL_TOKEN;
+  }
 
   let res: Response;
   try {
     res = await fetch(`${MARKITDOWN_URL}/convert`, {
       method: "POST",
       body: form,
+      headers,
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
@@ -29,16 +45,7 @@ export async function convertResumeFile(file: File): Promise<ConversionResult> {
   }
 
   if (!res.ok) {
-    let detail = "";
-    try {
-      const body = await res.json();
-      detail = body?.detail || body?.error || "";
-    } catch {
-      // ignore parse error
-    }
-    throw new Error(
-      `MarkItDown conversion failed (${res.status})${detail ? `: ${detail}` : ""}`
-    );
+    throw new Error(`MarkItDown conversion failed (${res.status})`);
   }
 
   return res.json() as Promise<ConversionResult>;

--- a/src/lib/utils/file-validation.ts
+++ b/src/lib/utils/file-validation.ts
@@ -1,0 +1,36 @@
+const PDF_MAGIC = "%PDF-";
+// DOCX is a ZIP file — all ZIP files start with PK\x03\x04
+const DOCX_MAGIC = Buffer.from([0x50, 0x4b, 0x03, 0x04]);
+
+export function hasPdfMagicHeader(buffer: Buffer): boolean {
+  return (
+    buffer.length >= PDF_MAGIC.length &&
+    buffer.subarray(0, PDF_MAGIC.length).toString("ascii") === PDF_MAGIC
+  );
+}
+
+export function hasDocxMagicHeader(buffer: Buffer): boolean {
+  return (
+    buffer.length >= DOCX_MAGIC.length &&
+    buffer.subarray(0, DOCX_MAGIC.length).equals(DOCX_MAGIC)
+  );
+}
+
+export function isSupportedResumeFile(file: File, buffer: Buffer): boolean {
+  const name = (file?.name ?? "").toLowerCase();
+  const type = (file?.type ?? "").toLowerCase();
+
+  const looksLikePdf =
+    name.endsWith(".pdf") ||
+    type === "application/pdf" ||
+    type === "application/x-pdf";
+
+  const looksLikeDocx =
+    name.endsWith(".docx") ||
+    type ===
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+  if (looksLikePdf) return hasPdfMagicHeader(buffer);
+  if (looksLikeDocx) return hasDocxMagicHeader(buffer);
+  return false;
+}

--- a/workers/document-conversion/.env.example
+++ b/workers/document-conversion/.env.example
@@ -1,0 +1,7 @@
+# MarkItDown microservice environment variables
+# Copy to .env for local dev; set as env vars in Railway/Render for production
+
+MAX_FILE_SIZE_MB=10
+ALLOWED_ORIGINS=http://localhost:3000
+# Shared secret between the Next.js app and this service (set MARKITDOWN_INTERNAL_TOKEN in Vercel too)
+INTERNAL_TOKEN=generate-a-random-secret-here

--- a/workers/document-conversion/Dockerfile
+++ b/workers/document-conversion/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system deps needed by some markitdown extras (e.g. pdf rendering)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+# Non-root user for security
+RUN useradd -m appuser
+USER appuser
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/workers/document-conversion/README.md
+++ b/workers/document-conversion/README.md
@@ -1,0 +1,64 @@
+# MarkItDown Document Conversion Service
+
+FastAPI microservice that wraps Microsoft MarkItDown to convert PDF and DOCX resume files into structured Markdown.
+
+## Why a separate service
+
+MarkItDown is Python. ResumeBuilder runs on Vercel (Node). Vercel's Python runtime cannot reliably handle MarkItDown's native library dependencies (pypdf, python-docx). Railway or Render host this service; Vercel calls it via `MARKITDOWN_SERVICE_URL`.
+
+## Local development
+
+```bash
+cd workers/document-conversion
+python3 -m venv venv && source venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload --port 8000
+```
+
+Test:
+```bash
+curl -F "file=@/path/to/resume.pdf" http://localhost:8000/convert
+curl http://localhost:8000/health
+```
+
+## Docker
+
+```bash
+docker build -t markitdown-service .
+docker run -p 8000:8000 -e ALLOWED_ORIGINS=http://localhost:3000 markitdown-service
+```
+
+## Deploy to Railway
+
+1. Create a new Railway project, point at this directory.
+2. Set `ALLOWED_ORIGINS` to your ResumeBuilder production domain.
+3. Copy the Railway service URL into Vercel as `MARKITDOWN_SERVICE_URL`.
+
+## API
+
+### `POST /convert`
+
+Accepts: `multipart/form-data` with a `file` field (PDF or DOCX, max 10MB).
+
+Returns:
+```json
+{
+  "markdown": "# John Doe\n\n## Experience\n...",
+  "format": "pdf",
+  "char_count": 1842
+}
+```
+
+Errors: 400 (empty), 413 (too large), 415 (wrong format), 500 (parse failure).
+
+### `GET /health`
+
+Returns `{"status": "ok", "max_file_mb": 10}`.
+
+## Security
+
+- Files are written to a temp path with a uuid name — never the user-supplied filename.
+- Temp files are deleted in a `finally` block on both success and failure.
+- Only `.pdf` and `.docx` extensions accepted.
+- `MAX_FILE_SIZE_MB` enforced before conversion runs.
+- Service runs as a non-root user in Docker.

--- a/workers/document-conversion/converter.py
+++ b/workers/document-conversion/converter.py
@@ -1,0 +1,45 @@
+"""
+MarkItDown wrapper with safe temp file handling.
+Initialized once at module level to avoid re-loading dependencies per request.
+"""
+
+import os
+import tempfile
+from markitdown import MarkItDown
+
+_md = MarkItDown()
+
+
+def convert_file(file_bytes: bytes, original_filename: str) -> dict:
+    """
+    Convert a PDF or DOCX file to Markdown.
+    Uses a uuid-named temp file — never the user-supplied filename.
+    Cleans up on both success and failure.
+    """
+    name = original_filename.lower()
+    if name.endswith(".pdf"):
+        suffix = ".pdf"
+        fmt = "pdf"
+    elif name.endswith(".docx"):
+        suffix = ".docx"
+        fmt = "docx"
+    else:
+        raise ValueError(f"Unsupported file format: {original_filename}")
+
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+            tmp.write(file_bytes)
+            tmp_path = tmp.name
+
+        result = _md.convert(tmp_path)
+        markdown = result.text_content or ""
+
+        return {
+            "markdown": markdown,
+            "format": fmt,
+            "char_count": len(markdown),
+        }
+    finally:
+        if tmp_path and os.path.exists(tmp_path):
+            os.unlink(tmp_path)

--- a/workers/document-conversion/main.py
+++ b/workers/document-conversion/main.py
@@ -1,0 +1,72 @@
+"""
+MarkItDown microservice — FastAPI entry point.
+Exposes POST /convert and GET /health.
+"""
+
+import os
+import logging
+from fastapi import FastAPI, UploadFile, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from converter import convert_file
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="MarkItDown Conversion Service", version="1.0.0")
+
+MAX_MB = int(os.getenv("MAX_FILE_SIZE_MB", "10"))
+MAX_BYTES = MAX_MB * 1024 * 1024
+
+ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=ALLOWED_ORIGINS,
+    allow_methods=["POST", "GET"],
+    allow_headers=["*"],
+)
+
+ALLOWED_CONTENT_TYPES = {
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+}
+
+ALLOWED_EXTENSIONS = {".pdf", ".docx"}
+
+
+def _validate_file(file: UploadFile) -> None:
+    name = (file.filename or "").lower()
+    ext = os.path.splitext(name)[1]
+    if ext not in ALLOWED_EXTENSIONS:
+        raise HTTPException(415, f"Unsupported file extension: {ext}. Allowed: pdf, docx")
+    if file.content_type and file.content_type not in ALLOWED_CONTENT_TYPES:
+        logger.warning("Unexpected content-type %s for %s", file.content_type, name)
+
+
+@app.post("/convert")
+async def convert(file: UploadFile):
+    _validate_file(file)
+
+    file_bytes = await file.read()
+    if len(file_bytes) > MAX_BYTES:
+        raise HTTPException(413, f"File exceeds {MAX_MB}MB limit")
+    if len(file_bytes) == 0:
+        raise HTTPException(400, "Empty file")
+
+    logger.info("Converting %s (%d bytes)", file.filename, len(file_bytes))
+
+    try:
+        result = convert_file(file_bytes, file.filename or "upload.pdf")
+    except ValueError as e:
+        raise HTTPException(415, str(e))
+    except Exception as e:
+        logger.exception("Conversion failed for %s", file.filename)
+        raise HTTPException(500, f"Conversion error: {str(e)}")
+
+    logger.info("Converted %s: %d chars of Markdown", file.filename, result["char_count"])
+    return result
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok", "max_file_mb": MAX_MB}

--- a/workers/document-conversion/main.py
+++ b/workers/document-conversion/main.py
@@ -1,12 +1,16 @@
 """
 MarkItDown microservice — FastAPI entry point.
 Exposes POST /convert and GET /health.
+
+Auth: requires X-Internal-Token header matching INTERNAL_TOKEN env var.
+Set INTERNAL_TOKEN to a random secret shared with the Next.js app.
 """
 
 import os
 import logging
-from fastapi import FastAPI, UploadFile, HTTPException
+from fastapi import FastAPI, UploadFile, HTTPException, Header, Depends
 from fastapi.middleware.cors import CORSMiddleware
+from typing import Optional
 from converter import convert_file
 
 logging.basicConfig(level=logging.INFO)
@@ -18,6 +22,7 @@ MAX_MB = int(os.getenv("MAX_FILE_SIZE_MB", "10"))
 MAX_BYTES = MAX_MB * 1024 * 1024
 
 ALLOWED_ORIGINS = os.getenv("ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+INTERNAL_TOKEN = os.getenv("INTERNAL_TOKEN", "")
 
 app.add_middleware(
     CORSMiddleware,
@@ -34,6 +39,13 @@ ALLOWED_CONTENT_TYPES = {
 ALLOWED_EXTENSIONS = {".pdf", ".docx"}
 
 
+def _require_token(x_internal_token: Optional[str] = Header(default=None)) -> None:
+    if not INTERNAL_TOKEN:
+        return  # token check disabled in local dev if env var not set
+    if x_internal_token != INTERNAL_TOKEN:
+        raise HTTPException(401, "Unauthorized")
+
+
 def _validate_file(file: UploadFile) -> None:
     name = (file.filename or "").lower()
     ext = os.path.splitext(name)[1]
@@ -44,7 +56,10 @@ def _validate_file(file: UploadFile) -> None:
 
 
 @app.post("/convert")
-async def convert(file: UploadFile):
+async def convert(
+    file: UploadFile,
+    _: None = Depends(_require_token),
+):
     _validate_file(file)
 
     file_bytes = await file.read()
@@ -59,9 +74,9 @@ async def convert(file: UploadFile):
         result = convert_file(file_bytes, file.filename or "upload.pdf")
     except ValueError as e:
         raise HTTPException(415, str(e))
-    except Exception as e:
+    except Exception:
         logger.exception("Conversion failed for %s", file.filename)
-        raise HTTPException(500, f"Conversion error: {str(e)}")
+        raise HTTPException(500, "Conversion failed")
 
     logger.info("Converted %s: %d chars of Markdown", file.filename, result["char_count"])
     return result

--- a/workers/document-conversion/requirements.txt
+++ b/workers/document-conversion/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn[standard]==0.30.0
+python-multipart==0.0.9
+markitdown[pdf,docx]==0.1.6


### PR DESCRIPTION
## Summary

- Adds a Python/FastAPI microservice wrapping Microsoft MarkItDown for structured Markdown extraction from PDF and DOCX resumes
- Unblocks DOCX upload (previously rejected with "coming soon")
- Replaces `pdfjs-dist` flat-text extraction with structured Markdown, improving LLM optimization quality

## Changes

**New (infrastructure):**
- `workers/document-conversion/main.py` — FastAPI service with `/convert` and `/health`
- `workers/document-conversion/converter.py` — MarkItDown wrapper with safe temp file handling
- `workers/document-conversion/Dockerfile` — python:3.12-slim, non-root user
- `workers/document-conversion/requirements.txt` — fastapi, uvicorn, markitdown[pdf,docx]

**New (Next.js):**
- `src/lib/markitdown-client.ts` — typed HTTP client with 30s timeout
- `src/lib/utils/file-validation.ts` — `isSupportedResumeFile()` for PDF + DOCX magic bytes

**Edited:**
- `src/app/api/upload-resume/route.ts` — replaces `parsePdf` + `isPdfUpload` with `convertResumeFile` + `isSupportedResumeFile`; removes stale imports

## Before going live

1. Run the POC gate locally: `pip install markitdown[pdf,docx] && markitdown sample-resume.pdf`
2. Build and run the Docker service: `docker build -t markitdown-service workers/document-conversion && docker run -p 8000:8000 markitdown-service`
3. Add `MARKITDOWN_SERVICE_URL=http://localhost:8000` to `.env.local`
4. Test a DOCX upload end-to-end in the local dev server
5. Deploy service to Railway/Render and set `MARKITDOWN_SERVICE_URL` in Vercel

## Test plan

- [ ] `curl http://localhost:8000/health` returns `{"status":"ok"}`
- [ ] `curl -F "file=@resume.pdf" http://localhost:8000/convert` returns Markdown with visible section structure
- [ ] `curl -F "file=@resume.docx" http://localhost:8000/convert` returns Markdown
- [ ] DOCX upload via web UI succeeds (no "PDF only" rejection)
- [ ] Supabase `resumes.raw_text` contains Markdown with section headers, not flat text
- [ ] Oversized file (>10MB) returns 400
- [ ] Unsupported format (.txt) returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)