### PR TITLE
fix(ats): feed scorer real JD requirements when parsed_data is sparse

### DIFF
--- a/docs/agent-os/ats-low-score-fix-2026-06-19.md
+++ b/docs/agent-os/ats-low-score-fix-2026-06-19.md
@@ -1,0 +1,79 @@
+# Fix: Low ATS score after PR #75 — job-description pipeline feeds the scorer near-empty data
+
+> **Target repo:** this repo (`new-ResumeBuilder-ai-`, web/Next.js).
+> **iOS repo:** no changes — it renders the backend score; deploying this fix to Vercel (`new-resume-builder-ai` → resumelybuilderai.com) propagates to the iOS app automatically.
+> **Created:** 2026-06-19. Source incident: user re-optimized on the Resumely iOS app after PR #75 (`a6e69cb`) and still saw a low ATS score.
+
+## Context
+
+After PR #75 (`fix/ats-score-issues`, merge `a6e69cb`) merged to `main`, the user re-ran resume optimization on the **Resumely iOS app** and still saw a low ATS score. Investigation shows this is expected: **PR #75 could not have fixed this symptom.**
+
+Two facts establish that:
+
+1. **iOS shows a server-computed score, not the web UI.** The iOS app calls `POST /api/optimize` with only `resumeId` + `jobDescriptionId` and renders `ats_score_after` natively (`OptimizedResumeViewModel.currentATSScore`). PR #75's display-sync fixes (`resolve-display-scores.ts`, the optimization `[id]/page.tsx`) are **web-frontend only** and never execute on iOS. Only PR #75's **server-side scoring library** changes reach the device.
+
+2. **PR #75 improved keyword *matching accuracy*, not job-description *extraction*.** Its commits (`95b9442`, `90b203b`) add whole-word phrase matching and fix the `||`→`??` display bug. Better matching cannot raise a score when there is nothing to match against.
+
+### Root cause (confirmed against production DB `brtdyamysfmctrhuankn`)
+
+Every recent optimization is scored nearly **blind to the job description**:
+
+| opt day | opt score | `optimizations.jd_text` len | `job_descriptions.raw_text` len | `parsed_data.requirements` |
+|---|---|---|---|---|
+| 2026-06-19 (BDM, Tel Aviv) | 35 | **0** | 221 | **null** |
+| 2026-06-18 | 29 | **0** | 16 ("dueto" junk) | null |
+| 2026-06-16 | 33 | **0** | 234 | null |
+| 2026-06-15 | 39 | **0** | 263 | null |
+
+Representative subscores (2026-06-19): `keyword_exact 27, keyword_phrase 2, recency_fit 18, metrics_presence 0, semantic_relevance 70, format 85, sections 100`. The keyword/phrase/recency analyzers collapse because they receive no real job requirements, dragging the aggregate to ~29–39 regardless of résumé quality.
+
+Why the data is empty:
+- **`parsed_data.requirements` is JSON `null`** even though parsing ran (the object has `requirements`, `nice_to_have`, `qualifications`, `responsibilities` keys — only `requirements` is populated-as-null). The scraper/parser is not filling it.
+- **`optimizations.jd_text` is length 0** on every record — the JD text is never persisted onto the optimization.
+- **`raw_text` is a truncated snippet** (~220 chars) — JD capture grabs a teaser, not the full posting.
+- In `prepareInput` (`src/lib/ats/index.ts:203-227`), when `job_extracted_json.requirements` is null the code sets `must_have = []` **with no fallback** — it does not re-extract from `job_clean_text` and does not read the populated `qualifications`/`responsibilities` keys.
+
+Intended outcome: scores reflect the actual résumé↔JD match instead of being structurally capped near 30 by an empty JD payload.
+
+## Approach (both layers — scorer robustness + JD ingestion)
+
+### Layer A — Scorer robustness (immediate score lift, server-side)
+File: `src/lib/ats/index.ts`, function `prepareInput` (lines ~194-248).
+
+- When `job_extracted_json` is provided but `requirements` is null/empty, **do not leave `must_have = []`**. Fall back in this order:
+  1. `job_extracted_json.requirements` (array/string) — current behavior.
+  2. Merge in `job_extracted_json.qualifications` and `job_extracted_json.responsibilities` when present (these exist in `parsed_data` today).
+  3. If still empty, call `extractJobData(input.job_clean_text || input.job_extracted_json.raw_text, input.job_extracted_json)` so the generic-keyword fallback (already in `jd-extractor.ts:31-44`) actually runs.
+- Mirror the same null-safe handling for `nice_to_have`.
+- Keep the existing `containsWholePhrase` / `scoreSkillListMatch` logic from PR #75 unchanged — it is correct; it was just starved of input.
+
+Reuse, don't reinvent: `extractJobData` already filters generic business words and caps at 12 keywords; route the fallback through it rather than writing new extraction.
+
+### Layer B — JD ingestion (root fix)
+1. **Populate `requirements` at parse time.** In the JD scrape/parse step that writes `job_descriptions.parsed_data` (the producer of keys `posting_id`, `scraped_at`, `source_domain`, `provenance`), ensure `requirements` (and `nice_to_have`) are filled from the model output instead of landing null. Trace the writer via `grep -rn "parsed_data" src/app/api` and the JD scrape route.
+2. **Persist the JD text the scorer used.** Set `optimizations.jd_text` when the optimization is created (currently always empty) so re-scoring and debugging have the exact input. Check the `/api/optimize` and review-apply routes.
+3. **Stop scoring against truncated snippets.** Confirm whether `raw_text` ~220 chars is a scraper truncation (likely a LinkedIn/teaser capture). If so, capture the full posting or prefer `clean_text` when longer. Flag to user if this is a product/scraper limit rather than a bug.
+
+### Files to modify (representative)
+- `src/lib/ats/index.ts` — `prepareInput` fallback (Layer A, primary).
+- `src/lib/ats/extractors/jd-extractor.ts` — optionally read `qualifications`/`responsibilities` in `extractJobData`.
+- JD scrape/parse route under `src/app/api/**` that writes `parsed_data` — populate `requirements` (Layer B).
+- `src/app/api/optimize/route.ts` (and review-apply path) — persist `jd_text` (Layer B).
+
+## Tests
+- Extend `tests/unit/ats-skill-match.test.ts` (or add `tests/unit/ats-prepare-input.test.ts`): given `job_extracted_json` with `requirements: null` but populated `qualifications`/`responsibilities` and a real `clean_text`, assert `must_have.length > 0` and `keyword_exact` subscore > 0.
+- Regression: `requirements` present as array still used verbatim (no double-counting from qualifications merge).
+- Junk JD (16-char "dueto") still yields a low-but-defensible score without throwing.
+
+## Verification (use latest DB optimization — no new device run needed)
+1. Take the 2026-06-19 "Business Development Manager (Tel Aviv)" optimization (raw_text 221 chars, requirements null, baseline opt score **35**).
+2. After Layer A, re-run scoring against that exact `resume_text` + `job_descriptions` row (via `rescoreOptimization` or a one-off script) and diff subscores. Expect `keyword_exact` / `keyword_phrase` to rise from ~27/2 and the aggregate to move materially above 35.
+3. After Layer B, re-parse that JD row and confirm `parsed_data.requirements` is a non-empty array and a fresh optimization persists non-empty `optimizations.jd_text`.
+4. Read-only confirm via Supabase MCP (`brtdyamysfmctrhuankn`): the latest optimizations now show non-zero `jd_text` length and non-null `requirements`.
+5. Lint + tests green before declaring done. Deploy to production (Vercel `new-resume-builder-ai`) is required for the iOS app to see the change — flag the deploy for explicit approval.
+
+## Out of scope / notes
+- Do not change PR #75's matching algorithm — it is correct.
+- `metrics_presence` is consistently 0 (résumé genuinely lacks quantified metrics); that is a separate, legitimate signal, not part of this fix.
+- The two 16-char "dueto" JD rows are user/scrape junk, not the target case.
+- iOS in-memory LRU score cache (`OptimizationDetailCacheActor`, limit 10) clears on app restart; not the root cause but mention to the user if a stale score lingers after deploy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/ssr": "^0.7.0",
         "@supabase/supabase-js": "^2.57.2",
