### PR TITLE
fix(ats): resolve production 500 on free ATS check (PDF parsing)

### DIFF
--- a/src/app/api/public/ats-check/route.ts
+++ b/src/app/api/public/ats-check/route.ts
@@ -110,7 +110,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Only PDF resumes are supported.' }, { status: 400 });
   }
 
-  const pdfData = await parsePdf(fileBuffer);
+  let pdfData;
+  try {
+    pdfData = await parsePdf(fileBuffer);
+  } catch (error) {
+    console.error('PDF parse error:', error);
+    return NextResponse.json(
+      { error: 'We could not read your resume. Try exporting it as a text-based PDF.' },
+      { status: 400 }
+    );
+  }
   const resumeText = pdfData?.text?.trim();
 
   if (!resumeText) {

--- a/src/lib/pdf-parser.ts
+++ b/src/lib/pdf-parser.ts
@@ -1,29 +1,20 @@
 /**
  * PDF text extraction using pdfjs-dist (legacy Node.js build).
  *
- * pdfjs-dist is externalized in next.config.ts so webpack does not try to
- * bundle the ESM worker. At runtime the legacy CJS-compatible build is
- * loaded via require(). It handles XRef errors that pdf-parse 1.x throws on
- * PDFs produced by print-to-PDF drivers, iOS export tools, and newer PDF
- * generators by falling back to a full linear object scan.
+ * The legacy build handles XRef errors that pdf-parse 1.x throws on PDFs
+ * produced by print-to-PDF drivers, iOS export tools, and newer PDF generators
+ * by falling back to a full linear object scan.
+ *
+ * It is loaded via dynamic import(): pdf.mjs is an ES module, and on the Vercel
+ * Node serverless runtime the route is CommonJS, so require() of the .mjs throws
+ * ERR_REQUIRE_ESM. We deliberately do NOT set GlobalWorkerOptions.workerSrc —
+ * require.resolve() is rewritten to a numeric webpack module id in production
+ * bundles (pdfjs rejects it as "Invalid workerSrc type"), and in Node the legacy
+ * build runs parsing on the main thread via a fake worker without one.
  */
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-let _pdfWorkerSrc: string | null = null;
-
-function getWorkerSrc(): string {
-  if (!_pdfWorkerSrc) {
-    // resolve once — works in both local dev and Vercel deployments
-    _pdfWorkerSrc = require.resolve('pdfjs-dist/legacy/build/pdf.worker.mjs');
-  }
-  return _pdfWorkerSrc;
-}
-
 export async function parsePdf(dataBuffer: Buffer): Promise<{ text: string; numpages: number; info: any }> {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const pdfjsLib = require('pdfjs-dist/legacy/build/pdf.mjs');
-
-  pdfjsLib.GlobalWorkerOptions.workerSrc = getWorkerSrc();
+  const pdfjsLib: any = await import('pdfjs-dist/legacy/build/pdf.mjs');
 
   const data = new Uint8Array(dataBuffer);
   const loadingTask = pdfjsLib.getDocument({


### PR DESCRIPTION
## Problem
The free ATS check returned a **500 with an empty body** in production (reported by a new app user, screenshot showed `Server error (500):`). This affected **every server-side PDF parse path**, not just the free check (`parsePdf` is the shared choke point used by ats-check, resume-text-fallback, and the agent resume-parser).

## Root cause (confirmed from live Vercel runtime logs)
```
Error: require() of ES Module .../pdfjs-dist/legacy/build/pdf.mjs
from .../api/public/ats-check/route.js not supported.
code: 'ERR_REQUIRE_ESM'
```
`parsePdf` did `require('pdfjs-dist/legacy/build/pdf.mjs')`, but `pdf.mjs` is an ES module and the Vercel Node serverless route is CommonJS, so `require()` of the `.mjs` throws `ERR_REQUIRE_ESM` (unhandled → blank 500). It passed locally because Next's dev server resolves modules differently than the production bundle. Introduced by `922da0e` (pdf-parse → pdfjs-dist).

A **second latent bug** was masked behind the first: `getWorkerSrc()` used `require.resolve('…pdf.worker.mjs')`, which webpack rewrites to a numeric module id in production bundles (verified in `.next/server/.../route.js`: `workerSrc=40256`), so pdfjs rejected it as `Invalid workerSrc type`. pdfjs-dist 5.7.284 legacy build parses on the main thread via a fake worker without a `workerSrc`, so the worker wiring is removed entirely.

## Changes
- `src/lib/pdf-parser.ts`: `require()` → `await import()`; remove `getWorkerSrc()`/`require.resolve` worker wiring; do not set `workerSrc`.
- `src/app/api/public/ats-check/route.ts`: wrap `parsePdf` in try/catch returning a JSON 400 so a bad PDF can never again surface as a blank 500 (defense-in-depth).

## Verification
Local production build (`npm run build && npm run start`):
- **Before fix:** 500 `ERR_REQUIRE_ESM`, then `Invalid workerSrc type`.
- **After fix:** **HTTP 200** with a full ATS score JSON for a real PDF; no parse errors in server logs.

Production is **not** deployed by this PR — it ships on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)