### PR TITLE
fix(ats): switch PDF parsing to unpdf — fixes the Vercel 500 for real

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,12 +20,6 @@ const contentSecurityPolicy = `
 
 const nextConfig: NextConfig = {
   outputFileTracingRoot: path.join(__dirname),
-  // pdfjs-dist legacy build (pdf.mjs + pdf.worker.mjs) is loaded at runtime via a
-  // native dynamic import() that webpack leaves untouched (webpackIgnore), so its
-  // files are not auto-traced into the serverless bundle. Force-include them.
-  outputFileTracingIncludes: {
-    '/api/**': ['./node_modules/pdfjs-dist/legacy/build/pdf.mjs', './node_modules/pdfjs-dist/legacy/build/pdf.worker.mjs'],
-  },
   reactStrictMode: true,
   poweredByHeader: false,
   compress: true,
@@ -49,10 +43,6 @@ const nextConfig: NextConfig = {
       config.externals = config.externals || [];
       // Keep pdf-parse external (legacy — avoids its test-runner side effect on import)
       config.externals.push('pdf-parse');
-      // pdfjs-dist legacy build is ESM. We deliberately do NOT externalize it:
-      // webpack externals emit a require(), and require() of an .mjs throws
-      // ERR_REQUIRE_ESM on the Vercel Node runtime. parsePdf loads it with a
-      // webpackIgnore'd native import() instead (see src/lib/pdf-parser.ts).
     }
     return config;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "sanitize-html": "^2.13.0",
         "server-only": "^0.0.1",
         "tailwind-merge": "^3.3.1",
+        "unpdf": "^1.6.2",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -18484,6 +18485,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.6.2.tgz",
+      "integrity": "sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "sanitize-html": "^2.13.0",
     "server-only": "^0.0.1",
     "tailwind-merge": "^3.3.1",
+    "unpdf": "^1.6.2",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/src/lib/pdf-parser.ts
+++ b/src/lib/pdf-parser.ts
@@ -1,51 +1,27 @@
 /**
- * PDF text extraction using pdfjs-dist (legacy Node.js build).
+ * PDF text extraction using unpdf.
  *
- * The legacy build handles XRef errors that pdf-parse 1.x throws on PDFs
- * produced by print-to-PDF drivers, iOS export tools, and newer PDF generators
- * by falling back to a full linear object scan.
- *
- * It is loaded via a webpackIgnore'd native dynamic import(): pdf.mjs is an ES
- * module, and on the Vercel Node serverless runtime the route is CommonJS. A
- * plain import() of an externalized module is compiled by webpack into a
- * require(), and require() of an .mjs throws ERR_REQUIRE_ESM on Vercel's Node.
- * The webpackIgnore comment forces webpack to leave a real native import() in
- * the output, which Node loads as ESM correctly. The pdfjs files are kept in the
- * serverless bundle via outputFileTracingIncludes in next.config.ts.
- *
- * We deliberately do NOT set GlobalWorkerOptions.workerSrc — require.resolve() is
- * rewritten to a numeric webpack module id in production bundles (pdfjs rejects
- * it as "Invalid workerSrc type"), and in Node the legacy build runs parsing on
- * the main thread via a fake worker without one.
+ * unpdf wraps a serverless-first build of pdfjs that bundles the browser/DOM
+ * polyfills (DOMMatrix, Path2D, ImageData, ...) pdfjs needs at parse time. The
+ * raw pdfjs legacy build does not: on the Vercel Node runtime it failed first
+ * with ERR_REQUIRE_ESM (require() of the .mjs build) and then, once loaded, with
+ * "ReferenceError: DOMMatrix is not defined" — neither reproducible on local
+ * Node, which made every pdfjs fix a false green. unpdf avoids the whole class:
+ * it is a normal ESM dependency webpack bundles, with no worker or DOM globals
+ * required. Verified to extract text with DOMMatrix/Path2D/ImageData deleted
+ * from globalThis (the condition that broke pdfjs on Vercel).
  */
 
+import { extractText, getDocumentProxy } from 'unpdf';
+
 export async function parsePdf(dataBuffer: Buffer): Promise<{ text: string; numpages: number; info: any }> {
-  const pdfjsLib: any = await import(/* webpackIgnore: true */ 'pdfjs-dist/legacy/build/pdf.mjs');
-
   const data = new Uint8Array(dataBuffer);
-  const loadingTask = pdfjsLib.getDocument({
-    data,
-    useWorkerFetch: false,
-    isEvalSupported: false,
-  });
-
-  const pdf = await loadingTask.promise;
-  const numpages: number = pdf.numPages;
-  let text = '';
-
-  for (let i = 1; i <= numpages; i++) {
-    const page = await pdf.getPage(i);
-    const content = await page.getTextContent();
-    const pageText = (content.items as Array<{ str?: string }>)
-      .filter((item) => typeof item.str === 'string')
-      .map((item) => item.str as string)
-      .join(' ');
-    if (pageText.trim()) text += pageText + '\n';
-  }
+  const pdf = await getDocumentProxy(data);
+  const { totalPages, text } = await extractText(pdf, { mergePages: true });
 
   return {
     text: text.trim(),
-    numpages,
+    numpages: totalPages,
     info: {},
   };
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -30,3 +30,27 @@
 
 **Mistake:** `NEXT_PUBLIC_SUPABASE_URL` points at the wrong project (dev vs. prod).
 **Fix:** Check the URL subdomain against Supabase Settings > API. They must match.
+
+---
+
+## Raw pdfjs-dist is a trap on Vercel serverless — use unpdf instead
+
+**Symptom:** Server-side PDF parsing (e.g. `/api/public/ats-check`) returned a 500 with an empty body in production while working locally. Caught by the route's try/catch it became a 400 "We could not read your resume."
+
+**Final fix: do NOT call `pdfjs-dist` directly. Use `unpdf`** (a serverless-first wrapper that bundles a pdfjs build with the DOM polyfills baked in). It's a normal ESM dependency webpack bundles — no externals, no worker config, no tracing hacks, no DOM globals:
+```ts
+import { extractText, getDocumentProxy } from 'unpdf';
+const pdf = await getDocumentProxy(new Uint8Array(buffer));
+const { totalPages, text } = await extractText(pdf, { mergePages: true });
+```
+Always wrap the call in try/catch returning a JSON 400 so a bad PDF can never surface as a blank 500. Refs: PR #72 + #73 (incomplete pdfjs fixes), PR #74 (unpdf — the real fix).
+
+**The four layers we peeled before giving up on raw pdfjs — each a browser/Node env difference that was a false green locally:**
+1. `require()` of `pdf.mjs` (ESM) → `ERR_REQUIRE_ESM` on Vercel's Node. Changing to `import()` wasn't enough because `config.externals` makes **webpack compile `import()` back into a `require()`**.
+2. `webpackIgnore` native import fixed #1, but `require.resolve('…pdf.worker.mjs')` compiles to a numeric webpack module id → pdfjs "Invalid workerSrc type". Fix: don't set `workerSrc` (Node uses a main-thread fake worker).
+3. A webpackIgnore'd import isn't auto-traced, so `pdf.mjs`/`pdf.worker.mjs` are missing from the function bundle unless force-included via `outputFileTracingIncludes`.
+4. Once pdfjs finally loaded, it threw `ReferenceError: DOMMatrix is not defined` — Vercel's runtime takes a pdfjs code path needing the DOM global. **Not reproducible locally** (local pdfjs extracts text fine without DOMMatrix), so no local fix could be verified. This is why we switched to unpdf.
+
+**Two reproduction techniques (a plain `next start` is NOT enough — local Node hides these):**
+- ESM/require trap: `NODE_OPTIONS='--no-experimental-require-module' npm run start` makes local Node reject `require()` of ESM like Vercel's does.
+- DOM-globals trap: in a node script, `delete globalThis.DOMMatrix; delete globalThis.Path2D; delete globalThis.ImageData;` before parsing, to simulate Vercel's environment. unpdf passes this; raw pdfjs's failing path does not.


### PR DESCRIPTION
## TL;DR
Production free ATS check has been broken since the pdfjs switch. #72 and #73 each removed a layer but the feature still failed. This replaces raw `pdfjs-dist` with **unpdf** and is verified against the exact condition that broke pdfjs on Vercel.

## Why pdfjs couldn't be salvaged — four layers, each a local false-green
1. `require()` of `pdf.mjs` (ESM) → `ERR_REQUIRE_ESM` on Vercel's Node. `import()` alone didn't help: `config.externals` makes webpack compile `import()` back into `require()`.
2. `webpackIgnore` native import fixed #1, but `require.resolve('…pdf.worker.mjs')` → numeric webpack module id → pdfjs "Invalid workerSrc type". Fixed by not setting `workerSrc`.
3. webpackIgnore'd imports aren't auto-traced → `pdf.mjs`/`pdf.worker.mjs` missing from the function unless force-included.
4. pdfjs then threw **`ReferenceError: DOMMatrix is not defined`** on Vercel — a DOM global its serverless code path needs. **Not reproducible locally** (local pdfjs extracts text fine without DOMMatrix), so no pdfjs fix could be verified.

## Fix
Use `unpdf` — a serverless-first wrapper bundling a pdfjs build with DOM polyfills baked in. Normal ESM dep webpack bundles; no externals, worker config, tracing hacks, or DOM globals.

\`\`\`ts
import { extractText, getDocumentProxy } from 'unpdf';
const pdf = await getDocumentProxy(new Uint8Array(buffer));
const { totalPages, text } = await extractText(pdf, { mergePages: true });
\`\`\`

Same `{ text, numpages, info }` return shape → all callers (ats-check, resume-text-fallback, agent resume-parser) unchanged. Reverts the #73 next.config externals/tracing (unneeded). Adds `unpdf ^1.6.2`.

## Verification
- Production build returns **HTTP 200 with a full ATS score** under `NODE_OPTIONS=--no-experimental-require-module` (the Vercel-Node ESM repro).
- **unpdf extracts text with `DOMMatrix`/`Path2D`/`ImageData` deleted from `globalThis`** — the precise condition that broke pdfjs on Vercel.

Ships to production on merge. After merge I'll re-probe live prod to confirm 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)