### PR TITLE
Fix ATS requirement keyword matching

### DIFF
--- a/src/lib/ats/analyzers/keyword-exact.ts
+++ b/src/lib/ats/analyzers/keyword-exact.ts
@@ -9,7 +9,7 @@
 import { BaseAnalyzer } from './base';
 import type { AnalyzerInput, AnalyzerResult } from '../types';
 import { KEYWORD_THRESHOLDS } from '../config/thresholds';
-import { scoreSkillListMatch } from '../skill-match';
+import { scoreSkillCoverage } from '../skill-match';
 
 export class KeywordExactAnalyzer extends BaseAnalyzer {
   constructor() {
@@ -21,8 +21,8 @@ export class KeywordExactAnalyzer extends BaseAnalyzer {
       const mustHaveSkills = input.job_data.must_have.filter(Boolean);
       const niceToHaveSkills = input.job_data.nice_to_have.filter(Boolean);
 
-      const mustHaveResult = scoreSkillListMatch(mustHaveSkills, input.resume_text);
-      const niceToHaveResult = scoreSkillListMatch(niceToHaveSkills, input.resume_text);
+      const mustHaveResult = scoreSkillCoverage(mustHaveSkills, input.resume_text);
+      const niceToHaveResult = scoreSkillCoverage(niceToHaveSkills, input.resume_text);
 
       const mustHaveWeight = KEYWORD_THRESHOLDS.must_have_weight;
       const niceToHaveWeight = KEYWORD_THRESHOLDS.nice_to_have_weight;
@@ -34,10 +34,11 @@ export class KeywordExactAnalyzer extends BaseAnalyzer {
       if (totalPossiblePoints === 0) {
         score = 50;
       } else {
-        const earnedPoints =
-          mustHaveResult.matched.length * mustHaveWeight +
-          niceToHaveResult.matched.length * niceToHaveWeight;
-        score = this.safeDivide(earnedPoints, totalPossiblePoints) * 100;
+        const mustEarned =
+          (mustHaveResult.score / 100) * mustHaveSkills.length * mustHaveWeight;
+        const niceEarned =
+          (niceToHaveResult.score / 100) * niceToHaveSkills.length * niceToHaveWeight;
+        score = this.safeDivide(mustEarned + niceEarned, totalPossiblePoints) * 100;
       }
 
       const confidence = this.calculateConfidence({

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -74,6 +74,9 @@ export const KEYWORD_THRESHOLDS = {
   /** Minimum word length to consider as keyword */
   min_keyword_length: 3,
 
+  /** Minimum coverage to label a requirement matched in evidence/gap detection */
+  match_classification_threshold: 0.6,
+
   /** Weight multiplier for must-have skills */
   must_have_weight: 2.0,
 

--- a/src/lib/ats/extractors/skill-phrase-extractor.ts
+++ b/src/lib/ats/extractors/skill-phrase-extractor.ts
@@ -1,0 +1,63 @@
+import { KEYWORD_THRESHOLDS } from '../config/thresholds';
+import { normalizeText, tokenize } from '../utils/text-utils';
+
+const LEADING_NOISE = new Set([
+  'develop', 'build', 'lead', 'manage', 'conduct', 'maintain', 'identify',
+  'support', 'drive', 'create', 'design', 'execute', 'deliver', 'own', 'scale',
+  'generate', 'craft', 'communicate', 'represent', 'strengthen', 'analyze',
+  'evaluate', 'close', 'ensure', 'help', 'provide', 'perform', 'handle',
+  'oversee', 'coordinate', 'proven', 'strong', 'excellent', 'demonstrated',
+  'experienced', 'deep', 'solid', 'ability', 'track', 'record', 'knowledge',
+  'understanding', 'experience', 'years', 'including', 'various', 'related',
+  'relevant', 'existing', 'potential', 'complex', 'work', 'working',
+]);
+
+const CONNECTORS = new Set([
+  'and', 'or', 'the', 'a', 'an', 'of', 'to', 'in', 'for', 'with', 'while',
+  'as', 'within', 'across', 'into', 'your', 'our', 'their', 'that', 'this',
+  'on', 'by', 'at', 'from', 'is', 'are', 'be', 'will', 'you', 'we', 'they',
+  'them', 'its', 'plus', 'etc', 'via', 'per', 'end', 'able', 'other', 'both',
+  'all', 'any', 'using', 'use', 'well', 'more', 'most', 'than', 'then', 'new',
+]);
+
+const CLAUSE_SPLIT =
+  /[,;:.()\/]|\b(?:and|or|while|including|such as|with|to|but|as|within|across|through|for)\b/gi;
+
+/**
+ * Turn sentence-style job requirements into short keyword phrases without
+ * relying on a domain-specific allow-list.
+ */
+export function extractSkillPhrases(requirements: string[]): string[] {
+  const phrases = new Set<string>();
+
+  for (const raw of requirements) {
+    if (!raw) continue;
+
+    for (const clause of normalizeText(raw).split(CLAUSE_SPLIT)) {
+      const tokens = tokenize(clause).filter(Boolean);
+      let start = 0;
+
+      while (
+        start < tokens.length &&
+        (LEADING_NOISE.has(tokens[start]) ||
+          CONNECTORS.has(tokens[start]) ||
+          tokens[start].length < KEYWORD_THRESHOLDS.min_keyword_length)
+      ) {
+        start += 1;
+      }
+
+      const kept = tokens
+        .slice(start)
+        .filter(
+          (token) =>
+            !CONNECTORS.has(token) &&
+            token.length >= KEYWORD_THRESHOLDS.min_keyword_length,
+        );
+
+      if (kept.length === 0) continue;
+      phrases.add(kept.slice(0, 3).join(' '));
+    }
+  }
+
+  return Array.from(phrases);
+}

--- a/src/lib/ats/job-data-resolver.ts
+++ b/src/lib/ats/job-data-resolver.ts
@@ -4,6 +4,7 @@
 
 import type { JobExtraction } from './types';
 import { extractJobData } from './extractors/jd-extractor';
+import { extractSkillPhrases } from './extractors/skill-phrase-extractor';
 import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
 
 export function toParsedJobRecord(value: unknown): Record<string, unknown> {
@@ -197,6 +198,16 @@ export function buildJobDataFromExtractedJson(
     if (nice_to_have.length === 0) {
       nice_to_have = fromText.nice_to_have;
     }
+  }
+
+  const atomizedMustHave = extractSkillPhrases(must_have);
+  if (atomizedMustHave.length > 0) {
+    must_have = atomizedMustHave;
+  }
+
+  const atomizedNiceToHave = extractSkillPhrases(nice_to_have);
+  if (atomizedNiceToHave.length > 0) {
+    nice_to_have = atomizedNiceToHave;
   }
 
   return {

--- a/src/lib/ats/skill-match.ts
+++ b/src/lib/ats/skill-match.ts
@@ -60,8 +60,38 @@ export function skillMatchesResume(skill: string, resumeText: string): boolean {
   const matchedCount = skillTokens.filter((token) =>
     containsWholePhrase(normalizedResume, token)
   ).length;
-  const requiredMatches = Math.max(1, Math.ceil(skillTokens.length * 0.6));
+  const requiredMatches = Math.max(
+    1,
+    Math.ceil(skillTokens.length * KEYWORD_THRESHOLDS.match_classification_threshold),
+  );
   return matchedCount >= requiredMatches;
+}
+
+/** Fraction (0-1) of a skill phrase's significant tokens present in the resume. */
+export function skillCoverage(skill: string, resumeText: string): number {
+  const normalizedSkill = normalizeText(skill);
+  const normalizedResume = normalizeText(resumeText);
+
+  if (!normalizedSkill || !normalizedResume) {
+    return 0;
+  }
+
+  if (
+    normalizedSkill.length >= KEYWORD_THRESHOLDS.min_keyword_length &&
+    containsWholePhrase(normalizedResume, normalizedSkill)
+  ) {
+    return 1;
+  }
+
+  const tokens = significantTokens(skill);
+  if (tokens.length === 0) {
+    return 0;
+  }
+
+  const matched = tokens.filter((token) =>
+    containsWholePhrase(normalizedResume, token)
+  ).length;
+  return matched / tokens.length;
 }
 
 /**
@@ -92,5 +122,38 @@ export function scoreSkillListMatch(skills: string[], resumeText: string): {
     matched,
     missing,
     score: (matched.length / uniqueSkills.length) * 100,
+  };
+}
+
+/** Score a skill list by average token coverage; matched/missing keep a threshold. */
+export function scoreSkillCoverage(skills: string[], resumeText: string): {
+  matched: string[];
+  missing: string[];
+  score: number;
+} {
+  const uniqueSkills = [...new Set(skills.map((skill) => skill.trim()).filter(Boolean))];
+  if (uniqueSkills.length === 0) {
+    return { matched: [], missing: [], score: 50 };
+  }
+
+  const matched: string[] = [];
+  const missing: string[] = [];
+  let coverageSum = 0;
+
+  for (const skill of uniqueSkills) {
+    const coverage = skillCoverage(skill, resumeText);
+    coverageSum += coverage;
+
+    if (coverage >= KEYWORD_THRESHOLDS.match_classification_threshold) {
+      matched.push(skill);
+    } else {
+      missing.push(skill);
+    }
+  }
+
+  return {
+    matched,
+    missing,
+    score: (coverageSum / uniqueSkills.length) * 100,
   };
 }

--- a/tests/unit/ats-keyword-exact-coverage.test.ts
+++ b/tests/unit/ats-keyword-exact-coverage.test.ts
@@ -1,0 +1,58 @@
+import { KeywordExactAnalyzer } from '@/lib/ats/analyzers/keyword-exact';
+import { buildJobDataFromExtractedJson } from '@/lib/ats/job-data-resolver';
+import type { AnalyzerInput } from '@/lib/ats/types';
+
+const CAL = buildJobDataFromExtractedJson({
+  job_title: 'Business Development Manager',
+  company_name: 'Cal',
+  requirements: [
+    'Develop, build, and lead strategic partnerships while identifying opportunities for market expansion',
+    'Conduct market research and analyze industry trends, competitive landscapes, and customer behavior',
+    'Lead the identification and analysis of new business opportunities within the financial services sector',
+    'Manage negotiations and close commercial agreements with strategic partners',
+    'Lead cross-functional initiatives and support the execution of the growth strategy',
+    '2-3 years of experience in Business Development or Strategy Consulting',
+    'Experience working with senior executives and key stakeholders',
+    'Experience in the financial services industry and payments ecosystem',
+  ],
+});
+
+const SCALEOPS = buildJobDataFromExtractedJson({
+  job_title: 'Head of Partnerships',
+  company_name: 'ScaleOps',
+  requirements: [
+    'Strong understanding of public cloud, DevOps ecosystems, and subscription/SaaS business models',
+    'Experience structuring complex partnerships and co-selling motions',
+    'Deep knowledge of software channel and alliance business models',
+    'Demonstrated success building and scaling partner ecosystems globally',
+  ],
+});
+
+const OPTIMIZED_RESUME = `
+  Business Development Manager. Conducted market research and market analysis of
+  industry trends and competitive landscapes. Developed and led strategic
+  partnerships across the financial services and payments sector. Led negotiations
+  and closed commercial agreements with strategic partners. Drove cross-functional
+  growth initiatives. Worked with senior executives and key stakeholders.
+  HSBC Global Liquidity Management, Corporate Banking. Strategy consulting at EY.
+`;
+
+function inputFor(jobData: ReturnType<typeof buildJobDataFromExtractedJson>): AnalyzerInput {
+  return {
+    resume_text: OPTIMIZED_RESUME,
+    job_text: '',
+    job_data: jobData,
+  } as unknown as AnalyzerInput;
+}
+
+describe('keyword-exact end-to-end (atomized + proportional)', () => {
+  it('crosses the semantic-uncap threshold for a qualified, optimized candidate', async () => {
+    const res = await new KeywordExactAnalyzer().analyze(inputFor(CAL));
+    expect(res.score).toBeGreaterThan(40);
+  });
+
+  it('does NOT inflate a genuine domain mismatch (finance resume vs cloud role)', async () => {
+    const res = await new KeywordExactAnalyzer().analyze(inputFor(SCALEOPS));
+    expect(res.score).toBeLessThan(30);
+  });
+});

--- a/tests/unit/ats-prepare-input.test.ts
+++ b/tests/unit/ats-prepare-input.test.ts
@@ -71,8 +71,9 @@ describe('ats job-data resolver', () => {
 
     expect(jobData.must_have.length).toBeGreaterThan(0);
     expect(jobData.must_have).toEqual(
-      expect.arrayContaining(['5+ years B2B sales experience', 'CRM proficiency (Salesforce, HubSpot)']),
+      expect.arrayContaining(['b2b sales experience', 'crm proficiency salesforce']),
     );
+    expect(jobData.must_have.every((keyword) => keyword.split(' ').length <= 3)).toBe(true);
   });
 
   it('keeps explicit requirements without double-counting qualifications', () => {
@@ -82,7 +83,10 @@ describe('ats job-data resolver', () => {
     });
 
     const jobData = buildJobDataFromExtractedJson(withRequirements, cleanText);
-    expect(jobData.must_have).toEqual(['Existing requirement only']);
+    expect(jobData.must_have).toEqual(['requirement only']);
+    expect(jobData.must_have).not.toEqual(
+      expect.arrayContaining(['should not appear']),
+    );
   });
 
   it('normalizes parsed_data at scrape time', () => {

--- a/tests/unit/ats-skill-match.test.ts
+++ b/tests/unit/ats-skill-match.test.ts
@@ -1,4 +1,10 @@
-import { skillMatchesResume, scoreSkillListMatch } from '@/lib/ats/skill-match';
+import {
+  skillMatchesResume,
+  scoreSkillListMatch,
+  skillCoverage,
+  scoreSkillCoverage,
+} from '@/lib/ats/skill-match';
+import { buildJobDataFromExtractedJson } from '@/lib/ats/job-data-resolver';
 
 describe('skill-match', () => {
   const resumeText = `
@@ -46,5 +52,56 @@ describe('resolveAtsDisplay', () => {
 
     expect(resolved?.ats_score_original).toBe(0);
     expect(resolved?.ats_score_optimized).toBe(82);
+  });
+});
+
+describe('skill coverage (proportional)', () => {
+  const resume = `
+    OPYO, Business Development Manager, Partnerships.
+    Develop and nurture strategic partnerships across the financial ecosystem.
+  `;
+
+  it('returns 1 when every significant token is present', () => {
+    expect(skillCoverage('strategic partnerships', resume)).toBe(1);
+  });
+
+  it('returns a partial fraction, not 0, for partly-covered phrases', () => {
+    const c = skillCoverage('strategic partnerships financial ecosystem', resume);
+    expect(c).toBeGreaterThan(0.5);
+    expect(c).toBeLessThanOrEqual(1);
+  });
+
+  it('returns 0 when no significant token is present', () => {
+    expect(skillCoverage('kubernetes autoscaling', resume)).toBe(0);
+  });
+
+  it('scores a list by average coverage and labels matched/missing', () => {
+    const r = scoreSkillCoverage(['strategic partnerships', 'kubernetes autoscaling'], resume);
+    expect(r.score).toBeGreaterThan(40);
+    expect(r.score).toBeLessThan(60);
+    expect(r.matched).toEqual(['strategic partnerships']);
+    expect(r.missing).toEqual(['kubernetes autoscaling']);
+  });
+});
+
+describe('buildJobDataFromExtractedJson atomizes must_have', () => {
+  it('turns sentence requirements into short keyword phrases', () => {
+    const jd = buildJobDataFromExtractedJson({
+      job_title: 'Business Development Manager',
+      company_name: 'Cal',
+      requirements: [
+        'Conduct market research and analyze industry trends',
+        'Manage negotiations and close commercial agreements with strategic partners',
+        'Experience in the financial services industry and payments ecosystem',
+      ],
+    });
+
+    expect(jd.must_have.every((k) => k.split(' ').length <= 3)).toBe(true);
+    const lc = jd.must_have.map((k) => k.toLowerCase());
+    expect(lc.some((k) => k.includes('market research'))).toBe(true);
+    expect(lc.some((k) => k.includes('financial services'))).toBe(true);
+    expect(lc).not.toContain(
+      'conduct market research and analyze industry trends',
+    );
   });
 });

--- a/tests/unit/ats-skill-phrase-extractor.test.ts
+++ b/tests/unit/ats-skill-phrase-extractor.test.ts
@@ -1,0 +1,40 @@
+import { extractSkillPhrases } from '@/lib/ats/extractors/skill-phrase-extractor';
+
+const CAL_REQUIREMENTS = [
+  'Develop, build, and lead strategic partnerships while identifying opportunities for market expansion and entry into new markets',
+  'Conduct market research and analyze industry trends, competitive landscapes, and customer behavior',
+  'Lead the identification, evaluation, and analysis of new business opportunities within the financial services sector',
+  'Manage negotiations and close commercial agreements with strategic partners and potential key clients',
+  'Lead cross-functional initiatives and support the execution of the growth strategy',
+  '2-3 years of experience in Business Development, Strategy Consulting, or as a Commercial Lawyer',
+  'Experience working with senior executives and key stakeholders',
+  'Experience in the financial services industry and/or payments ecosystem',
+];
+
+describe('extractSkillPhrases', () => {
+  const phrases = extractSkillPhrases(CAL_REQUIREMENTS);
+  const lc = phrases.map((p) => p.toLowerCase());
+  const has = (needle: string) => lc.some((p) => p.includes(needle));
+
+  it('produces short keyword phrases, not whole sentences', () => {
+    expect(phrases.length).toBeGreaterThan(8);
+    expect(phrases.every((p) => p.split(' ').length <= 3)).toBe(true);
+  });
+
+  it('extracts the truthfully-addable BD/finance keywords', () => {
+    expect(has('market research')).toBe(true);
+    expect(has('strategic partnerships')).toBe(true);
+    expect(has('financial services')).toBe(true);
+    expect(has('negotiation')).toBe(true);
+    expect(has('business development')).toBe(true);
+    expect(has('stakeholders')).toBe(true);
+  });
+
+  it('drops leading action verbs and bare connectors', () => {
+    expect(lc).not.toContain('develop');
+    expect(lc).not.toContain('lead');
+    expect(lc).not.toContain('and');
+    expect(lc).not.toContain('the');
+    expect(lc).not.toContain('');
+  });
+});


### PR DESCRIPTION
## Summary
- add a domain-agnostic extractor that turns sentence-style requirements into short skill phrases
- atomize must_have/nice_to_have in buildJobDataFromExtractedJson so optimizer and scorer share the same keywords
- score keyword_exact with proportional token coverage while preserving matched/missing evidence labels
- add regression coverage for Cal BD requirements and ScaleOps mismatch guard

## Verification
- npx jest tests/unit/ats-skill-phrase-extractor.test.ts
- npx jest tests/unit/ats-skill-match.test.ts
- npx jest tests/unit/ats-keyword-exact-coverage.test.ts
- npx jest tests/unit
- npm run lint (0 errors, existing warnings only)
- npx tsc --noEmit (reports existing test-only errors; none in touched src/lib/ats files)