### PR TITLE
fix(scrape): use LinkedIn guest endpoint so jobs scrape real content from Vercel

### DIFF
--- a/src/app/api/debug/scrape-check/route.ts
+++ b/src/app/api/debug/scrape-check/route.ts
@@ -1,0 +1,54 @@
+/**
+ * GET /api/debug/scrape-check?url=<job url>&token=<secret>
+ *
+ * Preview-only diagnostic for the LinkedIn scrape fix. A real LinkedIn authwall
+ * only reproduces from a datacenter (Vercel) egress IP, so this lets us verify
+ * the deployed function actually pulls full job content.
+ *
+ * Hard-gated: returns 404 unless running on a Vercel PREVIEW deployment AND the
+ * ?token matches SCRAPE_CHECK_TOKEN. It can never run in production. Remove this
+ * route (or leave it permanently 404-gated) after verification.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { extractJob, isThinExtraction, ThinJobExtractionError } from "@/lib/scraper/jobExtractor";
+
+export const runtime = "nodejs";
+
+export async function GET(request: NextRequest) {
+  const isPreview = process.env.VERCEL_ENV === "preview";
+  const token = request.nextUrl.searchParams.get("token");
+  const expected = process.env.SCRAPE_CHECK_TOKEN;
+
+  if (!isPreview || !expected || token !== expected) {
+    return new NextResponse("Not found", { status: 404 });
+  }
+
+  const url = request.nextUrl.searchParams.get("url");
+  if (!url) {
+    return NextResponse.json({ error: "Missing ?url" }, { status: 400 });
+  }
+
+  try {
+    const data = await extractJob(url);
+    return NextResponse.json({
+      ok: true,
+      finalUrl: data.source_url,
+      titleLen: (data.job_title || "").length,
+      companyLen: (data.company_name || "").length,
+      aboutLen: (data.about_this_job || "").length,
+      requirementsCount: data.requirements?.length ?? 0,
+      qualificationsCount: data.qualifications?.length ?? 0,
+      responsibilitiesCount: data.responsibilities?.length ?? 0,
+      isThin: isThinExtraction(data),
+    });
+  } catch (err) {
+    if (err instanceof ThinJobExtractionError) {
+      return NextResponse.json({ ok: false, thin: true, url: err.url });
+    }
+    return NextResponse.json(
+      { ok: false, error: (err as Error)?.message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
-import { extractJob } from "@/lib/scraper/jobExtractor";
+import { extractJob, ThinJobExtractionError } from "@/lib/scraper/jobExtractor";
 import { scrapeJobDescription } from "@/lib/job-scraper";
 import { normalizeParsedJobData } from "@/lib/ats/job-data-resolver";
 import { isSupportedResumeFile } from "@/lib/utils/file-validation";
@@ -87,18 +87,44 @@ export async function POST(req: NextRequest) {
         if (extracted.responsibilities?.length) parts.push(`Responsibilities: ${extracted.responsibilities.join("; ")}`);
         if (extracted.qualifications?.length) parts.push(`Qualifications: ${extracted.qualifications.join("; ")}`);
         jobDescriptionText = parts.join("\n");
-      } catch {
-        // Fallback to simple scraper if structured extraction fails
-        try {
-          const text = await scrapeJobDescription(jobDescriptionUrl);
-          jobDescriptionText = text;
-          extractedData = { fallback: true, source_url: jobDescriptionUrl };
-          sourceUrl = jobDescriptionUrl;
-        } catch {
-          // Final fallback: proceed with URL only so optimization can continue
-          jobDescriptionText = `Job Posting URL: ${jobDescriptionUrl}`;
-          extractedData = { fallback: true, source_url: jobDescriptionUrl };
-          sourceUrl = jobDescriptionUrl;
+      } catch (err) {
+        const isThin =
+          err instanceof ThinJobExtractionError ||
+          (err as { code?: string })?.code === "THIN_JOB_EXTRACTION";
+
+        if (isThin) {
+          // The URL was fetched but came back effectively empty (e.g. LinkedIn
+          // authwall). Prefer pasted text if the user provided it; otherwise
+          // hard-fail with an actionable message instead of scoring garbage.
+          if (jobDescription && jobDescription.trim()) {
+            jobDescriptionText = jobDescription;
+            extractedData = { fallback: true, source_url: jobDescriptionUrl };
+            sourceUrl = jobDescriptionUrl;
+          } else {
+            return NextResponse.json(
+              {
+                error:
+                  "We couldn't read that job link. Paste the job description text instead.",
+                code: "JOB_URL_UNREADABLE",
+                field: "jobDescription",
+                sourceUrl: jobDescriptionUrl,
+              },
+              { status: 422 }
+            );
+          }
+        } else {
+          // Transient/parse failure (network, timeout): fall back to the simple
+          // scraper, then to a URL-only stub so optimization can still proceed.
+          try {
+            const text = await scrapeJobDescription(jobDescriptionUrl);
+            jobDescriptionText = text;
+            extractedData = { fallback: true, source_url: jobDescriptionUrl };
+            sourceUrl = jobDescriptionUrl;
+          } catch {
+            jobDescriptionText = `Job Posting URL: ${jobDescriptionUrl}`;
+            extractedData = { fallback: true, source_url: jobDescriptionUrl };
+            sourceUrl = jobDescriptionUrl;
+          }
         }
       }
     } else if (jobDescription) {

--- a/src/app/api/v1/applications/route.ts
+++ b/src/app/api/v1/applications/route.ts
@@ -66,15 +66,23 @@ export async function POST(req: NextRequest) {
     let sourceUrl: string | null = (body?.jobUrl as string | undefined) || null;
     if (url) {
       console.log('🔍 Extracting job from URL:', url);
-      extracted = await extractJob(url);
-      console.log('📊 Extracted data:', {
-        company: extracted.company_name,
-        title: extracted.job_title,
-        sourceUrl: extracted.source_url
-      });
-      mappedJobTitle = extracted.job_title || mappedJobTitle;
-      mappedCompany = extracted.company_name || mappedCompany;
-      sourceUrl = extracted.source_url;
+      try {
+        extracted = await extractJob(url);
+        console.log('📊 Extracted data:', {
+          company: extracted.company_name,
+          title: extracted.job_title,
+          sourceUrl: extracted.source_url
+        });
+        mappedJobTitle = extracted.job_title || mappedJobTitle;
+        mappedCompany = extracted.company_name || mappedCompany;
+        sourceUrl = extracted.source_url;
+      } catch (err) {
+        // A thin/unreadable scrape (e.g. LinkedIn authwall) must not 500 this
+        // endpoint — it only records title/company. Keep the body-supplied
+        // values and the original URL.
+        console.warn('⚠️ Job extraction failed, using provided title/company:', (err as Error)?.message);
+        sourceUrl = url;
+      }
     }
 
     // Create DB row first to get application id (avoid new columns for backward compatibility)

--- a/src/lib/scraper/jobExtractor.ts
+++ b/src/lib/scraper/jobExtractor.ts
@@ -79,6 +79,77 @@ function extractMetaContent(html: string, name: string): string | null {
   return m ? sanitizeText(m[1]) : null;
 }
 
+// A scrape is "thin" when the job body is shorter than this AND no structured
+// lists were found. LinkedIn's datacenter authwall snippet is ~222 chars with no
+// lists; a real posting body runs into the thousands. 300 sits safely between.
+const THIN_BODY_MIN_CHARS = 300;
+
+const CHROME_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/**
+ * Thrown when a job posting was fetched successfully but the extracted content
+ * is effectively empty (e.g. LinkedIn served a datacenter authwall instead of
+ * the real posting). Callers should surface an actionable "paste the text"
+ * message rather than scoring against the near-empty content.
+ */
+export class ThinJobExtractionError extends Error {
+  readonly code = "THIN_JOB_EXTRACTION" as const;
+  constructor(public readonly url: string) {
+    super("Job posting extraction returned insufficient content");
+    this.name = "ThinJobExtractionError";
+  }
+}
+
+/**
+ * True when extraction produced no usable job content — short body and no
+ * requirements/qualifications/responsibilities lists.
+ */
+export function isThinExtraction(data: ExtractedJobData): boolean {
+  const bodyLen = (data.about_this_job || "").length;
+  const hasLists =
+    (data.requirements?.length ?? 0) > 0 ||
+    (data.qualifications?.length ?? 0) > 0 ||
+    (data.responsibilities?.length ?? 0) > 0;
+  return bodyLen < THIN_BODY_MIN_CHARS && !hasLists;
+}
+
+/**
+ * Derive a LinkedIn numeric job id from any of the URL shapes LinkedIn uses.
+ * Priority: currentJobId query param → /jobs/view/{id} → trailing long integer.
+ */
+export function extractLinkedInJobId(url: URL): string | null {
+  const currentJobId = url.searchParams.get("currentJobId");
+  if (currentJobId && /^\d+$/.test(currentJobId)) return currentJobId;
+
+  const viewMatch = url.pathname.match(/\/jobs\/view\/(\d+)/);
+  if (viewMatch) return viewMatch[1];
+
+  const trailingMatch = url.pathname.match(/(\d{6,})\/?$/);
+  if (trailingMatch) return trailingMatch[1];
+
+  return null;
+}
+
+/**
+ * Single outbound-fetch seam for job scraping. A future residential-proxy
+ * service (PROXY_URL / SCRAPER_API_KEY) would slot in here. The LinkedIn guest
+ * endpoint works without a User-Agent, so we only send one when asked.
+ */
+async function fetchHtml(targetUrl: string, opts: { userAgent: boolean }): Promise<string> {
+  const res = await fetch(targetUrl, {
+    method: "GET",
+    headers: opts.userAgent ? { "User-Agent": CHROME_USER_AGENT } : {},
+    signal: AbortSignal.timeout(12_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch job posting: ${res.status} ${res.statusText}`);
+  }
+
+  return res.text();
+}
+
 export async function extractFromLinkedIn(html: string, url: string): Promise<ExtractedJobData> {
   const domain = new URL(url).hostname;
   // Try to extract from known containers
@@ -141,6 +212,23 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
     }
   }
 
+  // Guest-fragment fallback: the /jobs-guest/ API response has no og:title or
+  // <title> tag — title/company live in the topcard markup. Only fires when the
+  // meta/JSON-LD paths above produced nothing, so the full-page parsing stays
+  // primary.
+  if (!job_title) {
+    job_title =
+      sanitizeText(html.match(/class=["'][^"']*\btop-card-layout__title\b[^"']*["'][^>]*>([\s\S]*?)<\//i)?.[1]) ||
+      sanitizeText(html.match(/class=["'][^"']*\btopcard__title\b[^"']*["'][^>]*>([\s\S]*?)<\//i)?.[1]) ||
+      job_title;
+  }
+  if (!company_name) {
+    company_name =
+      sanitizeText(html.match(/class=["'][^"']*\btopcard__org-name-link\b[^"']*["'][^>]*>([\s\S]*?)<\//i)?.[1]) ||
+      sanitizeText(html.match(/class=["'][^"']*\btop-card-layout__second-subline\b[^"']*["'][^>]*>[\s\S]*?<a[^>]*>([\s\S]*?)<\//i)?.[1]) ||
+      company_name;
+  }
+
   // Location from meta or inline text
   const location = extractMetaContent(html, "job:location") ||
     sanitizeText((html.match(/"job-location"[^>]*>([\s\S]*?)<\//i)?.[1])) ||
@@ -191,6 +279,17 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
     }
   }
 
+  // Final fallback: the LinkedIn guest fragment holds the full posting inside
+  // show-more-less-html with <strong>/<ul> markup and no <p> tags, so the
+  // pattern-based extraction above can miss it. Use the whole sanitized body so
+  // the scorer always has the real JD text (and the thin gate doesn't trip).
+  if ((!about_this_job || about_this_job.length < 50) && fullDescription) {
+    const fullBody = sanitizeText(fullDescription);
+    if (fullBody && fullBody.length > (about_this_job?.length ?? 0)) {
+      about_this_job = fullBody;
+    }
+  }
+
   // Extract Responsibilities
   let responsibilities: string[] | null = null;
   const respMatch = fullDescription.match(/Responsibilities[\s\S]*?<ul[^>]*>([\s\S]*?)<\/ul>/i);
@@ -202,7 +301,7 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
 
   // Fallback: look for responsibility-related headings
   if (!responsibilities || responsibilities.length === 0) {
-    responsibilities = extractListAfterHeading(fullDescription || html, /<strong[^>]*>(What you['']ll do|Responsibilities|Your responsibilities|Key responsibilities)<\/strong>/i) ||
+    responsibilities = extractListAfterHeading(fullDescription || html, /<strong[^>]*>\s*(What you['']ll do|Responsibilities|Your responsibilities|Key responsibilities)/i) ||
                       extractListAfterHeading(fullDescription || html, /<h2[^>]*>(What you['']ll do|Responsibilities)<\/h2>/i);
   }
 
@@ -217,12 +316,12 @@ export async function extractFromLinkedIn(html: string, url: string): Promise<Ex
 
   // Fallback: look for requirement-related headings
   if (!requirements || requirements.length === 0) {
-    requirements = extractListAfterHeading(fullDescription || html, /<strong[^>]*>(Requirements|What we need|What you need|You have|Must have)<\/strong>/i) ||
+    requirements = extractListAfterHeading(fullDescription || html, /<strong[^>]*>\s*(Requirements|What we need|What you need|You have|Must have)/i) ||
                   extractListAfterHeading(fullDescription || html, /<h2[^>]*>(Requirements|Skills|You have)<\/h2>/i);
   }
 
   // Extract Qualifications (separate from requirements)
-  const qualifications = extractListAfterHeading(fullDescription || html, /<strong[^>]*>(Qualifications|What you bring|Basic Qualifications|Your qualifications)<\/strong>/i) ||
+  const qualifications = extractListAfterHeading(fullDescription || html, /<strong[^>]*>\s*(Qualifications|What you bring|Basic Qualifications|Your qualifications)/i) ||
                         extractListAfterHeading(fullDescription || html, /<h2[^>]*>(Qualifications|What you bring|Basic Qualifications)<\/h2>/i);
   const benefits = extractListAfterHeading(html, /<h2[^>]*>(Benefits|Perks)<\/h2>/i);
 
@@ -346,38 +445,45 @@ export async function extractGeneric(html: string, url: string): Promise<Extract
 }
 
 export async function extractJob(url: string): Promise<ExtractedJobData> {
-  // Handle LinkedIn URLs with currentJobId parameter
-  let finalUrl = url;
   const parsedUrl = new URL(url);
   const host = parsedUrl.hostname.toLowerCase();
+  const isLinkedIn = host.includes('linkedin.com');
 
-  if (host.includes('linkedin.com')) {
-    const currentJobId = parsedUrl.searchParams.get('currentJobId');
-    if (currentJobId) {
-      // Convert collection URL to direct job URL
-      finalUrl = `https://www.linkedin.com/jobs/view/${currentJobId}`;
-      console.log(`Converted LinkedIn URL to direct job URL: ${finalUrl}`);
+  let html: string;
+  let finalUrl = url;
+  let extracted: ExtractedJobData;
+
+  if (isLinkedIn) {
+    const jobId = extractLinkedInJobId(parsedUrl);
+    if (jobId) {
+      // The public guest endpoint returns the full posting body and works from
+      // datacenter IPs (no auth), unlike /jobs/view which LinkedIn degrades to
+      // an authwall for cloud egress. Try it first.
+      const guestUrl = `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/${jobId}`;
+      try {
+        html = await fetchHtml(guestUrl, { userAgent: false });
+        finalUrl = guestUrl;
+      } catch {
+        // Guest endpoint failed (e.g. 429) — fall back to the public view page.
+        finalUrl = `https://www.linkedin.com/jobs/view/${jobId}`;
+        html = await fetchHtml(finalUrl, { userAgent: true });
+      }
+    } else {
+      html = await fetchHtml(url, { userAgent: true });
     }
+    extracted = await extractFromLinkedIn(html, finalUrl);
+  } else {
+    html = await fetchHtml(url, { userAgent: true });
+    extracted = await extractGeneric(html, finalUrl);
   }
 
-  const res = await fetch(finalUrl, {
-    method: 'GET',
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-    },
-    signal: AbortSignal.timeout(12_000),
-  });
-
-  if (!res.ok) {
-    throw new Error(`Failed to fetch job posting: ${res.status} ${res.statusText}`);
+  // Guard against scoring against an empty/authwall scrape. Callers translate
+  // this into an actionable "paste the description" message.
+  if (isThinExtraction(extracted)) {
+    throw new ThinJobExtractionError(finalUrl);
   }
 
-  const html = await res.text();
-
-  if (host.includes('linkedin.com')) {
-    return extractFromLinkedIn(html, finalUrl);
-  }
-  return extractGeneric(html, finalUrl);
+  return extracted;
 }
 
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -54,3 +54,17 @@ Always wrap the call in try/catch returning a JSON 400 so a bad PDF can never su
 **Two reproduction techniques (a plain `next start` is NOT enough — local Node hides these):**
 - ESM/require trap: `NODE_OPTIONS='--no-experimental-require-module' npm run start` makes local Node reject `require()` of ESM like Vercel's does.
 - DOM-globals trap: in a node script, `delete globalThis.DOMMatrix; delete globalThis.Path2D; delete globalThis.ImageData;` before parsing, to simulate Vercel's environment. unpdf passes this; raw pdfjs's failing path does not.
+
+---
+
+## LinkedIn serves a degraded authwall to datacenter IPs — scrape the guest API, never /jobs/view
+
+**Symptom:** URL-submitted LinkedIn jobs scored very low (~21/100) in production but looked fine when tested locally. The stored `job_descriptions` row had `clean_text`/`raw_text` of exactly ~222 chars and every `parsed_data` field null.
+
+**Root cause:** `extractJob` fetched `https://www.linkedin.com/jobs/view/{id}`. From Vercel's serverless egress IP, LinkedIn returns a degraded authwall/`session_redirect` page that contains only the `og:description` meta tag (~222 chars) and NO `show-more-less-html` job body. `extractFromLinkedIn` parsed the meta snippet into `about_this_job` and returned a valid object **without throwing**, so the catch-fallbacks never fired and the thin data flowed straight to scoring. A residential IP (local dev / curl) gets the full page, so this is invisible locally — same class of false-green as the unpdf/DOMMatrix trap above.
+
+**Fix:** Use LinkedIn's public guest endpoint `https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/{id}` — it returns the full posting body, works from datacenter IPs, and needs no User-Agent. The guest fragment differs from the full page: no `og:title`/`<title>` (title/company come from `topcard__title` / `topcard__org-name-link`), no `<p>` tags in the body (recover the whole `show-more-less-html__markup` as the body), and `<strong>Qualifications<br><br></strong>` headings (the `<br>` breaks any regex requiring the keyword immediately before `</strong>` — match `<strong[^>]*>\s*(Keyword)` instead). Ref: PR fix/linkedin-guest-scrape.
+
+**Never let a scrape silently produce a score.** Added `isThinExtraction` + `ThinJobExtractionError` thrown centrally in `extractJob`; `/api/upload-resume` now prefers pasted text and otherwise returns `422 JOB_URL_UNREADABLE`. Optimizing against an empty JD is worse than telling the user to paste it.
+
+**Reproduction caveat:** a real authwall only reproduces from a datacenter IP. Local curl/dev gets full content. Verify on a Vercel preview via the `?token=`-gated `/api/debug/scrape-check` route, not locally.

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -2,15 +2,15 @@
 
 Project: ResumeBuilder AI (Web)
 Status: Active
-Current Phase: ATS scoring pipeline error sweep (production score-capping bugs); PDF parse/render-preview rollout parked
-Active Story: LinkedIn job scrape returns thin/meta-only content in production (Vercel serverless IP likely flagged by LinkedIn anti-bot) — root cause of low scores on real test jobs; parked per founder decision 2026-06-19, no new scraping-proxy dependency added without explicit approval
-Last Completed Story: Wired job_extracted_json (parsed_data) into PUT /api/v1/optimizations/[id] save-path scoreOptimization() call (commit 85505a3, 2026-06-19) — closes the gap where manual edits/re-scores bypassed PR #76's structured resolver
-Next Recommended Story: If LinkedIn scrape-blocking needs fixing later — either evaluate a residential-IP scraping proxy (new paid dependency, needs approval) or add a thin-scrape detector that prompts the user to paste JD text manually instead of silently scoring against a truncated og:description snippet
+Current Phase: ATS scoring pipeline error sweep — LinkedIn scrape-blocking fix implemented, awaiting production verification on Vercel preview
+Active Story: Verify the LinkedIn guest-endpoint fix from a real Vercel datacenter IP (branch fix/linkedin-guest-scrape) — set SCRAPE_CHECK_TOKEN on the preview, hit /api/debug/scrape-check, confirm aboutLen>1000 & isThin:false; then re-optimize a fresh LinkedIn job on iOS and confirm the score lifts above ~21
+Last Completed Story: Implemented LinkedIn guest-API scrape fix + thinness gate (branch fix/linkedin-guest-scrape, pushed 2026-06-20) — root-cause fix for the score-capping bug
+Next Recommended Story: After preview verification passes, merge fix/linkedin-guest-scrape and remove (or keep 404-gated) the debug route; only revisit a residential proxy if LinkedIn 429s the Vercel IP at scale (fetchHtml() seam is ready)
 Estimated Completion: Web is live; launch-support items above remain
-Blockers: LinkedIn appears to serve degraded/meta-only HTML to Vercel's serverless egress IPs — confirmed by diffing a direct curl (full 2,950-char description, all sections present) against the production-scraped row (222 chars, every parsed_data field null) for the same job URL. Not fixable in the resolver/scorer layer; needs a scrape-layer fix.
-Risks: PDF/DOCX upload smoke test still not run (#1 pre-approval risk per tasks/MEMORY.md 2026-06-08); user_credits table vs profiles.credit_balance reconciliation must be resolved at Gate A
-Last Validation: PR #76 merged 2026-06-19 08:40 UTC + save-path fix (85505a3) 2026-06-19. CI/lint/tests all pass. Cloudflare Workers Build "match1resume1to1job" check fails on every PR (#72-76) — confirmed stale/orphaned integration (no wrangler.toml in repo), not a regression.
-Last Updated: 2026-06-19
+Blockers: —
+Risks: Guest-endpoint behavior on Vercel's IP is verified-by-design but not yet confirmed from a real datacenter IP (only reproducible post-deploy); PDF/DOCX upload smoke test still not run (#1 pre-approval risk per tasks/MEMORY.md 2026-06-08); user_credits table vs profiles.credit_balance reconciliation must be resolved at Gate A
+Last Validation: fix/linkedin-guest-scrape — 8 new unit tests pass, relevant suites 24/24, lint 0 errors (2026-06-20). The 16 other failing jest suites are pre-existing (Playwright e2e under jest + server-dependent contract tests), confirmed by stash-and-rerun on baseline.
+Last Updated: 2026-06-20
 Latest QA Report: tasks/2026-06-08-smoke-test-upload-backend.md (plan; execution pending)
 
 <!--

--- a/tests/fixtures/linkedin/authwall-fragment.html
+++ b/tests/fixtures/linkedin/authwall-fragment.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<!--
+  Fixture: the degraded authwall/session_redirect page LinkedIn serves to
+  datacenter (Vercel) egress IPs. Only meta tags are present; there is NO
+  show-more-less-html job body and no requirements/qualifications lists.
+  This reproduces the production thin-scrape that scored ~21/100.
+-->
+<html lang="en">
+<head>
+  <title>Sign Up | LinkedIn</title>
+  <meta property="og:title" content="Base44 hiring Partnership Manager - Base44 in Tel Aviv-Yafo, Tel Aviv District, Israel | LinkedIn" />
+  <meta property="og:description" content="Posted 9:13:27 AM. Job DescriptionAs a Partnership Manager at Base44, you&amp;#39;ll drive impactful affiliate marketing…See this and similar jobs on LinkedIn." />
+  <meta property="og:type" content="website" />
+</head>
+<body>
+  <main>
+    <h1>Join LinkedIn</h1>
+    <p>Sign in to view more job details and apply.</p>
+    <a href="https://www.linkedin.com/authwall">Sign in</a>
+  </main>
+</body>
+</html>

--- a/tests/fixtures/linkedin/guest-fragment.html
+++ b/tests/fixtures/linkedin/guest-fragment.html
@@ -1,0 +1,420 @@
+
+
+    
+<!---->    
+    
+
+    
+    <section class="top-card-layout container-lined overflow-hidden babybear:rounded-[0px]">
+        
+      
+
+      <div class="top-card-layout__card relative p-2 papabear:p-details-container-padding">
+            
+        
+      <a href="https://www.linkedin.com/company/base44?trk=public_jobs_topcard_logo" target="_self" data-tracking-control-name="public_jobs_topcard_logo" data-tracking-will-navigate>
+        
+          
+      <img class="artdeco-entity-image artdeco-entity-image--square-5
+          " data-delayed-url="https://media.licdn.com/dms/image/v2/D4D0BAQHQAUp4QBIXpQ/company-logo_100_100/B4DZqRzs4RHwAQ-/0/1763382841298/base44_logo?e=2147483647&amp;v=beta&amp;t=QnAYITMqR-EaRmzUAFrIKj-zw9MgF4l5mkHvE9vg5ek" data-ghost-classes="artdeco-entity-image--ghost" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/aajlclc14rr2scznz5qm2rj9u" alt="Base44">
+  
+        
+      </a>
+  
+      
+
+          <div class="top-card-layout__entity-info-container flex flex-wrap papabear:flex-nowrap">
+            <div class="top-card-layout__entity-info flex-grow flex-shrink-0 basis-0 babybear:flex-none babybear:w-full babybear:flex-none babybear:w-full">
+                  
+          <a href="https://il.linkedin.com/jobs/view/partnership-manager-base44-at-base44-4429904263?trk=public_jobs_topcard-title" data-tracking-control-name="public_jobs_topcard-title" class="topcard__link" data-tracking-will-navigate>
+            <h2 class="top-card-layout__title font-sans text-lg papabear:text-xl font-bold leading-open text-color-text mb-0 topcard__title">Partnership Manager - Base44</h2>
+          </a>
+      
+<!---->
+<!---->
+                <h4 class="top-card-layout__second-subline font-sans text-sm leading-open text-color-text-low-emphasis mt-0.5">
+                  
+        <div class="topcard__flavor-row">
+          <span class="topcard__flavor">
+              <a class="topcard__org-name-link topcard__flavor--black-link" data-tracking-control-name="public_jobs_topcard-org-name" data-tracking-will-navigate href="https://www.linkedin.com/company/base44?trk=public_jobs_topcard-org-name" rel="noopener" target="_blank">
+                Base44
+              </a>
+          </span>
+            <span class="topcard__flavor topcard__flavor--bullet">
+              Tel Aviv-Yafo, Tel Aviv District, Israel
+            </span>
+        </div>
+        <div class="topcard__flavor-row">
+          
+        <span class="posted-time-ago__text topcard__flavor--metadata">
+          
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      2 days ago
+  
+        </span>
+  
+          
+    
+    
+    
+
+        <span class="num-applicants__caption topcard__flavor--metadata topcard__flavor--bullet">
+          34 applicants
+        </span>
+  
+        </div>
+          
+    
+
+    
+      
+    
+
+    
+      <a href="https://www.linkedin.com/login?session_redirect=https%3A%2F%2Fwww%2Elinkedin%2Ecom%2Fsearch%2Fresults%2Fpeople%2F%3FfacetCurrentCompany%3D106589953&amp;emailAddress=&amp;fromSignIn=&amp;trk=public_jobs_see-who-was-hired_people-search-link_face-pile-cta" target="_self" data-tracking-control-name="full-link" data-tracking-will-navigate class="face-pile flex !no-underline see-who-was-hired">
+        
+      <div class="face-pile__images-container self-start flex-shrink-0 mr-1 leading-[1]">
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/9nfu1r6g05p0c1tvr2m81ol1h" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/2idbv5yww3ifd3ug4r2gn2d68" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/3q4jfy3r8bg0nr5oyuacmqoj8" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+      </div>
+        <div class="face-pile__text-container self-center">
+          <p class="face-pile__text font-sans text-sm
+              link-styled hover:underline">
+            See who Base44 has hired for this role
+          </p>
+<!---->        </div>
+          
+      </a>
+  
+  
+  
+  
+<!---->      
+                </h4>
+
+              <div class="top-card-layout__cta-container flex flex-wrap mt-0.5 papabear:mt-0 ml-[-12px]">
+                    
+          
+    
+    
+    
+
+      <button class="apply-button apply-button--default top-card-layout__cta mt-2 ml-1.5 h-auto babybear:flex-auto top-card-layout__cta--primary btn-md btn-primary" data-reference-id="miQpZ9d6TAGYxx2rqMwUcA==" data-tracking-id="jn3VqGeAQxmQYziA60bBFQ==" data-tracking-control-name="public_jobs_apply-link-onsite">
+        Apply
+      </button>
+  
+      
+
+                    
+            <a class="top-card-layout__cta mt-2 ml-1.5 h-auto babybear:flex-auto top-card-layout__cta--secondary btn-md btn-secondary" href="https://www.linkedin.com/login?emailAddress=&amp;fromSignIn=&amp;session_redirect=https%3A%2F%2Fil.linkedin.com%2Fjobs%2Fview%2Fpartnership-manager-base44-at-base44-4429904263&amp;trk=public_jobs" data-impression-id="public_jobs_topcard-save-job" data-tracking-control-name="public_jobs_topcard-save-job" data-tracking-will-navigate data-test-redirect-save-to-login>
+                Save
+            </a>
+      
+              </div>
+            </div>
+
+<!---->          </div>
+
+          
+
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+      <div class="ellipsis-menu absolute right-0 top-0 top-card-layout__ellipsis-menu mr-1 papabear:mt-0.5 papabear:mr-2">
+        
+
+    
+
+    <div class="collapsible-dropdown flex items-center relative hyphens-auto">
+          
+            <button class="ellipsis-menu__trigger
+                collapsible-dropdown__button btn-md btn-tertiary cursor-pointer
+                !py-[6px] !px-1 flex items-center rounded-[50%]
+                
+                " aria-expanded="false" aria-label="Open menu" data-tracking-control-name="public_jobs_ellipsis-menu-trigger" tabindex="0">
+              <icon class="ellipsis-menu__trigger-icon m-0 p-0 centered-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/671xosfpvk4c0kqtyl87hashi"></icon>
+            </button>
+          
+
+        <ul class="collapsible-dropdown__list hidden container-raised absolute w-auto overflow-y-auto flex-col items-stretch z-[9999] bottom-auto top-[100%]" role="menu" tabindex="-1">
+          
+              
+
+                <li class="ellipsis-menu__item border-t-1 border-solid border-color-border-low-emphasis first-of-type:border-none flex" role="presentation">
+                  
+
+    
+    
+
+    
+
+    
+
+    <a href="/uas/login?fromSignIn=true&amp;session_redirect=https%3A%2F%2Fil.linkedin.com%2Fjobs%2Fview%2Fpartnership-manager-base44-at-base44-4429904263&amp;trk=public_jobs_ellipsis-menu-semaphore-sign-in-redirect&amp;guestReportContentType=JOB&amp;_f=guest-reporting" data-tracking-control-name="public_jobs_ellipsis-menu-semaphore-sign-in-redirect" data-tracking-will-navigate data-item-type="semaphore" data-semaphore-content-type="JOB" data-semaphore-content-urn="urn:li:jobPosting:4429904263" data-semaphore-tracking-prefix="public_jobs_ellipsis-menu-semaphore" data-is-logged-in="false" data-modal="semaphore__toggle" class="semaphore__toggle visited:text-color-text-secondary ellipsis-menu__semaphore ellipsis-menu__item-button flex items-center w-full p-1 cursor-pointer font-sans text-sm font-bold link-styled focus:link-styled link:no-underline active:bg-color-background-container-tint focus:bg-color-background-container-tint hover:bg-color-background-container-tint outline-offset-[-2px]" role="menuitem">
+<!---->        
+                      <icon class="ellipsis-menu__item-icon text-color-text h-[24px] w-[24px] mr-1" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/iq0x9q37wj214o129ai1yjut">
+                      </icon>
+                      Report this job
+                    
+    </a>
+
+<!---->  
+                </li>
+<!---->          
+        </ul>
+
+<!---->    </div>
+  
+
+      </div>
+  
+
+<!---->      </div>
+    </section>
+  
+  
+
+    <div class="decorated-job-posting__details">
+<!---->
+      
+    
+    
+    
+    
+    
+
+    
+    <section class="core-section-container
+        my-3 description">
+<!---->
+<!---->
+<!---->
+      <div class="core-section-container__content break-words">
+        
+      
+    
+    
+
+<!---->  
+
+      <div class="description__text description__text--rich">
+        
+    
+    
+    
+
+    <section class="show-more-less-html" data-max-lines="5">
+        <div class="show-more-less-html__markup show-more-less-html__markup--clamp-after-5
+            relative overflow-hidden">
+          <strong>Job Description<br><br></strong>As a Partnership Manager at Base44, you'll drive impactful affiliate marketing strategies, build meaningful collaborations, and elevate our brand presence. You'll play a key role in identifying and fostering partnerships that align with our values and resonate with our target audience. In your day-to-day, you will:<br><br><ul><li>Develop and implement affiliate marketing strategies aligned with Base44's goals and objectives </li><li>Identify and establish partnerships with brands, organizations, and individuals whose values align with Base44's mission and audience </li><li>Build and maintain strong relationships with affiliates, serving as their main point of contact and providing ongoing support </li><li>Collaborate with affiliates to create engaging and impactful content and campaigns that highlight Base44's offerings </li><li>Monitor campaign performance, analyze data, and measure key performance indicators (KPIs) to evaluate success </li><li>Use data-driven insights to optimize affiliate strategies for maximum impact </li><li>Stay up-to-date on industry trends and emerging marketing techniques to maintain a competitive edge </li><li>Work closely with the marketing team to ensure alignment with broader marketing initiatives </li><li>Negotiate contracts and manage budgets for affiliate marketing, ensuring cost-effectiveness <br><br></li></ul><strong>Qualifications<br><br></strong><ul><li>1- 2 years of experience in digital marketing or a related role, with a focus on affiliate and collaborative marketing </li><li>Excellent written and spoken English communication skills </li><li>Strong knowledge of marketing platforms, affiliate trends, and industry best practices </li><li>Exceptional organizational and project management skills for seamless campaign execution </li><li>Creative mindset with the ability to ideate unique and high-impact marketing strategies </li><li>Self-motivated and results-oriented, with the ability to work independently and collaboratively </li><li>Strong communication and negotiation skills to build authentic and effective partnerships <br><br></li></ul><strong>Additional Information<br><br></strong>We're Base44, a newly acquired part of Wix, on a mission to change how software gets built. Our AI-powered platform empowers anyone to create custom software applications using natural language- no traditional coding required. Operating like a startup within Wix, we're fast, collaborative, and focused on turning complex problems into simple, powerful solutions.<br><br>We exist for creators, solo founders, startups, entrepreneurs, side hustlers, and everyone who wants to turn their ideas into reality. Whether you're launching a product, validating a concept, or exploring a hunch, Base44 helps you build it.<br><br>We're growing fast, the opportunity is huge, and with your help, our user-driven growth can become unstoppable.
+        </div>
+
+        
+
+    
+    
+    
+
+    <button class="show-more-less-html__button show-more-less-button
+        show-more-less-html__button--more
+        ml-0.5" data-tracking-control-name="public_jobs_show-more-html-btn" aria-label="Show more" aria-expanded="false">
+<!---->
+        
+            Show more
+          
+
+          <icon class="show-more-less-html__button-icon show-more-less-button-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/cyolgscd0imw2ldqppkrb84vo"></icon>
+    </button>
+  
+
+        
+
+    
+    
+    
+
+    <button class="show-more-less-html__button show-more-less-button
+        show-more-less-html__button--less
+        ml-0.5" data-tracking-control-name="public_jobs_show-less-html-btn" aria-label="Show less" aria-expanded="true">
+<!---->
+        
+            Show less
+          
+
+          <icon class="show-more-less-html__button-icon show-more-less-button-icon" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/4chtt12k98xwnba1nimld2oyg"></icon>
+    </button>
+  
+<!---->    </section>
+  
+      </div>
+
+      <ul class="description__job-criteria-list">
+        <li class="description__job-criteria-item">
+          <h3 class="description__job-criteria-subheader">
+            Seniority level
+          </h3>
+          <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Mid-Senior level
+          </span>
+        </li>
+        <li class="description__job-criteria-item">
+          <h3 class="description__job-criteria-subheader">
+            Employment type
+          </h3>
+          <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Full-time
+          </span>
+        </li>
+          <li class="description__job-criteria-item">
+            <h3 class="description__job-criteria-subheader">
+              Job function
+            </h3>
+            <span class="description__job-criteria-text description__job-criteria-text--criteria">
+              Other
+            </span>
+          </li>
+          <li class="description__job-criteria-item">
+            <h3 class="description__job-criteria-subheader">
+              Industries
+            </h3>
+            <span class="description__job-criteria-text description__job-criteria-text--criteria">
+            Software Development and IT Services and IT Consulting
+            </span>
+          </li>
+      </ul>
+    
+      </div>
+    </section>
+  
+  
+
+        
+    
+
+    
+
+      
+    <section class="core-section-container
+        my-3 find-a-referral">
+<!---->
+<!---->
+<!---->
+      <div class="core-section-container__content break-words">
+        
+        
+      
+    
+
+    
+      <div class="face-pile flex !no-underline">
+        
+      <div class="face-pile__images-container self-start flex-shrink-0 mr-1 leading-[1]">
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/bzm35e3651eojcpnxxuyvpjpo" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/224mq0thanhnrp5hhso7l1k9p" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+          
+      <img class="inline-block relative hue-web-entity__image
+          rounded-[50%]
+          w-4 h-4
+           face-pile__image border-1 border-solid border-color-transparent -ml-2 first:ml-0" data-delayed-url="https://static.licdn.com/aero-v1/sc/h/31zq62dby0m9b2ti4h5267rjk" data-ghost-classes="bg-color-entity-ghost-background" data-ghost-url="https://static.licdn.com/aero-v1/sc/h/9c8pery4andzj6ohjkjp54ma2" alt>
+      
+      </div>
+        
+          
+            <div class="find-a-referral__cta-container">
+              <p>Referrals increase your chances of interviewing at Base44 by 2x</p>
+              <a class="find-a-referral__cta" href="https://www.linkedin.com/login?session_redirect=https%3A%2F%2Fwww%2Elinkedin%2Ecom%2Fsearch%2Fresults%2Fpeople%2F%3FfacetCurrentCompany%3D106589953&amp;emailAddress=&amp;fromSignIn=&amp;trk=public_jobs_find-a-referral-cta" data-impression-id="public_jobs_find-a-referral-cta" data-tracking-control-name="public_jobs_find-a-referral-cta" data-tracking-will-navigate>
+                See who you know
+              </a>
+            </div>
+          
+        
+    
+      </div>
+  
+  
+  
+      
+      </div>
+    </section>
+  
+  
+
+<!---->    </div>
+
+<!---->
+<!---->
+    <code id="decoratedJobPostingId" style="display: none"><!--"4429904263"--></code>
+      <code id="referenceId" style="display: none"><!--"miQpZ9d6TAGYxx2rqMwUcA=="--></code>
+    <code id="joinUrlWithRedirect" style="display: none"><!--"https://www.linkedin.com/signup/cold-join?source=jobs_registration&session_redirect=https%3A%2F%2Fil.linkedin.com%2Fjobs%2Fview%2Fpartnership-manager-base44-at-base44-4429904263"--></code>
+  
+  

--- a/tests/unit/linkedin-job-extractor.test.ts
+++ b/tests/unit/linkedin-job-extractor.test.ts
@@ -1,0 +1,113 @@
+import fs from 'fs';
+import path from 'path';
+import {
+  extractFromLinkedIn,
+  extractJob,
+  extractLinkedInJobId,
+  isThinExtraction,
+  ThinJobExtractionError,
+} from '@/lib/scraper/jobExtractor';
+
+const FIXTURE_DIR = path.join(__dirname, '../fixtures/linkedin');
+const guestHtml = fs.readFileSync(path.join(FIXTURE_DIR, 'guest-fragment.html'), 'utf8');
+const authwallHtml = fs.readFileSync(path.join(FIXTURE_DIR, 'authwall-fragment.html'), 'utf8');
+
+const GUEST_URL =
+  'https://www.linkedin.com/jobs-guest/jobs/api/jobPosting/4429904263';
+
+describe('extractFromLinkedIn — guest fragment', () => {
+  it('populates title, company, body, and requirement lists', async () => {
+    const result = await extractFromLinkedIn(guestHtml, GUEST_URL);
+
+    expect(result.job_title).toBe('Partnership Manager - Base44');
+    expect(result.company_name).toBe('Base44');
+    // The full posting body is recovered into about_this_job (no <p> tags in the
+    // guest fragment), so the scorer always has real JD text.
+    expect((result.about_this_job || '').length).toBeGreaterThan(1000);
+
+    const listCount =
+      (result.requirements?.length ?? 0) +
+      (result.qualifications?.length ?? 0) +
+      (result.responsibilities?.length ?? 0);
+    expect(listCount).toBeGreaterThan(0);
+
+    expect(isThinExtraction(result)).toBe(false);
+  });
+});
+
+describe('isThinExtraction — authwall fragment', () => {
+  it('flags the degraded meta-only page as thin', async () => {
+    const result = await extractFromLinkedIn(
+      authwallHtml,
+      'https://www.linkedin.com/jobs/view/4429904263'
+    );
+    expect(isThinExtraction(result)).toBe(true);
+  });
+});
+
+describe('extractLinkedInJobId', () => {
+  it('reads /jobs/view/{id}', () => {
+    expect(
+      extractLinkedInJobId(new URL('https://www.linkedin.com/jobs/view/3812345678'))
+    ).toBe('3812345678');
+  });
+
+  it('reads the currentJobId query param', () => {
+    expect(
+      extractLinkedInJobId(
+        new URL('https://www.linkedin.com/jobs/collections/recommended?currentJobId=3812345678')
+      )
+    ).toBe('3812345678');
+  });
+
+  it('reads a trailing numeric id', () => {
+    expect(
+      extractLinkedInJobId(
+        new URL('https://www.linkedin.com/jobs/partnership-manager-at-base44-4429904263')
+      )
+    ).toBe('4429904263');
+  });
+
+  it('returns null for a non-job URL', () => {
+    expect(
+      extractLinkedInJobId(new URL('https://www.linkedin.com/feed/'))
+    ).toBeNull();
+  });
+});
+
+describe('extractJob — thinness gate (mocked fetch)', () => {
+  const realFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+  });
+
+  function mockFetchHtml(html: string) {
+    // jsdom doesn't define fetch/Response as own-properties, so assign a stub
+    // that returns the minimal shape extractJob's fetchHtml() reads.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: async () => html,
+    }) as unknown as typeof fetch;
+  }
+
+  it('rejects with ThinJobExtractionError on the authwall page', async () => {
+    mockFetchHtml(authwallHtml);
+    await expect(
+      extractJob('https://www.linkedin.com/jobs/view/4429904263')
+    ).rejects.toBeInstanceOf(ThinJobExtractionError);
+  });
+
+  it('resolves with populated requirements on the guest fragment', async () => {
+    mockFetchHtml(guestHtml);
+    const result = await extractJob('https://www.linkedin.com/jobs/view/4429904263');
+    const listCount =
+      (result.requirements?.length ?? 0) +
+      (result.qualifications?.length ?? 0) +
+      (result.responsibilities?.length ?? 0);
+    expect(listCount).toBeGreaterThan(0);
+    expect(isThinExtraction(result)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
LinkedIn served Vercel's serverless egress IP a degraded authwall page — only the ~222-char `og:description` meta, no job body. `extractFromLinkedIn` succeeded with that snippet (no throw), so every URL-submitted LinkedIn job was scored against near-empty content → artificially low ATS scores (~21/100). This defeats the app's core value: optimizing a resume against the job's real content.

Verified by diffing the production `job_descriptions` row (222 chars, all `parsed_data` fields null) against a direct fetch of LinkedIn's public guest endpoint (full 2,659-char body, intact Qualifications list).

## Fix
- **Guest endpoint:** `extractJob` derives the job id and fetches `/jobs-guest/jobs/api/jobPosting/{id}` (public embed API, works from datacenter IPs, no auth), falling back to `/jobs/view/{id}` only if the guest fetch errors.
- **Parser hardening for the guest fragment:** topcard `job_title`/`company_name` fallbacks (the fragment has no `og:title`/`<title>`), full-body recovery into `about_this_job` (no `<p>` tags), and loosened `<strong>` list headings that broke on `<br>` separators so Qualifications/Requirements parse.
- **Thinness gate:** `isThinExtraction` + `ThinJobExtractionError` throw at the single `extractJob` choke point when a scrape is effectively empty. `/api/upload-resume` prefers pasted text and otherwise returns `422 JOB_URL_UNREADABLE` ("paste the job description text instead") instead of silently scoring garbage. `/api/v1/applications` no longer 500s on it. Both apps already render the server error and already have a paste field — no UI changes needed.
- **Proxy seam:** `fetchHtml()` is the single place a residential proxy would slot in later (env-gated) if LinkedIn 429s the Vercel IP at scale. None added now.

## Test plan
- [x] `npx jest tests/unit/linkedin-job-extractor.test.ts` — 8 pass (guest + authwall fixtures, id extraction, thinness gate)
- [x] Relevant suites green (ats-prepare-input, upload-resume-fallback, legacy-endpoints, optimize-pipeline) — 24/24
- [x] `npm run lint` — 0 errors
- [ ] **Production verify (needs deploy):** set `SCRAPE_CHECK_TOKEN` on the preview, then `GET /api/debug/scrape-check?url=<linkedin job>&token=...` and confirm `aboutLen > 1000`, `isThin: false`. (Route is 404-gated to preview only; remove after.)
- [ ] Re-optimize a fresh LinkedIn job on iOS post-deploy — expect score materially above ~21.

## Notes
- A real LinkedIn authwall only reproduces from a datacenter IP, so the guest-endpoint behavior on Vercel must be confirmed via the debug route after deploy.
- The preview-only `src/app/api/debug/scrape-check/route.ts` should be removed (or left permanently 404-gated) after verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job description extraction reliability with enhanced fallback handling when scraping encounters issues.
  * Added safeguards to detect and prevent processing of incomplete job data.
  * Enhanced resilience when scraping fails by using user-provided information as fallback.

* **New Features**
  * Added validation tools for testing job data extraction in preview environments.

* **Tests**
  * Added comprehensive test coverage for job extraction edge cases and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->