### PR TITLE
fix(ats): complete Layer B JD ingestion pipeline

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { runOptimizePipeline } from "@/lib/ai-optimizer/optimize-pipeline";
-import { preferJobDescriptionText } from "@/lib/ats/job-data-resolver";
+import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { checkRateLimit, getRateLimitHeaders, RATE_LIMITS } from "@/lib/utils/rate-limit";
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
@@ -75,8 +75,13 @@ export async function POST(req: NextRequest) {
     // Credit check disabled — all users are on free tier for now.
     // Re-enable by uncommenting the consumeCredit block when monetization goes live.
 
-    const jobDescriptionText = preferJobDescriptionText(jdData as { raw_text?: string; clean_text?: string });
     const parsedData = (jdData as { parsed_data?: Record<string, unknown> }).parsed_data;
+
+    const jobDescriptionText = resolveJobDescriptionText({
+      raw_text: (jdData as { raw_text?: string }).raw_text,
+      clean_text: (jdData as { clean_text?: string }).clean_text,
+      parsed_data: parsedData,
+    });
 
     const pipelineResult = await runOptimizePipeline(
       (resumeData as any).raw_text,
@@ -92,7 +97,8 @@ export async function POST(req: NextRequest) {
       jobDescriptionId,
       resumeRawText: (resumeData as any).raw_text,
       jobDescriptionText,
-      jobTitle: 'Position',
+      jobTitle: (jdData as { title?: string }).title || 'Position',
+      jobExtractedJson: parsedData,
       optimizedResume,
     });
 

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { extractJob, ThinJobExtractionError } from "@/lib/scraper/jobExtractor";
 import { scrapeJobDescription } from "@/lib/job-scraper";
-import { normalizeParsedJobData } from "@/lib/ats/job-data-resolver";
+import {
+  buildJobDescriptionTextFromParsed,
+  buildParsedDataFromPlainText,
+  normalizeParsedJobData,
+  resolveJobDescriptionText,
+} from "@/lib/ats/job-data-resolver";
 import { isSupportedResumeFile } from "@/lib/utils/file-validation";
 import { convertResumeBuffer } from "@/lib/markitdown-client";
 import path from "path";
@@ -77,16 +82,10 @@ export async function POST(req: NextRequest) {
         extractedCompany = extracted.company_name;
         extractedData = normalizeParsedJobData(extracted);
         sourceUrl = jobDescriptionUrl;
-
-        const parts: string[] = [];
-        if (extracted.job_title) parts.push(`Job Title: ${extracted.job_title}`);
-        if (extracted.company_name) parts.push(`Company: ${extracted.company_name}`);
-        if (extracted.location) parts.push(`Location: ${extracted.location}`);
-        if (extracted.about_this_job) parts.push(`About: ${extracted.about_this_job}`);
-        if (extracted.requirements?.length) parts.push(`Requirements: ${extracted.requirements.join("; ")}`);
-        if (extracted.responsibilities?.length) parts.push(`Responsibilities: ${extracted.responsibilities.join("; ")}`);
-        if (extracted.qualifications?.length) parts.push(`Qualifications: ${extracted.qualifications.join("; ")}`);
-        jobDescriptionText = parts.join("\n");
+        jobDescriptionText = buildJobDescriptionTextFromParsed(extractedData);
+        if (!jobDescriptionText && extracted.about_this_job) {
+          jobDescriptionText = extracted.about_this_job;
+        }
       } catch (err) {
         const isThin =
           err instanceof ThinJobExtractionError ||
@@ -98,7 +97,9 @@ export async function POST(req: NextRequest) {
           // hard-fail with an actionable message instead of scoring garbage.
           if (jobDescription && jobDescription.trim()) {
             jobDescriptionText = jobDescription;
-            extractedData = { fallback: true, source_url: jobDescriptionUrl };
+            extractedData = buildParsedDataFromPlainText(jobDescription, {
+              sourceUrl: jobDescriptionUrl,
+            });
             sourceUrl = jobDescriptionUrl;
           } else {
             return NextResponse.json(
@@ -118,7 +119,7 @@ export async function POST(req: NextRequest) {
           try {
             const text = await scrapeJobDescription(jobDescriptionUrl);
             jobDescriptionText = text;
-            extractedData = { fallback: true, source_url: jobDescriptionUrl };
+            extractedData = buildParsedDataFromPlainText(text, { sourceUrl: jobDescriptionUrl });
             sourceUrl = jobDescriptionUrl;
           } catch {
             jobDescriptionText = `Job Posting URL: ${jobDescriptionUrl}`;
@@ -129,6 +130,7 @@ export async function POST(req: NextRequest) {
       }
     } else if (jobDescription) {
       jobDescriptionText = jobDescription;
+      extractedData = buildParsedDataFromPlainText(jobDescription);
     } else {
       return NextResponse.json({ error: "Job description or URL is required." }, { status: 400 });
     }
@@ -175,6 +177,12 @@ export async function POST(req: NextRequest) {
       .select()
       .maybeSingle();
 
+    const scoringJobText = resolveJobDescriptionText({
+      raw_text: jobDescriptionText,
+      clean_text: buildJobDescriptionTextFromParsed(extractedData),
+      parsed_data: extractedData,
+    });
+
     const jdInsert = supabase
       .from("job_descriptions")
       .insert({
@@ -182,7 +190,7 @@ export async function POST(req: NextRequest) {
         title: extractedTitle || "Job Position",
         company: extractedCompany || "Company Name",
         raw_text: jobDescriptionText,
-        clean_text: jobDescriptionText,
+        clean_text: scoringJobText,
         parsed_data: extractedData,
         source_url: sourceUrl,
       })
@@ -229,7 +237,9 @@ export async function POST(req: NextRequest) {
       resumeId: resumeData.id,
       jobDescriptionId: jdData.id,
     });
-    const pipelineResult = await runOptimizePipeline(resumeMarkdown, jobDescriptionText);
+    const pipelineResult = await runOptimizePipeline(resumeMarkdown, scoringJobText, {
+      jobExtractedJson: extractedData,
+    });
     const optimizedResume = pipelineResult.optimizedResume;
 
     const { reviewId, reviewRun } = await createOptimizationReviewRun({
@@ -238,8 +248,9 @@ export async function POST(req: NextRequest) {
       resumeId: resumeData.id,
       jobDescriptionId: jdData.id,
       resumeRawText: resumeMarkdown,
-      jobDescriptionText,
+      jobDescriptionText: scoringJobText,
       jobTitle: extractedTitle || jdData.title,
+      jobExtractedJson: extractedData,
       optimizedResume,
     });
 

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -7,7 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
 import { scoreResume } from '@/lib/ats/scorer';
-import { buildJobDataFromExtractedJson, preferJobDescriptionText } from '@/lib/ats/job-data-resolver';
+import { buildJobDataFromExtractedJson, resolveJobDescriptionText } from '@/lib/ats/job-data-resolver';
 import { TECHNICAL_KEYWORDS } from '@/lib/constants';
 
 export async function POST(request: NextRequest) {
@@ -229,7 +229,11 @@ export async function POST(request: NextRequest) {
         // Map parsed_data from database to JobExtraction format expected by scorer
         // Database structure: { job_title, requirements, nice_to_have, responsibilities, ... }
         // Scorer expects: { title, must_have, nice_to_have, responsibilities, ... }
-        const jobText = preferJobDescriptionText(jobDescription);
+        const jobText = resolveJobDescriptionText({
+          raw_text: jobDescription.raw_text,
+          clean_text: jobDescription.clean_text,
+          parsed_data: jobDescription.parsed_data,
+        });
         const jobDataForScorer = {
           ...buildJobDataFromExtractedJson(jobDescription.parsed_data, jobText),
           raw_text: jobText,

--- a/src/app/api/v1/optimizations/[id]/route.ts
+++ b/src/app/api/v1/optimizations/[id]/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import type { OptimizedResume } from "@/lib/ai-optimizer";
+import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { scoreOptimization } from "@/lib/ats/integration";
 
 export const runtime = "nodejs";
@@ -226,7 +227,7 @@ export async function PATCH(
 
     const { data: currentOpt, error: currentOptErr } = await supabase
       .from("optimizations")
-      .select("resume_id, jd_id, ats_score_original, ats_subscores_original")
+      .select("resume_id, jd_id, ats_score_original, ats_subscores_original, jd_text")
       .eq("id", id)
       .eq("user_id", userId)
       .maybeSingle();
@@ -265,7 +266,12 @@ export async function PATCH(
       const scored = await scoreOptimization({
         resumeOriginalText: (resumeRow as any)?.raw_text || "",
         resumeOptimizedJson: rewriteData,
-        jobDescriptionText: (jdRow as any)?.clean_text || (jdRow as any)?.raw_text || "",
+        jobDescriptionText: resolveJobDescriptionText({
+          raw_text: (jdRow as any)?.raw_text,
+          clean_text: (jdRow as any)?.clean_text,
+          parsed_data: (jdRow as any)?.parsed_data,
+          jd_text: (currentOpt as any)?.jd_text,
+        }),
         jobExtractedJson: (jdRow as any)?.parsed_data || undefined,
       });
       atsResult = scored;

--- a/src/lib/agent/handlers/handleTipImplementation.ts
+++ b/src/lib/agent/handlers/handleTipImplementation.ts
@@ -1,7 +1,7 @@
 import { parseTipNumbers, validateTipNumbers } from '../parseTipNumbers';
 import { applySuggestionsWithTracking } from '../applySuggestions';
 import type { Suggestion } from '@/lib/ats/types';
-import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
+import { buildJobDataFromExtractedJson, resolveJobDescriptionText } from '@/lib/ats/job-data-resolver';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 interface AgentContext {
@@ -72,7 +72,7 @@ export async function handleTipImplementation(
   console.log('💡 [handleTipImplementation] Fetching optimization:', optimizationId);
   const { data: optimization, error: fetchError } = await supabase
     .from('optimizations')
-    .select('rewrite_data, ats_score_optimized, ai_modification_count, user_id, jd_id, resume_id, ats_score_original, ats_subscores_original')
+    .select('rewrite_data, ats_score_optimized, ai_modification_count, user_id, jd_id, resume_id, ats_score_original, ats_subscores_original, jd_text')
     .eq('id', optimizationId)
     .maybeSingle(); // Use maybeSingle() to avoid 406 errors when no rows found
 
@@ -98,16 +98,21 @@ export async function handleTipImplementation(
   if (jobId) {
     const { data, error } = await supabase
       .from('job_descriptions')
-      .select('clean_text, raw_text, title')
+      .select('clean_text, raw_text, title, parsed_data')
       .eq('id', jobId)
       .maybeSingle();
     if (error) {
       console.error('WARN [handleTipImplementation] Failed to fetch job description:', error);
     } else {
       jobDesc = data;
-      jobText = (jobDesc?.clean_text || jobDesc?.raw_text || '').trim();
-      if (jobText) {
-        jobData = extractJobData(jobText);
+      jobText = resolveJobDescriptionText({
+        raw_text: jobDesc?.raw_text,
+        clean_text: jobDesc?.clean_text,
+        parsed_data: jobDesc?.parsed_data,
+        jd_text: optimization.jd_text,
+      });
+      if (jobText && jobDesc?.parsed_data) {
+        jobData = buildJobDataFromExtractedJson(jobDesc.parsed_data, jobText);
       }
     }
   }
@@ -205,8 +210,9 @@ export async function handleTipImplementation(
     const atsResult = await rescoreAfterTipImplementation({
       resumeOriginalText: resumeData.raw_text,
       resumeOptimizedJson: updatedResume,
-      jobDescriptionText: jobText || jobDesc.clean_text || jobDesc.raw_text,
+      jobDescriptionText: jobText,
       jobTitle: jobTitle,
+      jobExtractedJson: jobDesc?.parsed_data || undefined,
       previousOriginalScore: optimization.ats_score_original,
       previousSubscoresOriginal: optimization.ats_subscores_original,
     });
@@ -257,7 +263,8 @@ export async function handleTipImplementation(
       ats_subscores: atsResult.subscores,
       ats_suggestions: atsResult.suggestions,
       ats_confidence: atsResult.confidence,
-      ai_modification_count: (optimization.ai_modification_count || 0) + modifications.length, // Increment count (Phase 3)
+      ...(optimization.jd_text ? {} : { jd_text: jobText }),
+      ai_modification_count: (optimization.ai_modification_count || 0) + modifications.length,
       updated_at: new Date().toISOString(),
     };
     console.log('💡 [handleTipImplementation] Updating optimization in database with real scores and modification count');

--- a/src/lib/ats/integration.ts
+++ b/src/lib/ats/integration.ts
@@ -197,6 +197,7 @@ export async function rescoreAfterTipImplementation(params: {
   resumeOptimizedJson: OptimizedResume;
   jobDescriptionText: string;
   jobTitle?: string;
+  jobExtractedJson?: Record<string, unknown>;
   previousOriginalScore: number;
   previousSubscoresOriginal: any;
 }): Promise<ATSScoreOutput> {
@@ -205,6 +206,7 @@ export async function rescoreAfterTipImplementation(params: {
     resumeOptimizedJson,
     jobDescriptionText,
     jobTitle = 'Position',
+    jobExtractedJson,
     previousOriginalScore,
     previousSubscoresOriginal,
   } = params;
@@ -212,8 +214,10 @@ export async function rescoreAfterTipImplementation(params: {
   // Convert optimized resume JSON to text
   const resumeOptimizedText = resumeJsonToText(resumeOptimizedJson);
 
-  // Extract job requirements
-  const jobExtraction = extractJobRequirements(jobDescriptionText, jobTitle);
+  // Extract job requirements — prefer structured parsed_data when available
+  const jobExtraction = jobExtractedJson
+    ? buildJobDataFromExtractedJson(jobExtractedJson, jobDescriptionText)
+    : extractJobRequirements(jobDescriptionText, jobTitle);
 
   // Generate format reports
   const formatReport = generateFormatReport(resumeOriginalText);

--- a/src/lib/ats/job-data-resolver.ts
+++ b/src/lib/ats/job-data-resolver.ts
@@ -71,6 +71,105 @@ export function preferJobDescriptionText(jd: {
   return raw || clean;
 }
 
+export function buildJobDescriptionTextFromParsed(parsed: unknown): string {
+  const record = toParsedJobRecord(parsed);
+  const parts: string[] = [];
+
+  const title = record.job_title || record.title;
+  const company = record.company_name || record.company;
+  if (title) parts.push(`Job Title: ${title}`);
+  if (company) parts.push(`Company: ${company}`);
+  if (record.location) parts.push(`Location: ${String(record.location)}`);
+  if (record.about_this_job) parts.push(`About: ${String(record.about_this_job)}`);
+
+  const requirements = normalizeStringList(record.requirements);
+  const qualifications = normalizeStringList(record.qualifications);
+  const responsibilities = normalizeStringList(record.responsibilities);
+  const niceToHave = normalizeStringList(record.nice_to_have);
+
+  if (requirements.length > 0) {
+    parts.push(`Requirements: ${requirements.join('; ')}`);
+  } else if (qualifications.length > 0) {
+    parts.push(`Qualifications: ${qualifications.join('; ')}`);
+  }
+  if (responsibilities.length > 0) {
+    parts.push(`Responsibilities: ${responsibilities.join('; ')}`);
+  }
+  if (niceToHave.length > 0) {
+    parts.push(`Nice to have: ${niceToHave.join('; ')}`);
+  }
+
+  return parts.join('\n').trim();
+}
+
+/** Pick the richest JD text available for scoring (persisted jd_text > clean > raw > parsed). */
+export function resolveJobDescriptionText(input: {
+  raw_text?: string | null;
+  clean_text?: string | null;
+  parsed_data?: unknown;
+  jd_text?: string | null;
+}): string {
+  const candidates = [
+    (input.jd_text || '').trim(),
+    (input.clean_text || '').trim(),
+    (input.raw_text || '').trim(),
+    buildJobDescriptionTextFromParsed(input.parsed_data),
+  ].filter((value) => value.length > 0);
+
+  return candidates.reduce(
+    (longest, current) => (current.length > longest.length ? current : longest),
+    '',
+  );
+}
+
+export function buildParsedDataFromPlainText(
+  text: string,
+  meta?: { jobTitle?: string | null; company?: string | null; sourceUrl?: string | null },
+): ExtractedJobData {
+  const trimmed = text.trim();
+  const fromText = extractJobData(trimmed, {
+    title: meta?.jobTitle || undefined,
+    company: meta?.company || undefined,
+  });
+
+  let sourceDomain = 'manual';
+  if (meta?.sourceUrl) {
+    try {
+      sourceDomain = new URL(meta.sourceUrl).hostname;
+    } catch {
+      sourceDomain = 'manual';
+    }
+  }
+
+  return normalizeParsedJobData({
+    source_url: meta?.sourceUrl || '',
+    source_domain: sourceDomain,
+    scraped_at: new Date().toISOString(),
+    company_name: meta?.company || fromText.company || null,
+    job_title: meta?.jobTitle || fromText.title || null,
+    contact_person: null,
+    location: fromText.location || null,
+    employment_type: null,
+    seniority: fromText.seniority || null,
+    compensation: null,
+    about_this_job: trimmed.length <= 4000 ? trimmed : trimmed.slice(0, 4000),
+    requirements: fromText.must_have.length > 0 ? fromText.must_have : null,
+    qualifications: fromText.must_have.length > 0 ? fromText.must_have : null,
+    responsibilities: fromText.responsibilities.length > 0 ? fromText.responsibilities : null,
+    nice_to_have: fromText.nice_to_have.length > 0 ? fromText.nice_to_have : null,
+    benefits: null,
+    application_instructions: null,
+    posting_id: null,
+    provenance: { source: 'plain_text' },
+    summary_for_ui: {
+      company_name: meta?.company || fromText.company || null,
+      job_title: meta?.jobTitle || fromText.title || null,
+      contact_person: null,
+      location: fromText.location || null,
+    },
+  });
+}
+
 export function buildJobDataFromExtractedJson(
   extracted: unknown,
   jobCleanText?: string,

--- a/src/lib/ats/scorer.ts
+++ b/src/lib/ats/scorer.ts
@@ -8,7 +8,7 @@
 import { scoreResume as scoreResumeMain, rescoreOptimization } from './index';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { extractJobData } from './extractors/jd-extractor';
-import { buildJobDataFromExtractedJson, preferJobDescriptionText } from './job-data-resolver';
+import { buildJobDataFromExtractedJson, resolveJobDescriptionText } from './job-data-resolver';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 import type { ATSScoreOutput } from './types';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
@@ -43,7 +43,7 @@ export async function scoreResume(
     : resumeOptimizedText;
 
   // Extract job description text — prefer longer clean_text over truncated raw_text
-  const jobText = preferJobDescriptionText(jobDescriptionData);
+  const jobText = resolveJobDescriptionText(jobDescriptionData);
 
   const hasStructuredJob = jobDescriptionData.title || jobDescriptionData.job_title;
   const jobExtraction = hasStructuredJob

--- a/src/lib/optimization-review/index.ts
+++ b/src/lib/optimization-review/index.ts
@@ -13,6 +13,7 @@ type ReviewContext = {
   jobTitle?: string | null;
   jobDescriptionText: string;
   resumeOriginalText: string;
+  jobExtractedJson?: Record<string, unknown>;
 };
 
 type SectionDescriptor = {
@@ -271,6 +272,7 @@ export async function buildATSPreview(
       resumeOptimizedJson: optimizedResume,
       jobDescriptionText: context.jobDescriptionText,
       jobTitle: context.jobTitle || "Position",
+      jobExtractedJson: context.jobExtractedJson,
     });
 
     return {

--- a/src/lib/optimization-review/service.ts
+++ b/src/lib/optimization-review/service.ts
@@ -1,7 +1,7 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { scoreOptimization } from "@/lib/ats/integration";
-import { preferJobDescriptionText } from "@/lib/ats/job-data-resolver";
+import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import {
   buildATSPreview,
   buildFinalResumeMetadata,
@@ -38,6 +38,7 @@ interface CreateReviewRunParams {
   resumeRawText: string;
   jobDescriptionText: string;
   jobTitle?: string | null;
+  jobExtractedJson?: Record<string, unknown>;
   optimizedResume: OptimizedResume;
 }
 
@@ -100,6 +101,7 @@ export async function createOptimizationReviewRun({
   resumeRawText,
   jobDescriptionText,
   jobTitle,
+  jobExtractedJson,
   optimizedResume,
 }: CreateReviewRunParams): Promise<{ reviewId: string; reviewRun: OptimizationReviewRun }> {
   const { data: resumeRow } = await supabase
@@ -121,6 +123,7 @@ export async function createOptimizationReviewRun({
     jobDescriptionText,
     jobTitle,
     resumeOriginalText: resumeRawText,
+    jobExtractedJson,
   });
 
   const { data: inserted, error } = await supabase
@@ -207,8 +210,12 @@ export async function applyOptimizationReviewRun({
 
   let finalResume = buildResumeFromApprovedGroups(reviewRun.original_resume_json, approvedGroups);
 
-  const jobDescriptionText = preferJobDescriptionText(jdRow);
   const parsedData = (jdRow.parsed_data as Record<string, unknown> | null) || undefined;
+  const jobDescriptionText = resolveJobDescriptionText({
+    raw_text: jdRow.raw_text,
+    clean_text: jdRow.clean_text,
+    parsed_data: parsedData,
+  });
 
   let finalATSPreview: ReviewATSPreview | null = null;
   let finalATSResult: ATSScoreOutput | null = null;

--- a/tests/unit/ats-prepare-input.test.ts
+++ b/tests/unit/ats-prepare-input.test.ts
@@ -1,4 +1,10 @@
-import { buildJobDataFromExtractedJson, normalizeParsedJobData } from '@/lib/ats/job-data-resolver';
+import {
+  buildJobDataFromExtractedJson,
+  buildJobDescriptionTextFromParsed,
+  buildParsedDataFromPlainText,
+  normalizeParsedJobData,
+  resolveJobDescriptionText,
+} from '@/lib/ats/job-data-resolver';
 import { scoreResume } from '@/lib/ats/index';
 import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
 
@@ -83,6 +89,36 @@ describe('ats job-data resolver', () => {
     const normalized = normalizeParsedJobData(parsedData);
     expect(normalized.requirements).not.toBeNull();
     expect(normalized.requirements?.length).toBeGreaterThan(0);
+  });
+
+  it('builds parsed_data from pasted plain text', () => {
+    const pasted = `
+      Business Development Manager
+      Requirements:
+      - B2B sales experience
+      - Salesforce CRM
+      - SaaS background
+    `;
+    const parsed = buildParsedDataFromPlainText(pasted);
+    expect(parsed.requirements?.length).toBeGreaterThan(0);
+  });
+
+  it('prefers richer clean_text over truncated raw_text', () => {
+    const parsed = {
+      job_title: 'Business Development Manager',
+      requirements: ['B2B sales', 'Salesforce', 'SaaS', 'negotiation', 'pipeline management'],
+      qualifications: ['Fluent English'],
+      responsibilities: ['Own enterprise pipeline'],
+    };
+
+    const resolved = resolveJobDescriptionText({
+      raw_text: 'BDM role in Tel Aviv. Great opportunity.',
+      clean_text: buildJobDescriptionTextFromParsed(parsed),
+      parsed_data: parsed,
+    });
+
+    expect(resolved.length).toBeGreaterThan(80);
+    expect(resolved).toContain('Requirements:');
   });
 });
 


### PR DESCRIPTION
## Summary
Completes Layer B from the ATS low-score fix plan (partially landed in #76):

- **Parse time:** pasted JD text now produces `parsed_data.requirements` via `buildParsedDataFromPlainText`; URL scrape uses normalized `extractedData` for text assembly
- **Truncated snippets:** `clean_text` stores the richest JD text (`resolveJobDescriptionText`); scoring prefers clean/parsed over ~220-char `raw_text`
- **jd_text:** persisted on review apply (existing) + backfilled on tip rescoring when empty
- **Pipeline wiring:** upload-resume + `/api/optimize` + ATS preview pass `parsed_data` into scoring

## Test plan
- [x] `npm test -- tests/unit/ats-prepare-input.test.ts`
- [x] `npm run lint`
- [ ] Re-optimize on iOS after deploy — confirm `optimizations.jd_text` non-empty and score above ~35


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of job description processing and ATS score calculations through enhanced text resolution logic.
  * Refined optimization review scoring to incorporate more complete job data for better accuracy.

* **Tests**
  * Added test coverage for job description parsing from plain text input.
  * Added verification tests for job description text resolution and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->