+        "@swc/helpers": "0.5.23",
         "@tailwindcss/typography": "^0.5.16",
         "@types/diff-match-patch": "^1.0.36",
         "@types/fs-extra": "^11.0.4",
@@ -86,6 +87,9 @@
         "ts-jest": "^29.4.5",
         "tsx": "^4.20.6",
         "typescript": "5.9.2"
+      },
+      "optionalDependencies": {
+        "@swc/helpers": "^0.5.23"
       }
     },
     "node_modules/@acemir/cssom": {
@@ -6266,9 +6270,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -14869,6 +14873,15 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
     "ts-jest": "^29.4.5",
     "tsx": "^4.20.6",
     "typescript": "5.9.2"
+  },
+  "optionalDependencies": {
+    "@swc/helpers": "^0.5.23"
   }
 }

--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { runOptimizePipeline } from "@/lib/ai-optimizer/optimize-pipeline";
+import { preferJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { checkRateLimit, getRateLimitHeaders, RATE_LIMITS } from "@/lib/utils/rate-limit";
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
@@ -54,7 +55,7 @@ export async function POST(req: NextRequest) {
 
     const jdQuery = supabase
       .from("job_descriptions")
-      .select("raw_text")
+      .select("raw_text, clean_text, parsed_data, title")
       .eq("id", jobDescriptionId)
       .maybeSingle();
 
@@ -74,9 +75,13 @@ export async function POST(req: NextRequest) {
     // Credit check disabled — all users are on free tier for now.
     // Re-enable by uncommenting the consumeCredit block when monetization goes live.
 
+    const jobDescriptionText = preferJobDescriptionText(jdData as { raw_text?: string; clean_text?: string });
+    const parsedData = (jdData as { parsed_data?: Record<string, unknown> }).parsed_data;
+
     const pipelineResult = await runOptimizePipeline(
       (resumeData as any).raw_text,
-      (jdData as any).raw_text
+      jobDescriptionText,
+      parsedData ? { jobExtractedJson: parsedData } : undefined,
     );
     const optimizedResume = pipelineResult.optimizedResume;
 
@@ -86,7 +91,7 @@ export async function POST(req: NextRequest) {
       resumeId,
       jobDescriptionId,
       resumeRawText: (resumeData as any).raw_text,
-      jobDescriptionText: (jdData as any).raw_text,
+      jobDescriptionText,
       jobTitle: 'Position',
       optimizedResume,
     });

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { extractJob } from "@/lib/scraper/jobExtractor";
 import { scrapeJobDescription } from "@/lib/job-scraper";
+import { normalizeParsedJobData } from "@/lib/ats/job-data-resolver";
 import { isSupportedResumeFile } from "@/lib/utils/file-validation";
 import { convertResumeBuffer } from "@/lib/markitdown-client";
 import path from "path";
@@ -74,7 +75,7 @@ export async function POST(req: NextRequest) {
         const extracted = await extractJob(jobDescriptionUrl);
         extractedTitle = extracted.job_title;
         extractedCompany = extracted.company_name;
-        extractedData = extracted;
+        extractedData = normalizeParsedJobData(extracted);
         sourceUrl = jobDescriptionUrl;
 
         const parts: string[] = [];

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
 import { scoreResume } from '@/lib/ats/scorer';
+import { buildJobDataFromExtractedJson, preferJobDescriptionText } from '@/lib/ats/job-data-resolver';
 import { TECHNICAL_KEYWORDS } from '@/lib/constants';
 
 export async function POST(request: NextRequest) {
@@ -228,25 +229,13 @@ export async function POST(request: NextRequest) {
         // Map parsed_data from database to JobExtraction format expected by scorer
         // Database structure: { job_title, requirements, nice_to_have, responsibilities, ... }
         // Scorer expects: { title, must_have, nice_to_have, responsibilities, ... }
+        const jobText = preferJobDescriptionText(jobDescription);
         const jobDataForScorer = {
-          title: jobDescription.parsed_data.job_title || '',
-          company: jobDescription.parsed_data.company_name || '',
-          must_have: Array.isArray(jobDescription.parsed_data.requirements)
-            ? jobDescription.parsed_data.requirements
-            : (typeof jobDescription.parsed_data.requirements === 'string'
-              ? [jobDescription.parsed_data.requirements]
-              : []),
-          nice_to_have: Array.isArray(jobDescription.parsed_data.nice_to_have)
-            ? jobDescription.parsed_data.nice_to_have
-            : [],
-          responsibilities: Array.isArray(jobDescription.parsed_data.responsibilities)
-            ? jobDescription.parsed_data.responsibilities
-            : [],
-          seniority: jobDescription.parsed_data.seniority || '',
-          location: jobDescription.parsed_data.location || '',
-          industry: '',
-          // raw_text and clean_text are table-level columns, not in parsed_data
-          raw_text: jobDescription.clean_text || jobDescription.raw_text || '',
+          ...buildJobDataFromExtractedJson(
+            jobDescription.parsed_data as Record<string, unknown>,
+            jobText,
+          ),
+          raw_text: jobText,
           clean_text: jobDescription.clean_text || jobDescription.raw_text || '',
         };
 

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -231,10 +231,7 @@ export async function POST(request: NextRequest) {
         // Scorer expects: { title, must_have, nice_to_have, responsibilities, ... }
         const jobText = preferJobDescriptionText(jobDescription);
         const jobDataForScorer = {
-          ...buildJobDataFromExtractedJson(
-            jobDescription.parsed_data as Record<string, unknown>,
-            jobText,
-          ),
+          ...buildJobDataFromExtractedJson(jobDescription.parsed_data, jobText),
           raw_text: jobText,
           clean_text: jobDescription.clean_text || jobDescription.raw_text || '',
         };

--- a/src/lib/ai-optimizer/optimize-pipeline.ts
+++ b/src/lib/ai-optimizer/optimize-pipeline.ts
@@ -8,6 +8,7 @@ import {
 import { optimizeResume, type OptimizedResume } from './index';
 import { scoreOptimization, resumeJsonToText } from '@/lib/ats/integration';
 import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
+import { buildJobDataFromExtractedJson } from '@/lib/ats/job-data-resolver';
 import type { ATSScoreOutput } from '@/lib/ats/types';
 
 export interface OptimizationPipelineResult {
@@ -120,15 +121,18 @@ function buildGapsFromAtsResult(
 
 export async function runOptimizePipeline(
   resumeText: string,
-  jobDescription: string
+  jobDescription: string,
+  options?: { jobExtractedJson?: Record<string, unknown> }
 ): Promise<OptimizationPipelineResult> {
   const hebrewPattern = /[֐-׿]/;
   const isHebrew = hebrewPattern.test(resumeText) || hebrewPattern.test(jobDescription);
 
   console.log('Pipeline start:', { isHebrew, resumeLen: resumeText.length });
 
-  // Step 1: Extract JD structure
-  const jobExtraction = extractJobData(jobDescription);
+  // Step 1: Extract JD structure (use parsed_data fallbacks when available)
+  const jobExtraction = options?.jobExtractedJson
+    ? buildJobDataFromExtractedJson(options.jobExtractedJson, jobDescription)
+    : extractJobData(jobDescription);
   console.log('Pipeline JD extraction:', {
     must_have_count: jobExtraction.must_have.length,
     nice_to_have_count: jobExtraction.nice_to_have.length,
@@ -162,6 +166,7 @@ export async function runOptimizePipeline(
     resumeOriginalText: resumeText,
     resumeOptimizedJson: candidate1,
     jobDescriptionText: jobDescription,
+    jobExtractedJson: options?.jobExtractedJson,
   });
 
   console.log('Pipeline pass 1 score:', {
@@ -204,6 +209,7 @@ export async function runOptimizePipeline(
     resumeOriginalText: resumeText,
     resumeOptimizedJson: candidate2,
     jobDescriptionText: jobDescription,
+    jobExtractedJson: options?.jobExtractedJson,
   });
 
   console.log('Pipeline pass 2 score:', {

--- a/src/lib/ats/index.ts
+++ b/src/lib/ats/index.ts
@@ -205,10 +205,7 @@ async function prepareInput(input: ATSScoreInput) {
 
   let job_data;
   if (hasValidJobData) {
-    job_data = buildJobDataFromExtractedJson(
-      input.job_extracted_json as Record<string, unknown>,
-      fallbackJobText,
-    );
+    job_data = buildJobDataFromExtractedJson(input.job_extracted_json, fallbackJobText);
   } else {
     // Extract from text
     job_data = extractJobData(input.job_clean_text, input.job_extracted_json);

--- a/src/lib/ats/index.ts
+++ b/src/lib/ats/index.ts
@@ -19,6 +19,7 @@ import { applyPenalties } from './scorers/penalties';
 import { estimateConfidence } from './scorers/confidence';
 import { generateSuggestions } from './suggestions/generator';
 import { extractJobData, isJobExtractionComplete } from './extractors/jd-extractor';
+import { buildJobDataFromExtractedJson } from './job-data-resolver';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 import { generateQuickWins } from './quick-wins/generator';
@@ -196,32 +197,18 @@ async function prepareInput(input: ATSScoreInput) {
   // Handle both database format (job_title) and scorer format (title)
   const hasValidJobData = input.job_extracted_json?.title || input.job_extracted_json?.job_title;
 
+  const fallbackJobText =
+    input.job_clean_text ||
+    (input.job_extracted_json as { raw_text?: string; clean_text?: string }).clean_text ||
+    (input.job_extracted_json as { raw_text?: string; clean_text?: string }).raw_text ||
+    '';
+
   let job_data;
   if (hasValidJobData) {
-    // If we have database format (job_title), map to scorer format (title)
-    if (input.job_extracted_json.job_title && !input.job_extracted_json.title) {
-      job_data = {
-        title: input.job_extracted_json.job_title || '',
-        company: input.job_extracted_json.company_name || '',
-        must_have: Array.isArray(input.job_extracted_json.requirements)
-          ? input.job_extracted_json.requirements
-          : (typeof input.job_extracted_json.requirements === 'string'
-            ? [input.job_extracted_json.requirements]
-            : []),
-        nice_to_have: Array.isArray(input.job_extracted_json.nice_to_have)
-          ? input.job_extracted_json.nice_to_have
-          : [],
-        responsibilities: Array.isArray(input.job_extracted_json.responsibilities)
-          ? input.job_extracted_json.responsibilities
-          : [],
-        seniority: input.job_extracted_json.seniority || '',
-        location: input.job_extracted_json.location || '',
-        industry: input.job_extracted_json.industry || '',
-      };
-    } else {
-      // Already in correct format
-      job_data = input.job_extracted_json;
-    }
+    job_data = buildJobDataFromExtractedJson(
+      input.job_extracted_json as Record<string, unknown>,
+      fallbackJobText,
+    );
   } else {
     // Extract from text
     job_data = extractJobData(input.job_clean_text, input.job_extracted_json);

--- a/src/lib/ats/integration.ts
+++ b/src/lib/ats/integration.ts
@@ -8,6 +8,7 @@ import { scoreResume } from './index';
 import type { ATSScoreInput, JobExtraction, FormatReport, ATSScoreOutput } from './types';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
 import { extractJobData } from './extractors/jd-extractor';
+import { buildJobDataFromExtractedJson } from './job-data-resolver';
 
 /**
  * Extract keywords and requirements from job description text
@@ -149,19 +150,23 @@ export async function scoreOptimization(params: {
   resumeOptimizedJson: OptimizedResume;
   jobDescriptionText: string;
   jobTitle?: string;
+  jobExtractedJson?: Record<string, unknown>;
 }): Promise<ATSScoreOutput> {
   const {
     resumeOriginalText,
     resumeOptimizedJson,
     jobDescriptionText,
     jobTitle = 'Position',
+    jobExtractedJson,
   } = params;
 
   // Convert optimized resume JSON to text
   const resumeOptimizedText = resumeJsonToText(resumeOptimizedJson);
 
-  // Extract job requirements
-  const jobExtraction = extractJobRequirements(jobDescriptionText, jobTitle);
+  // Extract job requirements — prefer structured parsed_data with fallbacks
+  const jobExtraction = jobExtractedJson
+    ? buildJobDataFromExtractedJson(jobExtractedJson, jobDescriptionText)
+    : extractJobRequirements(jobDescriptionText, jobTitle);
 
   // Generate format reports
   const formatReport = generateFormatReport(resumeOriginalText);

--- a/src/lib/ats/job-data-resolver.ts
+++ b/src/lib/ats/job-data-resolver.ts
@@ -1,0 +1,127 @@
+/**
+ * Resolve structured job data for ATS scoring when parsed_data is incomplete.
+ */
+
+import type { JobExtraction } from './types';
+import { extractJobData } from './extractors/jd-extractor';
+
+export function normalizeStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => String(item).trim()).filter(Boolean);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return [value.trim()];
+  }
+  return [];
+}
+
+export function mergeUniqueLists(...lists: string[][]): string[] {
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const list of lists) {
+    for (const item of list) {
+      const key = item.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        merged.push(item);
+      }
+    }
+  }
+
+  return merged;
+}
+
+export function resolveMustHaveFromExtracted(extracted: Record<string, unknown>): string[] {
+  const requirements = normalizeStringList(extracted.requirements);
+  if (requirements.length > 0) {
+    return requirements;
+  }
+
+  return mergeUniqueLists(
+    normalizeStringList(extracted.qualifications),
+    normalizeStringList(extracted.responsibilities),
+    normalizeStringList(extracted.must_have),
+  );
+}
+
+export function resolveNiceToHaveFromExtracted(extracted: Record<string, unknown>): string[] {
+  return normalizeStringList(extracted.nice_to_have);
+}
+
+export function preferJobDescriptionText(jd: {
+  raw_text?: string | null;
+  clean_text?: string | null;
+}): string {
+  const raw = (jd.raw_text || '').trim();
+  const clean = (jd.clean_text || '').trim();
+
+  if (clean.length > raw.length) {
+    return clean;
+  }
+
+  return raw || clean;
+}
+
+export function buildJobDataFromExtractedJson(
+  extracted: Record<string, unknown>,
+  jobCleanText?: string,
+): JobExtraction {
+  const title = String(extracted.title || extracted.job_title || '');
+  const company = String(extracted.company || extracted.company_name || '');
+  let must_have = resolveMustHaveFromExtracted(extracted);
+  let nice_to_have = resolveNiceToHaveFromExtracted(extracted);
+  const responsibilities = normalizeStringList(extracted.responsibilities);
+
+  const fallbackText =
+    jobCleanText ||
+    String(extracted.clean_text || extracted.raw_text || '');
+
+  if (must_have.length === 0 && fallbackText) {
+    const fromText = extractJobData(fallbackText, {
+      title,
+      company,
+      must_have: [],
+      nice_to_have: [],
+      responsibilities,
+    });
+    must_have = fromText.must_have;
+    if (nice_to_have.length === 0) {
+      nice_to_have = fromText.nice_to_have;
+    }
+  }
+
+  return {
+    title,
+    company,
+    must_have,
+    nice_to_have,
+    responsibilities,
+    seniority: String(extracted.seniority || ''),
+    location: String(extracted.location || ''),
+    industry: String(extracted.industry || ''),
+    job_title: (extracted.job_title as string | null | undefined) ?? null,
+    company_name: (extracted.company_name as string | null | undefined) ?? null,
+    requirements: (extracted.requirements as string[] | string | null | undefined) ?? null,
+  };
+}
+
+/**
+ * Normalize scraper output so requirements is populated when only qualifications exist.
+ */
+export function normalizeParsedJobData<T extends Record<string, unknown>>(parsed: T): T {
+  const requirements = normalizeStringList(parsed.requirements);
+  if (requirements.length > 0) {
+    return { ...parsed, requirements };
+  }
+
+  const merged = resolveMustHaveFromExtracted(parsed);
+  if (merged.length === 0) {
+    return parsed;
+  }
+
+  return {
+    ...parsed,
+    requirements: merged,
+  };
+}

--- a/src/lib/ats/job-data-resolver.ts
+++ b/src/lib/ats/job-data-resolver.ts
@@ -4,6 +4,14 @@
 
 import type { JobExtraction } from './types';
 import { extractJobData } from './extractors/jd-extractor';
+import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
+
+export function toParsedJobRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === 'object') {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
 
 export function normalizeStringList(value: unknown): string[] {
   if (Array.isArray(value)) {
@@ -64,18 +72,19 @@ export function preferJobDescriptionText(jd: {
 }
 
 export function buildJobDataFromExtractedJson(
-  extracted: Record<string, unknown>,
+  extracted: unknown,
   jobCleanText?: string,
 ): JobExtraction {
-  const title = String(extracted.title || extracted.job_title || '');
-  const company = String(extracted.company || extracted.company_name || '');
-  let must_have = resolveMustHaveFromExtracted(extracted);
-  let nice_to_have = resolveNiceToHaveFromExtracted(extracted);
-  const responsibilities = normalizeStringList(extracted.responsibilities);
+  const record = toParsedJobRecord(extracted);
+  const title = String(record.title || record.job_title || '');
+  const company = String(record.company || record.company_name || '');
+  let must_have = resolveMustHaveFromExtracted(record);
+  let nice_to_have = resolveNiceToHaveFromExtracted(record);
+  const responsibilities = normalizeStringList(record.responsibilities);
 
   const fallbackText =
     jobCleanText ||
-    String(extracted.clean_text || extracted.raw_text || '');
+    String(record.clean_text || record.raw_text || '');
 
   if (must_have.length === 0 && fallbackText) {
     const fromText = extractJobData(fallbackText, {
@@ -97,25 +106,25 @@ export function buildJobDataFromExtractedJson(
     must_have,
     nice_to_have,
     responsibilities,
-    seniority: String(extracted.seniority || ''),
-    location: String(extracted.location || ''),
-    industry: String(extracted.industry || ''),
-    job_title: (extracted.job_title as string | null | undefined) ?? null,
-    company_name: (extracted.company_name as string | null | undefined) ?? null,
-    requirements: (extracted.requirements as string[] | string | null | undefined) ?? null,
+    seniority: String(record.seniority || ''),
+    location: String(record.location || ''),
+    industry: String(record.industry || ''),
+    job_title: (record.job_title as string | null | undefined) ?? null,
+    company_name: (record.company_name as string | null | undefined) ?? null,
+    requirements: (record.requirements as string[] | string | null | undefined) ?? null,
   };
 }
 
 /**
  * Normalize scraper output so requirements is populated when only qualifications exist.
  */
-export function normalizeParsedJobData<T extends Record<string, unknown>>(parsed: T): T {
+export function normalizeParsedJobData(parsed: ExtractedJobData): ExtractedJobData {
   const requirements = normalizeStringList(parsed.requirements);
   if (requirements.length > 0) {
     return { ...parsed, requirements };
   }
 
-  const merged = resolveMustHaveFromExtracted(parsed);
+  const merged = resolveMustHaveFromExtracted(toParsedJobRecord(parsed));
   if (merged.length === 0) {
     return parsed;
   }

--- a/src/lib/ats/scorer.ts
+++ b/src/lib/ats/scorer.ts
@@ -8,6 +8,7 @@
 import { scoreResume as scoreResumeMain, rescoreOptimization } from './index';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { extractJobData } from './extractors/jd-extractor';
+import { buildJobDataFromExtractedJson, preferJobDescriptionText } from './job-data-resolver';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 import type { ATSScoreOutput } from './types';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
@@ -41,12 +42,12 @@ export async function scoreResume(
     ? extractResumeText(resumeOriginal)
     : resumeOptimizedText;
 
-  // Extract job description text
-  const jobText = jobDescriptionData.raw_text || jobDescriptionData.clean_text || '';
+  // Extract job description text — prefer longer clean_text over truncated raw_text
+  const jobText = preferJobDescriptionText(jobDescriptionData);
 
-  // Use existing job data extraction or create from text
-  const jobExtraction = jobDescriptionData.title
-    ? jobDescriptionData
+  const hasStructuredJob = jobDescriptionData.title || jobDescriptionData.job_title;
+  const jobExtraction = hasStructuredJob
+    ? buildJobDataFromExtractedJson(jobDescriptionData, jobText)
     : extractJobData(jobText);
 
   // Generate format report

--- a/src/lib/optimization-review/service.ts
+++ b/src/lib/optimization-review/service.ts
@@ -1,6 +1,7 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { scoreOptimization } from "@/lib/ats/integration";
+import { preferJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import {
   buildATSPreview,
   buildFinalResumeMetadata,
@@ -197,7 +198,7 @@ export async function applyOptimizationReviewRun({
 
   const { data: jdRow, error: jdError } = await supabase
     .from("job_descriptions")
-    .select("raw_text, clean_text, title")
+    .select("raw_text, clean_text, title, parsed_data")
     .eq("id", reviewRun.jd_id)
     .maybeSingle();
   if (jdError || !jdRow) {
@@ -206,14 +207,18 @@ export async function applyOptimizationReviewRun({
 
   let finalResume = buildResumeFromApprovedGroups(reviewRun.original_resume_json, approvedGroups);
 
+  const jobDescriptionText = preferJobDescriptionText(jdRow);
+  const parsedData = (jdRow.parsed_data as Record<string, unknown> | null) || undefined;
+
   let finalATSPreview: ReviewATSPreview | null = null;
   let finalATSResult: ATSScoreOutput | null = null;
   try {
     const atsResult = await scoreOptimization({
       resumeOriginalText: resumeRow.raw_text || "",
       resumeOptimizedJson: finalResume,
-      jobDescriptionText: jdRow.clean_text || jdRow.raw_text || "",
+      jobDescriptionText,
       jobTitle: jdRow.title || "Position",
+      jobExtractedJson: parsedData,
     });
     finalATSResult = atsResult;
 
@@ -251,6 +256,7 @@ export async function applyOptimizationReviewRun({
       ats_subscores_original: finalATSResult?.subscores_original ?? null,
       ats_suggestions: finalATSPreview?.suggestions ?? reviewRun.ats_preview_json?.suggestions ?? null,
       ats_confidence: finalATSPreview?.confidence ?? reviewRun.ats_preview_json?.confidence ?? null,
+      jd_text: jobDescriptionText,
     })
     .select("id")
     .maybeSingle();

--- a/src/lib/scraper/jobExtractor.ts
+++ b/src/lib/scraper/jobExtractor.ts
@@ -231,6 +231,14 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
   const seniority = sanitizeText((html.match(/Seniority level<[^>]*>\s*<span[^>]*>([\s\S]*?)<\//i)?.[1])) || null;
   const compensation = sanitizeText((html.match(/Pay|Salary|Compensation[\s\S]{0,40}<[^>]*>([\s\S]*?)<\//i)?.[1])) || null;
 
+  const mergedRequirements =
+    requirements && requirements.length > 0
+      ? requirements
+      : [...(qualifications || []), ...(responsibilities || [])].filter(
+          (item, index, arr) =>
+            arr.findIndex((other) => other.toLowerCase() === item.toLowerCase()) === index,
+        );
+
   const extracted: ExtractedJobData = {
     source_url: url,
     source_domain: domain,
@@ -243,7 +251,7 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
     seniority,
     compensation,
     about_this_job: sanitizeText(about_this_job),
-    requirements: requirements || null,
+    requirements: mergedRequirements.length > 0 ? mergedRequirements : null,
     responsibilities: responsibilities || null,
     qualifications: qualifications || null,
     nice_to_have: null,
@@ -255,7 +263,7 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
       job_title: job_title,
       contact_person: null,
       about_this_job: about_this_job ? "meta og:description or About section" : null,
-      requirements: requirements ? "h2 Requirements/Skills section" : null,
+      requirements: mergedRequirements.length > 0 ? "h2 Requirements/Skills section or merged qualifications" : null,
       responsibilities: responsibilities ? "h2 Responsibilities section" : null,
       qualifications: qualifications ? "h2 Qualifications section" : null,
       nice_to_have: null,
@@ -288,6 +296,14 @@ export async function extractGeneric(html: string, url: string): Promise<Extract
   const benefits = extractListAfterHeading(html, /<h2[^>]*>(Benefits|Perks)<\/h2>/i);
   const location = sanitizeText((html.match(/Location[:\s]<[^>]*>([\s\S]*?)<\//i)?.[1])) || null;
 
+  const mergedRequirements =
+    requirements && requirements.length > 0
+      ? requirements
+      : [...(qualifications || []), ...(responsibilities || [])].filter(
+          (item, index, arr) =>
+            arr.findIndex((other) => other.toLowerCase() === item.toLowerCase()) === index,
+        );
+
   return {
     source_url: url,
     source_domain: domain,
@@ -300,7 +316,7 @@ export async function extractGeneric(html: string, url: string): Promise<Extract
     seniority: null,
     compensation: null,
     about_this_job: sanitizeText(about_this_job),
-    requirements: requirements || null,
+    requirements: mergedRequirements.length > 0 ? mergedRequirements : null,
     responsibilities: responsibilities || null,
     qualifications: qualifications || null,
     nice_to_have: null,
@@ -312,7 +328,7 @@ export async function extractGeneric(html: string, url: string): Promise<Extract
       job_title,
       contact_person: null,
       about_this_job: about_this_job ? "About/Overview section" : null,
-      requirements: requirements ? "Requirements/Skills section" : null,
+      requirements: mergedRequirements.length > 0 ? "Requirements/Skills section or merged qualifications" : null,
       responsibilities: responsibilities ? "Responsibilities section" : null,
       qualifications: qualifications ? "Qualifications section" : null,
       nice_to_have: null,

--- a/tests/unit/ats-prepare-input.test.ts
+++ b/tests/unit/ats-prepare-input.test.ts
@@ -1,5 +1,39 @@
 import { buildJobDataFromExtractedJson, normalizeParsedJobData } from '@/lib/ats/job-data-resolver';
 import { scoreResume } from '@/lib/ats/index';
+import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
+
+function mockExtractedJobData(
+  overrides: Partial<ExtractedJobData> = {},
+): ExtractedJobData {
+  return {
+    source_url: 'https://example.com/jobs/1',
+    source_domain: 'example.com',
+    scraped_at: '2026-06-19T00:00:00.000Z',
+    company_name: 'Example Corp',
+    job_title: 'Business Development Manager',
+    contact_person: null,
+    location: 'Tel Aviv',
+    employment_type: null,
+    seniority: null,
+    compensation: null,
+    about_this_job: null,
+    requirements: null,
+    responsibilities: [],
+    qualifications: [],
+    nice_to_have: null,
+    benefits: null,
+    application_instructions: null,
+    posting_id: null,
+    provenance: {},
+    summary_for_ui: {
+      company_name: 'Example Corp',
+      job_title: 'Business Development Manager',
+      contact_person: null,
+      location: 'Tel Aviv',
+    },
+    ...overrides,
+  };
+}
 
 describe('ats job-data resolver', () => {
   const cleanText = `
@@ -12,9 +46,7 @@ describe('ats job-data resolver', () => {
     - Strong negotiation and pipeline management skills
   `;
 
-  const parsedData = {
-    job_title: 'Business Development Manager',
-    company_name: 'Example Corp',
+  const parsedData = mockExtractedJobData({
     requirements: null,
     qualifications: [
       '5+ years B2B sales experience',
@@ -26,8 +58,7 @@ describe('ats job-data resolver', () => {
       'Partner with marketing on lead generation campaigns',
     ],
     nice_to_have: ['Experience selling SaaS products'],
-    location: 'Tel Aviv',
-  };
+  });
 
   it('fills must_have from qualifications when requirements is null', () => {
     const jobData = buildJobDataFromExtractedJson(parsedData, cleanText);
@@ -39,10 +70,10 @@ describe('ats job-data resolver', () => {
   });
 
   it('keeps explicit requirements without double-counting qualifications', () => {
-    const withRequirements = {
-      ...parsedData,
+    const withRequirements = mockExtractedJobData({
       requirements: ['Existing requirement only'],
-    };
+      qualifications: ['Should not appear in must_have'],
+    });
 
     const jobData = buildJobDataFromExtractedJson(withRequirements, cleanText);
     expect(jobData.must_have).toEqual(['Existing requirement only']);
@@ -50,8 +81,8 @@ describe('ats job-data resolver', () => {
 
   it('normalizes parsed_data at scrape time', () => {
     const normalized = normalizeParsedJobData(parsedData);
-    expect(Array.isArray(normalized.requirements)).toBe(true);
-    expect((normalized.requirements as string[]).length).toBeGreaterThan(0);
+    expect(normalized.requirements).not.toBeNull();
+    expect(normalized.requirements?.length).toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/ats-prepare-input.test.ts
+++ b/tests/unit/ats-prepare-input.test.ts
@@ -1,0 +1,99 @@
+import { buildJobDataFromExtractedJson, normalizeParsedJobData } from '@/lib/ats/job-data-resolver';
+import { scoreResume } from '@/lib/ats/index';
+
+describe('ats job-data resolver', () => {
+  const cleanText = `
+    Business Development Manager - Tel Aviv
+    Requirements:
+    - 5+ years B2B sales experience
+    - CRM proficiency (Salesforce, HubSpot)
+    - Fluent English and Hebrew
+    - SaaS or technology industry background
+    - Strong negotiation and pipeline management skills
+  `;
+
+  const parsedData = {
+    job_title: 'Business Development Manager',
+    company_name: 'Example Corp',
+    requirements: null,
+    qualifications: [
+      '5+ years B2B sales experience',
+      'CRM proficiency (Salesforce, HubSpot)',
+      'Fluent English and Hebrew',
+    ],
+    responsibilities: [
+      'Own enterprise pipeline and quarterly revenue targets',
+      'Partner with marketing on lead generation campaigns',
+    ],
+    nice_to_have: ['Experience selling SaaS products'],
+    location: 'Tel Aviv',
+  };
+
+  it('fills must_have from qualifications when requirements is null', () => {
+    const jobData = buildJobDataFromExtractedJson(parsedData, cleanText);
+
+    expect(jobData.must_have.length).toBeGreaterThan(0);
+    expect(jobData.must_have).toEqual(
+      expect.arrayContaining(['5+ years B2B sales experience', 'CRM proficiency (Salesforce, HubSpot)']),
+    );
+  });
+
+  it('keeps explicit requirements without double-counting qualifications', () => {
+    const withRequirements = {
+      ...parsedData,
+      requirements: ['Existing requirement only'],
+    };
+
+    const jobData = buildJobDataFromExtractedJson(withRequirements, cleanText);
+    expect(jobData.must_have).toEqual(['Existing requirement only']);
+  });
+
+  it('normalizes parsed_data at scrape time', () => {
+    const normalized = normalizeParsedJobData(parsedData);
+    expect(Array.isArray(normalized.requirements)).toBe(true);
+    expect((normalized.requirements as string[]).length).toBeGreaterThan(0);
+  });
+});
+
+describe('scoreResume with sparse parsed_data', () => {
+  it('produces keyword_exact > 0 when qualifications exist but requirements is null', async () => {
+    const resumeText = `
+      Business Development Manager with 6 years of B2B SaaS sales.
+      Skills: Salesforce, HubSpot, pipeline management, negotiation, enterprise sales.
+      Fluent in English and Hebrew. Closed $2M ARR across Tel Aviv accounts.
+    `;
+
+    const optimizedText = resumeText;
+
+    const result = await scoreResume({
+      resume_original_text: resumeText,
+      resume_optimized_text: optimizedText,
+      job_clean_text: `
+        Business Development Manager Tel Aviv
+        Qualifications: B2B sales, Salesforce, HubSpot, SaaS, negotiation, pipeline management
+      `,
+      job_extracted_json: buildJobDataFromExtractedJson(
+        {
+          job_title: 'Business Development Manager',
+          requirements: null,
+          qualifications: ['B2B sales', 'Salesforce', 'HubSpot', 'SaaS', 'negotiation'],
+          responsibilities: ['Pipeline management', 'Enterprise revenue targets'],
+        },
+        'Business Development Manager Tel Aviv',
+      ),
+      format_report: {
+        has_tables: false,
+        has_images: false,
+        has_headers_footers: false,
+        has_nonstandard_fonts: false,
+        has_odd_glyphs: false,
+        has_multi_column: false,
+        format_safety_score: 85,
+        issues: [],
+      },
+    });
+
+    expect(result.subscores.keyword_exact).toBeGreaterThan(0);
+    expect(result.ats_score_optimized).toBeGreaterThan(35);
+  });
+});


### PR DESCRIPTION
## Summary
- When `parsed_data.requirements` is null, ATS scoring now falls back to `qualifications` + `responsibilities`, then re-extracts from JD text instead of leaving `must_have` empty.
- iOS `/api/optimize` loads `parsed_data` and prefers longer `clean_text` over truncated `raw_text` (~220-char LinkedIn snippets).
- JD scrape normalizes `requirements` at ingest; review apply persists `optimizations.jd_text`.

## Test plan
- [x] `npm test -- tests/unit/ats-prepare-input.test.ts`
- [x] `npm run lint`
- [ ] Re-optimize BDM Tel Aviv job on iOS after deploy — expect score materially above 35
- [ ] Deploy to Vercel `new-resume-builder-ai` (required for iOS to pick up server-side fix)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved ATS score resilience when job descriptions lack complete requirement data; system now intelligently falls back to qualifications and responsibilities information.
  * Enhanced job data extraction and normalization to handle missing or incomplete fields more gracefully.

* **Documentation**
  * Added troubleshooting guide explaining ATS score behavior and remediation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->