### PR TITLE
fix(ats): sync score display and improve keyword matching accuracy

### DIFF
--- a/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
@@ -13,6 +13,7 @@ import { buildResumeFromApprovedGroups } from "@/lib/optimization-review";
 import type { OptimizationReviewRun, ReviewChangeGroup } from "@/types/optimization-review";
 import { useTranslations } from "next-intl";
 import { ROUTES } from "@/lib/constants";
+import { stashAtsBootstrap } from "@/lib/ats/resolve-display-scores";
 
 type ReviewPayload = {
   review: OptimizationReviewRun;
@@ -148,6 +149,13 @@ export default function OptimizationReviewPage() {
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.error || t("errors.apply"));
+      }
+
+      if (data.optimizationId && data.atsImpact) {
+        stashAtsBootstrap(String(data.optimizationId), {
+          ats_score_original: data.atsImpact.before ?? null,
+          ats_score_optimized: data.atsImpact.after ?? null,
+        });
       }
 
       router.push(`${ROUTES.optimizations}/${data.optimizationId}`);

--- a/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
@@ -249,8 +249,8 @@ export default function OptimizationReviewPage() {
         {payload.review.ats_preview_json && (
           <div className="space-y-2">
             <CompactATSScoreCard
-              atsScoreOriginal={payload.review.ats_preview_json.before || 0}
-              atsScoreOptimized={payload.review.ats_preview_json.after || 0}
+              atsScoreOriginal={payload.review.ats_preview_json.before ?? 0}
+              atsScoreOptimized={payload.review.ats_preview_json.after ?? 0}
             />
             <p className="text-xs text-muted-foreground">
               {t("atsNote")}

--- a/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
-import { Link } from "@/navigation";
+import { Link, useRouter } from "@/navigation";
+import { ROUTES } from "@/lib/constants";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { createClientComponentClient } from "@/lib/supabase";
@@ -80,6 +81,7 @@ export default function OptimizationPage() {
   const [saving, setSaving] = useState(false);
 
   const params = useParams();
+  const router = useRouter();
   const supabase = createClientComponentClient();
   const { toast } = useToast();
   const t = useTranslations("dashboard.optimization");
@@ -102,7 +104,7 @@ export default function OptimizationPage() {
     {
       label: t("readiness.stats.atsSupport"),
       value:
-        matchScore !== null || atsV2Data?.ats_score_optimized !== null
+        matchScore != null || atsV2Data?.ats_score_optimized != null
           ? `${Math.round(atsV2Data?.ats_score_optimized ?? matchScore ?? 0)}%`
           : "--",
     },
@@ -593,7 +595,7 @@ export default function OptimizationPage() {
                 {t("error.reload")}
               </button>
               <button
-                onClick={() => window.location.href = '/dashboard/applications'}
+                onClick={() => router.push(`${ROUTES.dashboard}/applications`)}
                 className="w-full px-4 py-2 bg-muted text-muted-foreground rounded hover:bg-muted/80"
               >
                 {t("error.backToDashboard")}
@@ -758,7 +760,7 @@ export default function OptimizationPage() {
       }
 
       // Navigate to applications monitor
-      window.location.href = `/dashboard/applications`;
+      router.push(`${ROUTES.dashboard}/applications`);
 
     } catch (error) {
       console.error('Error in handleApply:', error);

--- a/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
@@ -16,6 +16,12 @@ import { ReadinessOverview } from "@/components/optimization/ReadinessOverview";
 import { SectionSelectionProvider } from "@/hooks/useSectionSelection";
 import { CacheBustingErrorBoundary } from "@/components/error/CacheBustingErrorBoundary";
 import { CompactATSScoreCard } from "@/components/ats/CompactATSScoreCard";
+import {
+  consumeAtsBootstrap,
+  mergeAtsDisplay,
+  resolveAtsDisplay,
+  type ResolvedAtsDisplay,
+} from "@/lib/ats/resolve-display-scores";
 import { useToast } from "@/hooks/useToast";
 import {
   Select,
@@ -43,7 +49,7 @@ export default function OptimizationPage() {
   const dragOffset = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
 
   // ATS v2 state
-  const [atsV2Data, setAtsV2Data] = useState<any>(null);
+  const [atsV2Data, setAtsV2Data] = useState<ResolvedAtsDisplay | null>(null);
   const [atsSuggestions, setAtsSuggestions] = useState<any[]>([]);
 
   // CRITICAL: Do not remove! Used by handleChatMessageSent and handleDesignUpdate callbacks
@@ -209,6 +215,13 @@ export default function OptimizationPage() {
     }
   }, [t]);
 
+  const applyAtsDisplay = useCallback((display: ResolvedAtsDisplay | null) => {
+    setAtsV2Data(display);
+    if (display?.ats_score_optimized != null) {
+      setMatchScore(display.ats_score_optimized);
+    }
+  }, []);
+
   const fetchOptimizationData = useCallback(async () => {
     try {
       const idVal = String(params.id || "");
@@ -283,22 +296,29 @@ export default function OptimizationPage() {
         throw new Error(t("error.jobNotFound"));
       }
 
-      setResumeText((resumeData as any)?.raw_text || "");
-      setJobDescription(jdData as any); // Store full job description for Apply button (includes title/company/source_url)
-      setOptimizedResume((optimizationRow as any).rewrite_data);
-      setMatchScore((optimizationRow as any).match_score);
-
-      // Set ATS v2 data if available
       const row = optimizationRow as any;
-      if (row.ats_score_optimized !== null) {
-        setAtsV2Data({
+      const bootstrap = consumeAtsBootstrap(idVal);
+      const resolvedAts = mergeAtsDisplay(
+        {
+          match_score: row.match_score,
           ats_score_original: row.ats_score_original,
           ats_score_optimized: row.ats_score_optimized,
-          subscores: row.ats_subscores,
-          subscores_original: row.ats_subscores_original,
-          confidence: row.ats_confidence,
-        });
-        setAtsSuggestions(row.ats_suggestions || []);
+          ats_subscores: row.ats_subscores,
+          ats_subscores_original: row.ats_subscores_original,
+          ats_confidence: row.ats_confidence,
+          ats_suggestions: row.ats_suggestions,
+        },
+        bootstrap
+      );
+
+      setResumeText((resumeData as any)?.raw_text || "");
+      setJobDescription(jdData as any);
+      setOptimizedResume((optimizationRow as any).rewrite_data);
+      setMatchScore(resolvedAts?.ats_score_optimized ?? row.match_score ?? null);
+
+      if (resolvedAts) {
+        applyAtsDisplay(resolvedAts);
+        setAtsSuggestions((row.ats_suggestions as any[]) || []);
       }
 
       // Generate AI summary of job description
@@ -310,15 +330,35 @@ export default function OptimizationPage() {
     } finally {
       setLoading(false);
     }
-  }, [params.id, supabase, t, generateJobDescriptionSummary]);
+  }, [params.id, supabase, t, generateJobDescriptionSummary, applyAtsDisplay]);
 
   useEffect(() => {
     fetchOptimizationData();
   }, [fetchOptimizationData]);
 
   // Refresh resume data and design when chat sends a message
-  const handleChatMessageSent = async () => {
-    console.log(' [handleChatMessageSent] CALLED! Starting refresh process...');
+  const handleChatMessageSent = async (immediateAts?: {
+    original?: number | null;
+    optimized?: number | null;
+  }) => {
+    if (immediateAts?.optimized != null || immediateAts?.original != null) {
+      setAtsV2Data((prev) => {
+        const next = resolveAtsDisplay({
+          match_score: immediateAts.optimized ?? prev?.ats_score_optimized ?? null,
+          ats_score_original: immediateAts.original ?? prev?.ats_score_original ?? null,
+          ats_score_optimized: immediateAts.optimized ?? prev?.ats_score_optimized ?? null,
+          ats_subscores: prev?.subscores,
+          ats_subscores_original: prev?.subscores_original,
+          ats_confidence: prev?.confidence ?? null,
+          ats_suggestions: prev?.suggestions,
+        });
+        return next ?? prev;
+      });
+      if (immediateAts.optimized != null) {
+        setMatchScore(immediateAts.optimized);
+      }
+    }
+
     try {
       const idVal2 = String(params.id || "");
 
@@ -336,7 +376,7 @@ export default function OptimizationPage() {
       const cacheBuster = Date.now();
       const { data: optimizationRow, error: optError } = await supabase
         .from("optimizations")
-        .select("rewrite_data, ats_score_optimized, ats_subscores, ats_score_original, ats_subscores_original, updated_at")
+        .select("rewrite_data, match_score, ats_score_optimized, ats_subscores, ats_score_original, ats_subscores_original, ats_confidence, ats_suggestions, updated_at")
         .eq("id", idVal2)
         .maybeSingle();
 
@@ -352,27 +392,26 @@ export default function OptimizationPage() {
         }
 
         // Force a complete re-render by creating new object reference
-        const newData = JSON.parse(JSON.stringify((optimizationRow as any).rewrite_data));
+        const optRow = optimizationRow as any;
+        const resolvedAts = resolveAtsDisplay({
+          match_score: optRow.match_score,
+          ats_score_original: optRow.ats_score_original,
+          ats_score_optimized: optRow.ats_score_optimized,
+          ats_subscores: optRow.ats_subscores,
+          ats_subscores_original: optRow.ats_subscores_original,
+          ats_confidence: optRow.ats_confidence,
+          ats_suggestions: optRow.ats_suggestions,
+        });
+
+        const newData = JSON.parse(JSON.stringify(optRow.rewrite_data));
+        if (resolvedAts?.ats_score_optimized != null) {
+          newData.matchScore = resolvedAts.ats_score_optimized;
+        }
         setOptimizedResume(newData);
 
-        // Update ATS scores if they changed
-        const optRow = optimizationRow as any;
-        if (optRow.ats_score_optimized !== null || optRow.ats_score_original !== null) {
-          console.log(' Updating ATS scores:', {
-            original: optRow.ats_score_original,
-            optimized: optRow.ats_score_optimized,
-            previousOptimized: atsV2Data?.ats_score_optimized,
-            scoreChanged: optRow.ats_score_optimized !== atsV2Data?.ats_score_optimized
-          });
-
-          // Force React to detect change by creating completely new object
-          setAtsV2Data({
-            ats_score_original: optRow.ats_score_original,
-            ats_score_optimized: optRow.ats_score_optimized,
-            subscores: optRow.ats_subscores,
-            subscores_original: optRow.ats_subscores_original,
-            confidence: atsV2Data?.confidence || null
-          });
+        if (resolvedAts) {
+          applyAtsDisplay(resolvedAts);
+          setAtsSuggestions((optRow.ats_suggestions as any[]) || []);
         }
 
         // Force component re-render
@@ -508,16 +547,22 @@ export default function OptimizationPage() {
   };
 
   const handleExpertAtsImpact = useCallback((impact: { before: number | null; after: number | null; delta: number | null }) => {
-    setAtsV2Data((prev: any) => ({
-      ats_score_original: impact.before ?? prev?.ats_score_original ?? null,
-      ats_score_optimized: impact.after ?? prev?.ats_score_optimized ?? null,
-      subscores: prev?.subscores ?? null,
-      subscores_original: prev?.subscores_original ?? null,
-      confidence: prev?.confidence ?? null,
-    }));
+    setAtsV2Data((prev) => {
+      const next = resolveAtsDisplay({
+        match_score: impact.after ?? prev?.ats_score_optimized ?? null,
+        ats_score_original: impact.before ?? prev?.ats_score_original ?? null,
+        ats_score_optimized: impact.after ?? prev?.ats_score_optimized ?? null,
+        ats_subscores: prev?.subscores,
+        ats_subscores_original: prev?.subscores_original,
+        ats_confidence: prev?.confidence ?? null,
+        ats_suggestions: prev?.suggestions,
+      });
+      return next ?? prev;
+    });
 
     if (impact.after !== null) {
       setMatchScore(impact.after);
+      setOptimizedResume((prev) => (prev ? { ...prev, matchScore: impact.after ?? prev.matchScore } : prev));
     }
   }, []);
 
@@ -736,10 +781,21 @@ export default function OptimizationPage() {
         throw new Error(j.error || 'Failed to save');
       }
       const result = await res.json();
-      setOptimizedResume(editDraft);
       if (result.ats_score_optimized != null) {
-        setAtsV2Data((prev: any) => prev ? { ...prev, ats_score_optimized: result.ats_score_optimized, ats_score_original: result.ats_score_original } : prev);
-        setMatchScore(result.ats_score_optimized);
+        const resolved = resolveAtsDisplay({
+          match_score: result.ats_score_optimized,
+          ats_score_original: result.ats_score_original,
+          ats_score_optimized: result.ats_score_optimized,
+          ats_subscores: result.ats_subscores,
+          ats_subscores_original: result.ats_subscores_original,
+          ats_confidence: result.ats_confidence,
+        });
+        if (resolved) {
+          applyAtsDisplay(resolved);
+        }
+        setOptimizedResume({ ...editDraft, matchScore: result.ats_score_optimized });
+      } else {
+        setOptimizedResume(editDraft);
       }
       setRefreshKey(k => k + 1);
       setIsEditing(false);
@@ -879,8 +935,8 @@ export default function OptimizationPage() {
           <div className="lg:col-span-2">
             {atsV2Data ? (
               <CompactATSScoreCard
-                atsScoreOriginal={atsV2Data.ats_score_original || matchScore}
-                atsScoreOptimized={atsV2Data.ats_score_optimized || matchScore}
+                atsScoreOriginal={atsV2Data.ats_score_original}
+                atsScoreOptimized={atsV2Data.ats_score_optimized}
                 subscores={atsV2Data.subscores}
                 subscoresOriginal={atsV2Data.subscores_original}
               />

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -269,6 +269,7 @@ export async function POST(request: NextRequest) {
         const { error: scoreUpdateError } = await supabase
           .from('optimizations')
           .update({
+            match_score: scoreResult.ats_score_optimized,
             ats_score_optimized: scoreResult.ats_score_optimized,
             ats_subscores: scoreResult.subscores,
           })

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -173,7 +173,8 @@ export async function POST(request: NextRequest) {
     const { error: updateError } = await supabase
       .from('optimizations')
       .update({ rewrite_data: updatedResumeData })
-      .eq('id', optimization_id);
+      .eq('id', optimization_id)
+      .eq('user_id', user.id);
 
     if (updateError) {
       console.error('❌ Failed to update optimization:', updateError);
@@ -260,7 +261,7 @@ export async function POST(request: NextRequest) {
         // Calculate new ATS score
         const scoreResult = await scoreResume(
           updatedResumeData,
-          {},  // original resume (not needed for optimized score)
+          currentResumeData,
           jobDataForScorer,
           jobDescription.embeddings || null
         );
@@ -273,7 +274,8 @@ export async function POST(request: NextRequest) {
             ats_score_optimized: scoreResult.ats_score_optimized,
             ats_subscores: scoreResult.subscores,
           })
-          .eq('id', optimization_id);
+          .eq('id', optimization_id)
+          .eq('user_id', user.id);
 
         if (scoreUpdateError) {
           console.error('❌ Failed to update ATS score:', scoreUpdateError);
@@ -317,13 +319,6 @@ export async function POST(request: NextRequest) {
         updated_resume: updatedResumeData,
       }, { status: 500 });
     }
-
-    // This should not be reached anymore (score calculation always returns inside try/catch)
-    return NextResponse.json({
-      success: true,
-      message: `Applied changes from Tip #${suggestion.number || '?'}`,
-      updated_resume: updatedResumeData,
-    }, { status: 200 });
 
   } catch (error) {
     console.error('Error in POST /api/v1/chat/approve-change:', error);

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -221,6 +221,7 @@ export function ChatSidebar({
       }
 
       const data: ChatSendMessageResponse = await response.json();
+      let resumeRefreshHandled = false;
 
       if (process.env.NODE_ENV === 'development') {
         logger.debug('Chat send response payload', {
@@ -270,6 +271,7 @@ export function ChatSidebar({
             await onMessageSent({
               optimized: data.tips_applied.new_ats_score ?? null,
             });
+            resumeRefreshHandled = true;
             if (process.env.NODE_ENV === 'development') {
               logger.debug('onMessageSent completed after tips applied', { optimizationId });
             }
@@ -315,6 +317,7 @@ export function ChatSidebar({
             logger.debug('Calling onMessageSent after design customization', { optimizationId });
           }
           onMessageSent();
+          resumeRefreshHandled = true;
           if (process.env.NODE_ENV === 'development') {
             logger.debug('onMessageSent completed after design customization', { optimizationId });
           }
@@ -332,8 +335,8 @@ export function ChatSidebar({
       if (data.session_id) {
         await loadMessages(data.session_id);
 
-        // Always trigger resume refresh after messages that change data
-        if (onMessageSent) {
+        // Refresh resume when the response changed data but no targeted handler ran.
+        if (onMessageSent && !resumeRefreshHandled) {
           onMessageSent();
         }
       }

--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -267,7 +267,9 @@ export function ChatSidebar({
             logger.debug('Calling onMessageSent after tips applied', { optimizationId });
           }
           try {
-            await onMessageSent();
+            await onMessageSent({
+              optimized: data.tips_applied.new_ats_score ?? null,
+            });
             if (process.env.NODE_ENV === 'development') {
               logger.debug('onMessageSent completed after tips applied', { optimizationId });
             }

--- a/src/lib/agent/handlers/handleTipImplementation.ts
+++ b/src/lib/agent/handlers/handleTipImplementation.ts
@@ -175,6 +175,7 @@ export async function handleTipImplementation(
 
       const updatePayload = {
         rewrite_data: updatedResume,
+        match_score: scoreAfter,
         ats_score_optimized: scoreAfter,
         ai_modification_count: (optimization.ai_modification_count || 0) + modifications.length,
         updated_at: new Date().toISOString(),
@@ -259,6 +260,7 @@ export async function handleTipImplementation(
     // 8. Update database with REAL scores and modification count
     const updatePayload = {
       rewrite_data: updatedResume,
+      match_score: scoreAfter,
       ats_score_optimized: scoreAfter,
       ats_subscores: atsResult.subscores,
       ats_suggestions: atsResult.suggestions,

--- a/src/lib/agent/handlers/handleTipImplementation.ts
+++ b/src/lib/agent/handlers/handleTipImplementation.ts
@@ -85,7 +85,7 @@ export async function handleTipImplementation(
     };
   }
   
-  const scoreBefore = optimization.ats_score_optimized || 0;
+  const scoreBefore = optimization.ats_score_optimized ?? 0;
   console.log('💡 [handleTipImplementation] Current score:', scoreBefore);
 
   const jobId = optimization.jd_id;
@@ -154,20 +154,17 @@ export async function handleTipImplementation(
       // Log modifications even in fallback path (Phase 3, T019)
       if (modifications.length > 0 && optimization.user_id) {
         try {
-          for (const modification of modifications) {
-            await supabase
-              .from('content_modifications')
-              .insert({
-                user_id: optimization.user_id,
-                optimization_id: optimizationId,
-                operation_type: modification.operation,
-                field_path: modification.field_path,
-                old_value: modification.old_value !== undefined ? JSON.stringify(modification.old_value) : null,
-                new_value: modification.new_value !== undefined ? JSON.stringify(modification.new_value) : null,
-                ats_score_before: scoreBefore,
-                ats_score_after: scoreAfter,
-              });
-          }
+          const modificationRecords = modifications.map((modification) => ({
+            user_id: optimization.user_id,
+            optimization_id: optimizationId,
+            operation_type: modification.operation,
+            field_path: modification.field_path,
+            old_value: modification.old_value !== undefined ? JSON.stringify(modification.old_value) : null,
+            new_value: modification.new_value !== undefined ? JSON.stringify(modification.new_value) : null,
+            ats_score_before: scoreBefore,
+            ats_score_after: scoreAfter,
+          }));
+          await supabase.from('content_modifications').insert(modificationRecords);
         } catch (logError) {
           console.error('⚠️ Failed to log modifications:', logError);
         }
@@ -229,26 +226,21 @@ export async function handleTipImplementation(
       console.log(`💡 [handleTipImplementation] Logging ${modifications.length} modifications to database...`);
 
       try {
-        // Insert each modification into content_modifications table
-        for (const modification of modifications) {
-          const modificationRecord = {
-            user_id: optimization.user_id,
-            optimization_id: optimizationId,
-            operation_type: modification.operation,
-            field_path: modification.field_path,
-            old_value: modification.old_value !== undefined ? JSON.stringify(modification.old_value) : null,
-            new_value: modification.new_value !== undefined ? JSON.stringify(modification.new_value) : null,
-            ats_score_before: scoreBefore,
-            ats_score_after: scoreAfter,
-            suggestion_text: suggestions.find(s =>
-              modification.field_path.includes('achievements') && s.text.includes(String(modification.new_value))
-            )?.text || null,
-          };
+        const modificationRecords = modifications.map((modification) => ({
+          user_id: optimization.user_id,
+          optimization_id: optimizationId,
+          operation_type: modification.operation,
+          field_path: modification.field_path,
+          old_value: modification.old_value !== undefined ? JSON.stringify(modification.old_value) : null,
+          new_value: modification.new_value !== undefined ? JSON.stringify(modification.new_value) : null,
+          ats_score_before: scoreBefore,
+          ats_score_after: scoreAfter,
+          suggestion_text: suggestions.find((s) =>
+            modification.field_path.includes('achievements') && s.text.includes(String(modification.new_value))
+          )?.text || null,
+        }));
 
-          await supabase
-            .from('content_modifications')
-            .insert(modificationRecord);
-        }
+        await supabase.from('content_modifications').insert(modificationRecords);
 
         console.log(`✅ [handleTipImplementation] Successfully logged ${modifications.length} modifications`);
       } catch (logError) {

--- a/src/lib/ats/analyzers/keyword-exact.ts
+++ b/src/lib/ats/analyzers/keyword-exact.ts
@@ -9,6 +9,7 @@
 import { BaseAnalyzer } from './base';
 import type { AnalyzerInput, AnalyzerResult } from '../types';
 import { KEYWORD_THRESHOLDS } from '../config/thresholds';
+import { scoreSkillListMatch } from '../skill-match';
 
 export class KeywordExactAnalyzer extends BaseAnalyzer {
   constructor() {
@@ -17,66 +18,43 @@ export class KeywordExactAnalyzer extends BaseAnalyzer {
 
   async analyze(input: AnalyzerInput): Promise<AnalyzerResult> {
     try {
-      // Extract keywords from both resume and JD
-      const resumeKeywords = new Set(
-        this.tokenize(input.resume_text).filter(
-          word => word.length >= KEYWORD_THRESHOLDS.min_keyword_length
-        )
-      );
+      const mustHaveSkills = input.job_data.must_have.filter(Boolean);
+      const niceToHaveSkills = input.job_data.nice_to_have.filter(Boolean);
 
-      // Must-have keywords (high priority)
-      const mustHave = new Set(
-        input.job_data.must_have
-          .flatMap(skill => this.tokenize(skill))
-          .filter(word => word.length >= KEYWORD_THRESHOLDS.min_keyword_length)
-      );
+      const mustHaveResult = scoreSkillListMatch(mustHaveSkills, input.resume_text);
+      const niceToHaveResult = scoreSkillListMatch(niceToHaveSkills, input.resume_text);
 
-      // Nice-to-have keywords (lower priority)
-      const niceToHave = new Set(
-        input.job_data.nice_to_have
-          .flatMap(skill => this.tokenize(skill))
-          .filter(word => word.length >= KEYWORD_THRESHOLDS.min_keyword_length)
-      );
-
-      // Calculate matches
-      const mustHaveMatched = this.findMissing(mustHave, resumeKeywords);
-      const mustHaveMatchedCount = mustHave.size - mustHaveMatched.length;
-
-      const niceToHaveMatched = this.findMissing(niceToHave, resumeKeywords);
-      const niceToHaveMatchedCount = niceToHave.size - niceToHaveMatched.length;
-
-      // Weighted score calculation
       const mustHaveWeight = KEYWORD_THRESHOLDS.must_have_weight;
       const niceToHaveWeight = KEYWORD_THRESHOLDS.nice_to_have_weight;
 
       const totalPossiblePoints =
-        mustHave.size * mustHaveWeight + niceToHave.size * niceToHaveWeight;
+        mustHaveSkills.length * mustHaveWeight + niceToHaveSkills.length * niceToHaveWeight;
 
-      const earnedPoints =
-        mustHaveMatchedCount * mustHaveWeight +
-        niceToHaveMatchedCount * niceToHaveWeight;
+      let score: number;
+      if (totalPossiblePoints === 0) {
+        score = 50;
+      } else {
+        const earnedPoints =
+          mustHaveResult.matched.length * mustHaveWeight +
+          niceToHaveResult.matched.length * niceToHaveWeight;
+        score = this.safeDivide(earnedPoints, totalPossiblePoints) * 100;
+      }
 
-      const score = this.safeDivide(earnedPoints, totalPossiblePoints) * 100;
-
-      // Confidence based on data quality
       const confidence = this.calculateConfidence({
-        hasRequiredData: mustHave.size > 0 || niceToHave.size > 0,
-        dataCompleteness: mustHave.size > 0 ? 1.0 : 0.7,
+        hasRequiredData: mustHaveSkills.length > 0 || niceToHaveSkills.length > 0,
+        dataCompleteness: mustHaveSkills.length > 0 ? 1.0 : 0.7,
         parsingErrors: 0,
       });
 
       return this.createResult(
         score,
         {
-          matched: [
-            ...Array.from(mustHave).filter(kw => resumeKeywords.has(kw)),
-            ...Array.from(niceToHave).filter(kw => resumeKeywords.has(kw)),
-          ],
-          missing: [...mustHaveMatched, ...niceToHaveMatched],
-          mustHaveMatched: mustHaveMatchedCount,
-          mustHaveTotal: mustHave.size,
-          niceToHaveMatched: niceToHaveMatchedCount,
-          niceToHaveTotal: niceToHave.size,
+          matched: [...mustHaveResult.matched, ...niceToHaveResult.matched],
+          missing: [...mustHaveResult.missing, ...niceToHaveResult.missing].slice(0, 20),
+          mustHaveMatched: mustHaveResult.matched.length,
+          mustHaveTotal: mustHaveSkills.length,
+          niceToHaveMatched: niceToHaveResult.matched.length,
+          niceToHaveTotal: niceToHaveSkills.length,
         },
         confidence
       );

--- a/src/lib/ats/analyzers/semantic.ts
+++ b/src/lib/ats/analyzers/semantic.ts
@@ -11,6 +11,7 @@ import type { AnalyzerInput, AnalyzerResult } from '../types';
 import { getEmbedding, cosineSimilarity } from '../utils/embeddings';
 import { SEMANTIC_THRESHOLDS } from '../config/thresholds';
 import { extractSectionText } from '../extractors/resume-text-extractor';
+import { scoreSkillListMatch } from '../skill-match';
 
 export class SemanticAnalyzer extends BaseAnalyzer {
   constructor() {
@@ -131,18 +132,7 @@ export class SemanticAnalyzer extends BaseAnalyzer {
    * This is a simplified version - in real implementation, would access shared state
    */
   private async getKeywordScore(input: AnalyzerInput): Promise<number> {
-    // Simplified keyword check
-    const resumeWords = new Set(this.tokenize(input.resume_text));
-    const mustHaveWords = new Set(
-      input.job_data.must_have.flatMap(skill => this.tokenize(skill))
-    );
-
-    if (mustHaveWords.size === 0) return 50;
-
-    const matchedCount = Array.from(mustHaveWords).filter(word =>
-      resumeWords.has(word)
-    ).length;
-
-    return (matchedCount / mustHaveWords.size) * 100;
+    const mustHaveResult = scoreSkillListMatch(input.job_data.must_have, input.resume_text);
+    return mustHaveResult.score;
   }
 }

--- a/src/lib/ats/extractors/jd-extractor.ts
+++ b/src/lib/ats/extractors/jd-extractor.ts
@@ -26,9 +26,18 @@ export function extractJobData(jobText: string, existingExtraction?: Partial<Job
     industry: existingExtraction?.industry || '',
   };
 
-  // If no must_have skills found, use general keyword extraction as fallback
+  // If no must_have skills found, use technical keyword extraction as fallback.
+  // Filter generic business words so the keyword denominator stays realistic.
   if (extraction.must_have.length === 0) {
-    extraction.must_have = extractKeywords(jobText).slice(0, 20);
+    const genericFallbackTerms = new Set([
+      'job', 'role', 'position', 'company', 'team', 'work', 'working',
+      'experience', 'years', 'ability', 'strong', 'excellent', 'good',
+      'communication', 'skills', 'responsibilities', 'requirements',
+      'description', 'summary', 'overview', 'preferred', 'required',
+    ]);
+    extraction.must_have = extractKeywords(jobText)
+      .filter((keyword) => !genericFallbackTerms.has(keyword.toLowerCase()))
+      .slice(0, 12);
   }
 
   return extraction;

--- a/src/lib/ats/resolve-display-scores.ts
+++ b/src/lib/ats/resolve-display-scores.ts
@@ -1,0 +1,109 @@
+/**
+ * Resolve ATS scores for UI display from optimization row fields.
+ * Uses nullish coalescing so legitimate 0 scores are not replaced by fallbacks.
+ */
+
+export interface OptimizationAtsRow {
+  match_score?: number | null;
+  ats_score_original?: number | null;
+  ats_score_optimized?: number | null;
+  ats_subscores?: unknown;
+  ats_subscores_original?: unknown;
+  ats_confidence?: number | null;
+  ats_suggestions?: unknown;
+}
+
+export interface ResolvedAtsDisplay {
+  ats_score_original: number;
+  ats_score_optimized: number;
+  subscores: unknown;
+  subscores_original: unknown;
+  confidence: number | null;
+  suggestions: unknown;
+}
+
+export interface AtsScoreBootstrap {
+  ats_score_original: number | null;
+  ats_score_optimized: number | null;
+  subscores?: unknown;
+  subscores_original?: unknown;
+  confidence?: number | null;
+}
+
+const BOOTSTRAP_KEY_PREFIX = 'optimization-ats-bootstrap:';
+
+export function resolveAtsDisplay(row: OptimizationAtsRow): ResolvedAtsDisplay | null {
+  const optimized = row.ats_score_optimized ?? row.match_score ?? null;
+  const original = row.ats_score_original ?? null;
+
+  if (optimized === null && original === null) {
+    return null;
+  }
+
+  const resolvedOptimized = optimized ?? original ?? 0;
+  const resolvedOriginal = original ?? optimized ?? 0;
+
+  return {
+    ats_score_original: resolvedOriginal,
+    ats_score_optimized: resolvedOptimized,
+    subscores: row.ats_subscores ?? null,
+    subscores_original: row.ats_subscores_original ?? null,
+    confidence: row.ats_confidence ?? null,
+    suggestions: row.ats_suggestions ?? null,
+  };
+}
+
+export function stashAtsBootstrap(optimizationId: string, bootstrap: AtsScoreBootstrap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.sessionStorage.setItem(
+      `${BOOTSTRAP_KEY_PREFIX}${optimizationId}`,
+      JSON.stringify(bootstrap)
+    );
+  } catch {
+    // Ignore storage failures — DB fetch remains the fallback.
+  }
+}
+
+export function consumeAtsBootstrap(optimizationId: string): AtsScoreBootstrap | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(`${BOOTSTRAP_KEY_PREFIX}${optimizationId}`);
+    if (!raw) return null;
+    window.sessionStorage.removeItem(`${BOOTSTRAP_KEY_PREFIX}${optimizationId}`);
+    return JSON.parse(raw) as AtsScoreBootstrap;
+  } catch {
+    return null;
+  }
+}
+
+export function mergeAtsDisplay(
+  dbRow: OptimizationAtsRow,
+  bootstrap: AtsScoreBootstrap | null
+): ResolvedAtsDisplay | null {
+  const fromDb = resolveAtsDisplay(dbRow);
+  if (!bootstrap) {
+    return fromDb;
+  }
+
+  const bootstrapResolved = resolveAtsDisplay({
+    match_score: bootstrap.ats_score_optimized,
+    ats_score_original: bootstrap.ats_score_original,
+    ats_score_optimized: bootstrap.ats_score_optimized,
+    ats_subscores: bootstrap.subscores,
+    ats_subscores_original: bootstrap.subscores_original,
+    ats_confidence: bootstrap.confidence ?? null,
+  });
+
+  if (!fromDb) {
+    return bootstrapResolved;
+  }
+
+  // Prefer DB when it already has a post-optimization score; otherwise use bootstrap.
+  const dbHasOptimized = dbRow.ats_score_optimized != null;
+  if (dbHasOptimized) {
+    return fromDb;
+  }
+
+  return bootstrapResolved ?? fromDb;
+}

--- a/src/lib/ats/skill-match.ts
+++ b/src/lib/ats/skill-match.ts
@@ -14,6 +14,16 @@ const STOP_WORDS = new Set([
   'role', 'job', 'position', 'company', 'years', 'year', 'experience',
 ]);
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function containsWholePhrase(normalizedResume: string, normalizedPhrase: string): boolean {
+  if (!normalizedPhrase) return false;
+  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(normalizedPhrase)}([^a-z0-9]|$)`);
+  return pattern.test(normalizedResume);
+}
+
 function significantTokens(text: string): string[] {
   return tokenize(text).filter(
     (word) => word.length >= KEYWORD_THRESHOLDS.min_keyword_length && !STOP_WORDS.has(word)
@@ -31,9 +41,9 @@ export function skillMatchesResume(skill: string, resumeText: string): boolean {
     return false;
   }
 
-  // Full phrase / substring match (handles "Node.js", "machine learning", etc.)
+  // Whole-phrase match (handles "Node.js", "machine learning", etc.)
   if (normalizedSkill.length >= KEYWORD_THRESHOLDS.min_keyword_length) {
-    if (normalizedResume.includes(normalizedSkill)) {
+    if (containsWholePhrase(normalizedResume, normalizedSkill)) {
       return true;
     }
   }
@@ -44,10 +54,12 @@ export function skillMatchesResume(skill: string, resumeText: string): boolean {
   }
 
   if (skillTokens.length === 1) {
-    return normalizedResume.includes(skillTokens[0]);
+    return containsWholePhrase(normalizedResume, skillTokens[0]);
   }
 
-  const matchedCount = skillTokens.filter((token) => normalizedResume.includes(token)).length;
+  const matchedCount = skillTokens.filter((token) =>
+    containsWholePhrase(normalizedResume, token)
+  ).length;
   const requiredMatches = Math.max(1, Math.ceil(skillTokens.length * 0.6));
   return matchedCount >= requiredMatches;
 }

--- a/src/lib/ats/skill-match.ts
+++ b/src/lib/ats/skill-match.ts
@@ -1,0 +1,84 @@
+/**
+ * Skill/requirement matching helpers for ATS keyword scoring.
+ * Matches at the requirement-phrase level, not only individual tokens.
+ */
+
+import { normalizeText, tokenize } from './utils/text-utils';
+import { KEYWORD_THRESHOLDS } from './config/thresholds';
+
+const STOP_WORDS = new Set([
+  'the', 'and', 'for', 'with', 'this', 'that', 'from', 'have', 'will',
+  'are', 'been', 'has', 'had', 'was', 'were', 'can', 'may', 'could',
+  'would', 'should', 'must', 'being', 'about', 'into', 'through', 'during',
+  'your', 'our', 'their', 'you', 'all', 'any', 'able', 'work', 'team',
+  'role', 'job', 'position', 'company', 'years', 'year', 'experience',
+]);
+
+function significantTokens(text: string): string[] {
+  return tokenize(text).filter(
+    (word) => word.length >= KEYWORD_THRESHOLDS.min_keyword_length && !STOP_WORDS.has(word)
+  );
+}
+
+/**
+ * Returns true when a JD skill/requirement appears in the resume text.
+ */
+export function skillMatchesResume(skill: string, resumeText: string): boolean {
+  const normalizedSkill = normalizeText(skill);
+  const normalizedResume = normalizeText(resumeText);
+
+  if (!normalizedSkill || !normalizedResume) {
+    return false;
+  }
+
+  // Full phrase / substring match (handles "Node.js", "machine learning", etc.)
+  if (normalizedSkill.length >= KEYWORD_THRESHOLDS.min_keyword_length) {
+    if (normalizedResume.includes(normalizedSkill)) {
+      return true;
+    }
+  }
+
+  const skillTokens = significantTokens(skill);
+  if (skillTokens.length === 0) {
+    return false;
+  }
+
+  if (skillTokens.length === 1) {
+    return normalizedResume.includes(skillTokens[0]);
+  }
+
+  const matchedCount = skillTokens.filter((token) => normalizedResume.includes(token)).length;
+  const requiredMatches = Math.max(1, Math.ceil(skillTokens.length * 0.6));
+  return matchedCount >= requiredMatches;
+}
+
+/**
+ * Score a list of JD skills/requirements against resume text.
+ */
+export function scoreSkillListMatch(skills: string[], resumeText: string): {
+  matched: string[];
+  missing: string[];
+  score: number;
+} {
+  const uniqueSkills = [...new Set(skills.map((skill) => skill.trim()).filter(Boolean))];
+  if (uniqueSkills.length === 0) {
+    return { matched: [], missing: [], score: 50 };
+  }
+
+  const matched: string[] = [];
+  const missing: string[] = [];
+
+  for (const skill of uniqueSkills) {
+    if (skillMatchesResume(skill, resumeText)) {
+      matched.push(skill);
+    } else {
+      missing.push(skill);
+    }
+  }
+
+  return {
+    matched,
+    missing,
+    score: (matched.length / uniqueSkills.length) * 100,
+  };
+}

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -220,11 +220,16 @@ export interface DiffResult {
 /**
  * ChatSidebar component props
  */
+export interface AtsScoreUpdate {
+  original?: number | null;
+  optimized?: number | null;
+}
+
 export interface ChatSidebarProps {
   optimizationId: string;
   initialOpen?: boolean;
   onClose?: () => void;
-  onMessageSent?: () => void;
+  onMessageSent?: (immediateAts?: AtsScoreUpdate) => void | Promise<void>;
   onDesignPreview?: (customization: any) => void;
 }
 

--- a/tests/unit/ats-skill-match.test.ts
+++ b/tests/unit/ats-skill-match.test.ts
@@ -1,0 +1,44 @@
+import { skillMatchesResume, scoreSkillListMatch } from '@/lib/ats/skill-match';
+
+describe('skill-match', () => {
+  const resumeText = `
+    Senior Software Engineer with 5 years of experience.
+    Skills: Python, React, AWS, machine learning, Node.js
+    Built scalable microservices on AWS using Python and React.
+  `;
+
+  it('matches full skill phrases via substring', () => {
+    expect(skillMatchesResume('Python', resumeText)).toBe(true);
+    expect(skillMatchesResume('machine learning', resumeText)).toBe(true);
+    expect(skillMatchesResume('Node.js', resumeText)).toBe(true);
+  });
+
+  it('matches multi-word requirements when most tokens are present', () => {
+    expect(skillMatchesResume('Experience with Python and AWS', resumeText)).toBe(true);
+  });
+
+  it('does not match unrelated skills', () => {
+    expect(skillMatchesResume('COBOL', resumeText)).toBe(false);
+  });
+
+  it('scores skill lists proportionally', () => {
+    const result = scoreSkillListMatch(['Python', 'React', 'COBOL'], resumeText);
+    expect(result.matched).toEqual(['Python', 'React']);
+    expect(result.missing).toEqual(['COBOL']);
+    expect(result.score).toBeCloseTo(66.67, 1);
+  });
+});
+
+describe('resolveAtsDisplay', () => {
+  it('preserves zero scores instead of falling back', async () => {
+    const { resolveAtsDisplay } = await import('@/lib/ats/resolve-display-scores');
+    const resolved = resolveAtsDisplay({
+      match_score: 82,
+      ats_score_original: 0,
+      ats_score_optimized: 82,
+    });
+
+    expect(resolved?.ats_score_original).toBe(0);
+    expect(resolved?.ats_score_optimized).toBe(82);
+  });
+});

--- a/tests/unit/ats-skill-match.test.ts
+++ b/tests/unit/ats-skill-match.test.ts
@@ -17,6 +17,12 @@ describe('skill-match', () => {
     expect(skillMatchesResume('Experience with Python and AWS', resumeText)).toBe(true);
   });
 
+  it('does not match short skill names inside longer words', () => {
+    const resume = 'Senior JavaScript engineer building React applications';
+    expect(skillMatchesResume('Java', resume)).toBe(false);
+    expect(skillMatchesResume('JavaScript', resume)).toBe(true);
+  });
+
   it('does not match unrelated skills', () => {
     expect(skillMatchesResume('COBOL', resumeText)).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Fix stale ATS score display on the optimization page by centralizing score resolution, syncing `matchScore`/`rewrite_data.matchScore` with ATS v2 fields, applying immediate chat tip score updates, and bootstrapping scores after review apply.
- Fix low absolute ATS scores by matching JD requirements at the skill/phrase level instead of individual tokens, and by tightening generic JD keyword fallback extraction.
- Keep backend rescore paths consistent by updating `match_score` whenever `ats_score_optimized` changes.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx jest tests/unit/ats-skill-match.test.ts`
- [ ] Upload resume → complete review → apply → verify optimization page shows correct before/after scores immediately
- [ ] Apply ATS tips in chat → verify score card and resume preview update without a manual refresh
- [ ] Score a resume with strong JD overlap (Python, React, AWS) and confirm the optimized score is materially higher than before


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved ATS scoring flow with unified score resolution and temporary score persistence to keep review pages in sync.
  * Enhanced chat-driven ATS score refresh so the score card can update immediately when available.

* **Bug Fixes**
  * Ensure ATS and keyword matching correctly preserve legitimate `0` score values (no accidental fallback).
  * Persist `match score` alongside optimized ATS results during recalculation and ATS impact updates.

* **New Features**
  * Smarter keyword extraction and updated keyword/semantic matching to improve relevance.

* **Tests**
  * Added unit tests for skill matching and ATS score resolution edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->