### PR TITLE
fix(ats): word-bound keyword extraction so tech terms aren't matched as substrings

### DIFF
--- a/src/lib/ats/utils/text-utils.ts
+++ b/src/lib/ats/utils/text-utils.ts
@@ -133,8 +133,10 @@ export function countPhraseMatches(text: string, phrases: string[]): number {
 export function extractKeywords(text: string, maxKeywords: number = KEYWORD_THRESHOLDS.max_keywords): string[] {
   const keywords: string[] = [];
 
-  // Extract capitalized terms (likely proper nouns, technologies)
-  const capitalizedPattern = /\b[A-Z][a-z]+(?:\s+[A-Z][a-z]+)*\b/g;
+  // Extract capitalized terms (likely proper nouns, technologies).
+  // Use [ \t]+ (not \s+) between words so a phrase never spans a line break —
+  // otherwise "Company: Fresha\nAbout:" yields the junk keyword "Fresha\nAbout".
+  const capitalizedPattern = /\b[A-Z][a-z]+(?:[ \t]+[A-Z][a-z]+)*\b/g;
   const capitalized = text.match(capitalizedPattern) || [];
 
   // Extract acronyms and technical terms (2+ uppercase letters)
@@ -161,9 +163,15 @@ export function extractKeywords(text: string, maxKeywords: number = KEYWORD_THRE
     'leadership', 'communication', 'problem-solving', 'teamwork', 'analytical', 'strategic',
   ];
 
-  // Find all technical terms that appear in the text (case-insensitive)
+  // Find all technical terms that appear in the text (case-insensitive).
+  // Alphanumeric lookarounds prevent substring false-positives: without them
+  // "rust" matches inside "trusted", "api" inside "rapidly", "express" inside
+  // "expressing", "go" inside "Google" — fabricating tech skills that a
+  // non-technical JD never listed and tanking the keyword sub-scores. \b can't
+  // be used here because several terms contain symbols (c++, .net, ci/cd,
+  // rest api), where \b would sit at the wrong place.
   for (const term of technicalTerms) {
-    const regex = new RegExp(term, 'gi');
+    const regex = new RegExp(`(?<![A-Za-z0-9])(?:${term})(?![A-Za-z0-9])`, 'gi');
     const matches = text.match(regex);
     if (matches) {
       // Preserve original casing from text

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,6 +4,15 @@
 
 ---
 
+## ATS keyword extractor matched tech terms as substrings (fabricated skills → low scores)
+
+**Symptom:** Non-technical roles (Business Development, Partnership Manager) scored ~34 even with a fully-scraped 6KB JD. `must_have` for a Fresha BD role came out as `["rust","express","api","Fresha\nAbout","Trusted"]`.
+**Root cause:** `extractKeywords` in `src/lib/ats/utils/text-utils.ts` matched each technical term with `new RegExp(term, 'gi')` — no word boundaries. So `rust` matched inside "t**rust**ed", `api` inside "r**api**dly", `express` inside "**express**ing", `go` inside "Google". These fabricated skills never appear in the resume, collapsing `keyword_exact` (22%) and `keyword_phrase` (12%).
+**Fix:** Wrap each term in alphanumeric lookarounds `(?<![A-Za-z0-9])(?:term)(?![A-Za-z0-9])` (not `\b` — several terms contain symbols like `c++`, `.net`, `ci/cd`, `rest api`). Also changed the capitalized-phrase pattern from `\s+` to `[ \t]+` so phrases don't span line breaks ("Fresha\nAbout").
+**Note:** This was one of several compounding causes of low scores — see progress.md 2026-06-21. It is necessary but not sufficient on its own (lifts ~2 pts); the JD structured-requirement extraction and AI-optimizer metric quality are the larger remaining levers.
+
+---
+
 ## Supabase 406: `.single()` on missing or multiple rows
 
 **Mistake:** Using `.single()` on a query that can return zero or multiple rows.

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -2,15 +2,15 @@
 
 Project: ResumeBuilder AI (Web)
 Status: Active
-Current Phase: ATS scoring pipeline error sweep — LinkedIn scrape-blocking fix implemented, awaiting production verification on Vercel preview
-Active Story: Verify the LinkedIn guest-endpoint fix from a real Vercel datacenter IP (branch fix/linkedin-guest-scrape) — set SCRAPE_CHECK_TOKEN on the preview, hit /api/debug/scrape-check, confirm aboutLen>1000 & isThin:false; then re-optimize a fresh LinkedIn job on iOS and confirm the score lifts above ~21
-Last Completed Story: Implemented LinkedIn guest-API scrape fix + thinness gate (branch fix/linkedin-guest-scrape, pushed 2026-06-20) — root-cause fix for the score-capping bug
-Next Recommended Story: After preview verification passes, merge fix/linkedin-guest-scrape and remove (or keep 404-gated) the debug route; only revisit a residential proxy if LinkedIn 429s the Vercel IP at scale (fetchHtml() seam is ready)
-Estimated Completion: Web is live; launch-support items above remain
-Blockers: —
-Risks: Guest-endpoint behavior on Vercel's IP is verified-by-design but not yet confirmed from a real datacenter IP (only reproducible post-deploy); PDF/DOCX upload smoke test still not run (#1 pre-approval risk per tasks/MEMORY.md 2026-06-08); user_credits table vs profiles.credit_balance reconciliation must be resolved at Gate A
-Last Validation: fix/linkedin-guest-scrape — 8 new unit tests pass, relevant suites 24/24, lint 0 errors (2026-06-20). The 16 other failing jest suites are pre-existing (Playwright e2e under jest + server-dependent contract tests), confirmed by stash-and-rerun on baseline.
-Last Updated: 2026-06-20
+Current Phase: ATS scoring accuracy — root-caused the persistent low scores to multiple compounding causes (NOT a deploy gap). Fixed the substring-keyword bug; larger levers (JD structured-requirement extraction, AI-optimizer metric quality) remain.
+Active Story: Land the keyword-substring fix (branch claude/nostalgic-euclid-564122) — extractKeywords no longer matches tech terms as substrings. Verified against real prod data (Fresha BD optimization d30a6841 / jd 42dc3790).
+Last Completed Story: Diagnosed why scores stay low despite the merged LinkedIn + Layer B fixes. Confirmed prod is fresh (1h-old deploy on git-main alias, www.resumelybuilderai.com). Reproduced score 34 with exact inputs; found must_have = ["rust","express","api","Fresha\nAbout","Trusted"] from unbounded substring matching in extractKeywords. Fixed + tested.
+Next Recommended Story: Decide direction with founder (product call). Two highest-ROI levers: (A) extract real requirement/qualification bullets from the LinkedIn guest fragment — parsed_data.requirements/qualifications/responsibilities are ALL null even when about_this_job is full (6KB), so the scorer falls back to a noisy keyword proxy; (B) AI-optimizer writes metric-free achievement bullets (metrics_presence legitimately = 0), so the optimize prompt needs to enforce quantified results.
+Estimated Completion: Web is live; scoring-accuracy work is incremental
+Blockers: Direction decision — "low scores" can mean improve extraction accuracy OR re-weight the model (keyword_phrase is structurally ~0 by design; 12% weight). Needs founder input before touching weights, given the "defensible Resumely Match Score" positioning.
+Risks: keyword_phrase analyzer (12%) requires verbatim 3-6 word n-gram overlap — near-0 for any paraphrased resume; this is a design weakness, not a bug. metrics_presence (10%) correctly penalizes metric-free AI output.
+Last Validation: claude/nostalgic-euclid-564122 — 3 new keyword-extraction tests + 24/24 ATS unit suites pass, lint clean, tsc no new errors (21 pre-existing, none in touched files). Real-data repro: keyword_exact 25→33 after fix (2026-06-21).
+Last Updated: 2026-06-21
 Latest QA Report: tasks/2026-06-08-smoke-test-upload-backend.md (plan; execution pending)
 
 <!--
@@ -34,6 +34,18 @@ Found while verifying live: the fix does not fully close the score-capping bug.
 2. PUT /api/v1/optimizations/[id] (save-edit path) calls scoreOptimization() without jobExtractedJson, so it falls back to extractJobRequirements()'s naive text parsing instead of buildJobDataFromExtractedJson()'s structured fallback — meaning saves/re-scores through this path still don't benefit from PR #76.
 
 Next: confirm with a brand-new optimize run (not a re-opened old one) whether the score lifts; if it does, file a follow-up to wire job_extracted_json into the save-path scoreOptimization() call in src/app/api/v1/optimizations/[id]/route.ts.
+
+## 2026-06-21 — Persistent low scores root-caused: NOT a deploy gap; multi-causal scoring bug
+Investigated why the founder still sees low scores despite the LinkedIn guest-scrape + Layer B fixes being merged.
+
+Decisive findings (evidence from prod Supabase + Vercel):
+1. **Not a deploy gap.** Latest production deploy is 1h old and carries the `git-main` alias (→ www.resumelybuilderai.com). Production tracks main.
+2. **The LinkedIn guest scrape now WORKS.** Fresha BD job (opt d30a6841, created 2026-06-21 08:49 AFTER all fixes) has raw_text/clean_text = 6371 chars. The thin-scrape problem is solved for this job. (The older Base44 job f3a1f852 with 222 chars predates the Jun-20 fix.)
+3. **Real remaining bug = garbage keyword extraction.** parsed_data.requirements/qualifications/responsibilities are ALL null even with full about_this_job, so the scorer falls back to `extractJobData` on prose → `extractKeywords`. That function matched tech terms as substrings (no word boundaries): `rust`⊂"trusted", `api`⊂"rapidly", `express`⊂"expressing", `go`⊂"Google". For the BD role must_have came out `["rust","express","api","Fresha\nAbout","Trusted"]` → keyword_exact=25, keyword_phrase=0 → overall 34.
+
+Fix (this branch): word-bound the tech-term matching with alphanumeric lookarounds + stop capitalized phrases spanning newlines. Real-data repro: keyword_exact 25→33. Lint/tsc/24 ATS tests green.
+
+Honest scope note — the substring fix is necessary but only lifts ~2 pts. The dominant drags are: (a) JD structured requirements never extracted (Bug A, scraper); (b) keyword_phrase structurally ~0 (verbatim n-gram design, 12%); (c) metrics_presence legitimately 0 because the AI optimizer writes metric-free bullets (10%). Resolving "low scores" fully is a product decision — see keyed block "Next Recommended Story" / "Blockers".
 
 ## 2026-06-19 — Save-path resolver gap fixed; real root cause found (LinkedIn scrape blocking)
 Fixed commit 85505a3: PUT /api/v1/optimizations/[id] now selects parsed_data and forwards it as jobExtractedJson to scoreOptimization(), so manual edits/re-scores get the same structured fallback as the initial optimize path. Lint clean, ats-prepare-input.test.ts passes (4/4).

--- a/tests/unit/ats-keyword-extraction.test.ts
+++ b/tests/unit/ats-keyword-extraction.test.ts
@@ -1,0 +1,54 @@
+import { extractKeywords } from '@/lib/ats/utils/text-utils';
+import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
+
+describe('extractKeywords — technical-term boundary matching', () => {
+  // Regression: a Business Development Manager JD scored ~34 because the
+  // keyword extractor pulled "rust" out of "Trusted", "api" out of "rapidly",
+  // and "express" out of "expressing" — tech skills the resume could never
+  // match, collapsing keyword_exact and keyword_phrase.
+  it('does not extract tech skills from substrings of unrelated words', () => {
+    const text =
+      'We are a Trusted partner expressing our values while growing rapidly ' +
+      'across global markets, powered by Google-scale ambition.';
+    const keywords = extractKeywords(text).map((k) => k.toLowerCase());
+
+    expect(keywords).not.toContain('rust');
+    expect(keywords).not.toContain('api');
+    expect(keywords).not.toContain('express');
+    expect(keywords).not.toContain('go');
+  });
+
+  it('still extracts genuine standalone technical terms', () => {
+    const text =
+      'Backend engineer with Python, Rust, and REST API experience building ' +
+      'services in Go.';
+    const keywords = extractKeywords(text).map((k) => k.toLowerCase());
+
+    expect(keywords).toContain('python');
+    expect(keywords).toContain('rust');
+    expect(keywords).toContain('api');
+    expect(keywords).toContain('go');
+  });
+
+  it('does not join capitalized words across line breaks', () => {
+    const keywords = extractKeywords('Company: Fresha\nAbout: leading platform');
+    expect(keywords).not.toContain('Fresha\nAbout');
+  });
+});
+
+describe('extractJobData — non-technical JD keyword fallback', () => {
+  it('does not fabricate engineering skills for a business-development role', () => {
+    const jd =
+      'Job Title: Business Development Manager\n' +
+      'Company: Fresha\n' +
+      'About: As a Trusted advisor you will drive partnerships, expressing our ' +
+      'value to clients and growing the portfolio rapidly. You will build ' +
+      'relationships, negotiate deals, and own revenue targets.';
+    const data = extractJobData(jd);
+    const mustHave = data.must_have.map((s) => s.toLowerCase());
+
+    expect(mustHave).not.toContain('rust');
+    expect(mustHave).not.toContain('api');
+    expect(mustHave).not.toContain('express');
+  });
+});


### PR DESCRIPTION
## Problem
The founder kept seeing low Resumely Match Scores even after the LinkedIn guest-scrape and Layer B JD-ingestion fixes were merged. This PR root-causes that and fixes the most clear-cut defect.

## Investigation (evidence-based, against production data)
- **Not a deploy gap.** Latest production deploy is fresh (1h old, `git-main` alias → www.resumelybuilderai.com).
- **The LinkedIn guest scrape works now.** A Business Development Manager job (Fresha) created *after* all prior fixes has a fully-scraped 6,371-char JD — yet still scored **34**.
- **Real bug:** `parsed_data.requirements/qualifications/responsibilities` come back null even when the body is full, so the scorer falls back to `extractJobData` → `extractKeywords`, which matched technical terms as **substrings** (no word boundaries):
  - `rust` ⊂ "t**rust**ed", `api` ⊂ "r**api**dly", `express` ⊂ "**express**ing", `go` ⊂ "**Go**ogle"
  - For the BD role, `must_have` came out `["rust","express","api","Fresha\nAbout","Trusted"]` — skills the resume can never match, collapsing `keyword_exact` (22%) and `keyword_phrase` (12%).

## Fix
- Match terms with alphanumeric lookarounds `(?<![A-Za-z0-9])(?:term)(?![A-Za-z0-9])` instead of `\b` (several terms contain symbols: `c++`, `.net`, `ci/cd`, `rest api`).
- Capitalized-phrase pattern uses `[ \t]+` not `\s+` so phrases don't span line breaks (was producing `"Fresha\nAbout"`).
- New tests in `tests/unit/ats-keyword-extraction.test.ts` cover both regressions.

## Verification
- Real-data repro on the exact Fresha optimization: `keyword_exact` **25 → 33**.
- Lint clean; `tsc` no new errors (21 pre-existing, none in touched files); 24/24 ATS unit tests pass.

## Honest scope note
This fixes one confirmed bug but is **necessary, not sufficient** — it lifts the overall score only ~2 pts. The larger remaining levers (separate stories, some needing a product decision):
1. **JD structured-requirement extraction** — the LinkedIn guest fragment's requirement/qualification bullets aren't parsed into `parsed_data`, so the scorer uses a noisy keyword proxy.
2. **AI-optimizer metric quality** — `metrics_presence` is legitimately 0 because the optimize prompt produces metric-free achievement bullets.
3. **`keyword_phrase` (12%)** is structurally ~0 by design (verbatim 3–6 word n-gram overlap); re-weighting touches the "defensible Resumely Match Score" positioning and needs founder sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)