### PR TITLE
fix(ats): use webpackIgnore native import for pdfjs so Vercel stops 500ing

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,12 @@ const contentSecurityPolicy = `
 
 const nextConfig: NextConfig = {
   outputFileTracingRoot: path.join(__dirname),
+  // pdfjs-dist legacy build (pdf.mjs + pdf.worker.mjs) is loaded at runtime via a
+  // native dynamic import() that webpack leaves untouched (webpackIgnore), so its
+  // files are not auto-traced into the serverless bundle. Force-include them.
+  outputFileTracingIncludes: {
+    '/api/**': ['./node_modules/pdfjs-dist/legacy/build/pdf.mjs', './node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'],
+  },
   reactStrictMode: true,
   poweredByHeader: false,
   compress: true,
@@ -43,10 +49,10 @@ const nextConfig: NextConfig = {
       config.externals = config.externals || [];
       // Keep pdf-parse external (legacy — avoids its test-runner side effect on import)
       config.externals.push('pdf-parse');
-      // pdfjs-dist legacy build is ESM; keep it external so webpack does not try
-      // to bundle the worker or the DOMMatrix-dependent main build.
-      config.externals.push('pdfjs-dist/legacy/build/pdf.mjs');
-      config.externals.push('pdfjs-dist/legacy/build/pdf.worker.mjs');
+      // pdfjs-dist legacy build is ESM. We deliberately do NOT externalize it:
+      // webpack externals emit a require(), and require() of an .mjs throws
+      // ERR_REQUIRE_ESM on the Vercel Node runtime. parsePdf loads it with a
+      // webpackIgnore'd native import() instead (see src/lib/pdf-parser.ts).
     }
     return config;
   },

--- a/src/lib/pdf-parser.ts
+++ b/src/lib/pdf-parser.ts
@@ -5,16 +5,22 @@
  * produced by print-to-PDF drivers, iOS export tools, and newer PDF generators
  * by falling back to a full linear object scan.
  *
- * It is loaded via dynamic import(): pdf.mjs is an ES module, and on the Vercel
- * Node serverless runtime the route is CommonJS, so require() of the .mjs throws
- * ERR_REQUIRE_ESM. We deliberately do NOT set GlobalWorkerOptions.workerSrc —
- * require.resolve() is rewritten to a numeric webpack module id in production
- * bundles (pdfjs rejects it as "Invalid workerSrc type"), and in Node the legacy
- * build runs parsing on the main thread via a fake worker without one.
+ * It is loaded via a webpackIgnore'd native dynamic import(): pdf.mjs is an ES
+ * module, and on the Vercel Node serverless runtime the route is CommonJS. A
+ * plain import() of an externalized module is compiled by webpack into a
+ * require(), and require() of an .mjs throws ERR_REQUIRE_ESM on Vercel's Node.
+ * The webpackIgnore comment forces webpack to leave a real native import() in
+ * the output, which Node loads as ESM correctly. The pdfjs files are kept in the
+ * serverless bundle via outputFileTracingIncludes in next.config.ts.
+ *
+ * We deliberately do NOT set GlobalWorkerOptions.workerSrc — require.resolve() is
+ * rewritten to a numeric webpack module id in production bundles (pdfjs rejects
+ * it as "Invalid workerSrc type"), and in Node the legacy build runs parsing on
+ * the main thread via a fake worker without one.
  */
 
 export async function parsePdf(dataBuffer: Buffer): Promise<{ text: string; numpages: number; info: any }> {
-  const pdfjsLib: any = await import('pdfjs-dist/legacy/build/pdf.mjs');
+  const pdfjsLib: any = await import(/* webpackIgnore: true */ 'pdfjs-dist/legacy/build/pdf.mjs');
 
   const data = new Uint8Array(dataBuffer);
   const loadingTask = pdfjsLib.getDocument({


### PR DESCRIPTION
## Follow-up to #72 — production was still failing

#72 changed `require()` → `import()`, verified HTTP 200 on a local `next start`, and merged. But **production still failed**: the free ATS check returned a 400 "could not read your resume" (the try/catch guard from #72 catching a still-throwing parse).

### Why #72 didn't fix prod
Confirmed from live Vercel logs — still `ERR_REQUIRE_ESM` on `require()` of `pdf.mjs`. Three things interacted:
1. `next.config.ts` externalized `pdfjs-dist/legacy/build/pdf.mjs`, and **webpack compiles `import()` of an externalized module back into a `require()`** (verified in the built bundle).
2. `require()` of an `.mjs` throws `ERR_REQUIRE_ESM` on **Vercel's Node** runtime.
3. It passed locally only because **local Node v24 permits `require()` of ESM** — a false green.

Reproduced the exact Vercel error locally with `NODE_OPTIONS=--no-experimental-require-module`.

### Fix
- **`src/lib/pdf-parser.ts`**: `await import(/* webpackIgnore: true */ 'pdfjs-dist/legacy/build/pdf.mjs')` — forces webpack to leave a real **native** `import()` in the output; Node loads it as ESM on every runtime.
- **`next.config.ts`**: drop the pdfjs externals (they caused the `require()`), and add `outputFileTracingIncludes` so `pdf.mjs` + `pdf.worker.mjs` are bundled into the serverless function (a webpackIgnore'd import isn't auto-traced).

### Verification
- Built bundle now emits `import("pdfjs-dist/legacy/build/pdf.mjs")` (not `require`).
- Route `.nft.json` lists **both** `pdf.mjs` and `pdf.worker.mjs`.
- Under `--no-experimental-require-module` (faithful Vercel-Node repro): **HTTP 200 with a full ATS score** for a real PDF. Before: `ERR_REQUIRE_ESM`.

Ships to production on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF processing reliability by optimizing library bundling for serverless environments.
  * Enhanced PDF import handling to ensure consistent functionality across different deployment platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->