### PR TITLE
Add ATS per-keyword context suggestion APIs

### DIFF
--- a/src/app/api/v1/optimizations/[id]/route.ts
+++ b/src/app/api/v1/optimizations/[id]/route.ts
@@ -12,6 +12,8 @@ import { createRouteHandlerClient } from "@/lib/supabase-server";
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { scoreOptimization } from "@/lib/ats/integration";
+import { mapSuggestionsToBlockers } from "@/lib/ats/blocker-mapper";
+import type { Suggestion } from "@/lib/ats/types";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -149,7 +151,7 @@ export async function GET(
 
   const { data: row, error: rowErr } = await supabase
     .from("optimizations")
-    .select("rewrite_data, ats_score_original, ats_score_optimized, jd_id")
+    .select("rewrite_data, ats_score_original, ats_score_optimized, jd_id, ats_suggestions")
     .eq("id", id)
     .eq("user_id", user.id)
     .maybeSingle();
@@ -178,6 +180,8 @@ export async function GET(
     company = jd?.company ?? null;
   }
 
+  const blockers = mapSuggestionsToBlockers(row.ats_suggestions as Suggestion[] | null);
+
   return NextResponse.json({
     sections,
     contact,
@@ -188,6 +192,8 @@ export async function GET(
     ats_score_before: toIntPercent(row.ats_score_original),
     atsScoreAfter: toIntPercent(row.ats_score_optimized),
     ats_score_after: toIntPercent(row.ats_score_optimized),
+    atsBlockers: blockers,
+    ats_blockers: blockers,
   });
 }
 

--- a/src/app/api/v1/optimizations/[id]/suggestions/[suggestionId]/preview/route.ts
+++ b/src/app/api/v1/optimizations/[id]/suggestions/[suggestionId]/preview/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteHandlerClient } from "@/lib/supabase-server";
+import { generateAmendments } from "@/lib/ats/amendment-generator";
+import {
+  buildJobDataFromExtractedJson,
+  resolveJobDescriptionText,
+} from "@/lib/ats/job-data-resolver";
+import type { OptimizedResume } from "@/lib/ai-optimizer";
+import type { Suggestion } from "@/lib/ats/types";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; suggestionId: string }> },
+) {
+  const { id, suggestionId } = await params;
+  const decodedSuggestionId = decodeURIComponent(suggestionId);
+
+  const supabase = await createRouteHandlerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: row, error: rowErr } = await supabase
+    .from("optimizations")
+    .select("rewrite_data, ats_suggestions, jd_id")
+    .eq("id", id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (rowErr) {
+    return NextResponse.json({ error: rowErr.message }, { status: 500 });
+  }
+  if (!row) {
+    return NextResponse.json({ error: "Optimization not found" }, { status: 404 });
+  }
+
+  const suggestions = (row.ats_suggestions as Suggestion[] | null) || [];
+  const suggestion = suggestions.find((candidate) => candidate.id === decodedSuggestionId);
+  if (!suggestion) {
+    return NextResponse.json({ error: "Suggestion not found" }, { status: 404 });
+  }
+
+  const resumeContent = (row.rewrite_data as OptimizedResume | null) || null;
+  if (!resumeContent) {
+    return NextResponse.json({ error: "Resume content not found" }, { status: 404 });
+  }
+
+  let jobDescriptionText = "";
+  let jobData: ReturnType<typeof buildJobDataFromExtractedJson> | undefined;
+  if (row.jd_id) {
+    const { data: jdRow } = await supabase
+      .from("job_descriptions")
+      .select("raw_text, clean_text, parsed_data")
+      .eq("id", row.jd_id)
+      .maybeSingle();
+
+    if (jdRow) {
+      jobDescriptionText = resolveJobDescriptionText({
+        raw_text: jdRow.raw_text,
+        clean_text: jdRow.clean_text,
+        parsed_data: jdRow.parsed_data,
+      });
+      jobData = buildJobDataFromExtractedJson(jdRow.parsed_data, jobDescriptionText);
+    }
+  }
+
+  const result = await generateAmendments(suggestion, resumeContent, {
+    jobDescriptionText,
+    jobData,
+  });
+
+  if (!result.success) {
+    return NextResponse.json(
+      { error: result.error || "Failed to generate preview" },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({
+    suggestion_id: decodedSuggestionId,
+    affected_fields: result.affectedFields,
+  });
+}

--- a/src/lib/ats/__tests__/blocker-mapper.test.ts
+++ b/src/lib/ats/__tests__/blocker-mapper.test.ts
@@ -1,0 +1,55 @@
+import { mapSuggestionsToBlockers } from '../blocker-mapper';
+import type { Suggestion } from '../types';
+
+describe('mapSuggestionsToBlockers', () => {
+  it('maps a Suggestion into the iOS ATSOptimizationBlocker shape', () => {
+    const suggestions: Suggestion[] = [
+      {
+        id: 'keyword_exact:market-research',
+        text: 'Add "market research" in context',
+        estimated_gain: 6,
+        targets: ['keyword_exact'],
+        quick_win: true,
+        category: 'keywords',
+        action: {
+          type: 'add_keyword',
+          params: { keywords: ['market research'], target: 'experience', source: 'must_have' },
+        },
+      },
+    ];
+
+    const blockers = mapSuggestionsToBlockers(suggestions);
+
+    expect(blockers).toEqual([
+      {
+        id: 'keyword_exact:market-research',
+        category: 'keywords',
+        title: 'Add "market research" in context',
+        detail: 'Add "market research" in context',
+        suggested_action: 'Add "market research" in context',
+        estimated_gain: 6,
+        severity: 'medium',
+      },
+    ]);
+  });
+
+  it('derives severity from estimated_gain (>=10 high, >=5 medium, else low)', () => {
+    const make = (gain: number): Suggestion => ({
+      id: `s-${gain}`,
+      text: 'x',
+      estimated_gain: gain,
+      targets: ['keyword_exact'],
+      quick_win: false,
+      category: 'keywords',
+    });
+
+    const blockers = mapSuggestionsToBlockers([make(12), make(7), make(2)]);
+
+    expect(blockers.map((b) => b.severity)).toEqual(['high', 'medium', 'low']);
+  });
+
+  it('returns an empty array for an empty or undefined suggestion list', () => {
+    expect(mapSuggestionsToBlockers([])).toEqual([]);
+    expect(mapSuggestionsToBlockers(undefined)).toEqual([]);
+  });
+});

--- a/src/lib/ats/blocker-mapper.ts
+++ b/src/lib/ats/blocker-mapper.ts
@@ -1,0 +1,35 @@
+import type { Suggestion } from './types';
+
+export interface ATSBlockerDTO {
+  id: string;
+  category: string;
+  title: string;
+  detail: string;
+  suggested_action: string;
+  estimated_gain: number;
+  severity: 'high' | 'medium' | 'low';
+}
+
+function severityFromGain(gain: number): 'high' | 'medium' | 'low' {
+  if (gain >= 10) return 'high';
+  if (gain >= 5) return 'medium';
+  return 'low';
+}
+
+export function mapSuggestionsToBlockers(
+  suggestions: Suggestion[] | undefined | null,
+): ATSBlockerDTO[] {
+  if (!suggestions || suggestions.length === 0) {
+    return [];
+  }
+
+  return suggestions.map((suggestion) => ({
+    id: suggestion.id,
+    category: suggestion.category,
+    title: suggestion.text,
+    detail: suggestion.text,
+    suggested_action: suggestion.text,
+    estimated_gain: suggestion.estimated_gain,
+    severity: severityFromGain(suggestion.estimated_gain),
+  }));
+}

--- a/src/lib/ats/suggestions/__tests__/generator.test.ts
+++ b/src/lib/ats/suggestions/__tests__/generator.test.ts
@@ -1,0 +1,91 @@
+import { generateSuggestions } from '../generator';
+import type { AnalyzerResult, SubScores } from '../../types';
+
+const LOW_SUBSCORES: SubScores = {
+  keyword_exact: 30,
+  keyword_phrase: 70,
+  semantic_relevance: 70,
+  format_parseability: 90,
+  title_alignment: 80,
+  metrics_presence: 80,
+  section_completeness: 90,
+  recency_fit: 90,
+};
+
+function keywordAnalyzerResult(missing: string[]): AnalyzerResult {
+  return {
+    score: 30,
+    evidence: {
+      missing,
+      mustHaveTotal: missing.length * 2,
+      mustHaveMatched: missing.length,
+    },
+    confidence: 1,
+    warnings: [],
+  };
+}
+
+describe('generateSuggestions - keyword_exact fan-out', () => {
+  it('emits one suggestion per missing must-have keyword, not bundled duplicates', () => {
+    const suggestions = generateSuggestions({
+      subscores: LOW_SUBSCORES,
+      analyzerResults: new Map([
+        ['keyword_exact', keywordAnalyzerResult([
+          'market research',
+          'led negotiations',
+          'partnership strategy',
+        ])],
+      ]),
+      jobData: {
+        title: 'Head of Partnerships',
+        company: '',
+        must_have: ['market research', 'led negotiations', 'partnership strategy'],
+        nice_to_have: [],
+        responsibilities: [],
+        seniority: 'senior',
+        location: '',
+        industry: '',
+      },
+    });
+
+    const keywordSuggestions = suggestions.filter((s) => s.action?.type === 'add_keyword');
+
+    expect(keywordSuggestions).toHaveLength(3);
+    keywordSuggestions.forEach((suggestion) => {
+      expect(suggestion.action?.type).toBe('add_keyword');
+      if (suggestion.action?.type === 'add_keyword') {
+        expect(suggestion.action.params.keywords).toHaveLength(1);
+      }
+    });
+
+    const keywordTexts = keywordSuggestions.map((suggestion) =>
+      suggestion.action?.type === 'add_keyword' ? suggestion.action.params.keywords[0] : ''
+    );
+    expect(keywordTexts.sort()).toEqual(
+      ['led negotiations', 'market research', 'partnership strategy'].sort()
+    );
+  });
+
+  it('gives each split keyword suggestion a unique, stable id', () => {
+    const suggestions = generateSuggestions({
+      subscores: LOW_SUBSCORES,
+      analyzerResults: new Map([
+        ['keyword_exact', keywordAnalyzerResult(['market research', 'led negotiations'])],
+      ]),
+      jobData: {
+        title: 'Head of Partnerships',
+        company: '',
+        must_have: ['market research', 'led negotiations'],
+        nice_to_have: [],
+        responsibilities: [],
+        seniority: 'senior',
+        location: '',
+        industry: '',
+      },
+    });
+
+    const ids = suggestions.filter((s) => s.action?.type === 'add_keyword').map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    ids.forEach((id) => expect(id).toMatch(/^keyword_exact:/));
+  });
+});

--- a/src/lib/ats/suggestions/generator.ts
+++ b/src/lib/ats/suggestions/generator.ts
@@ -59,13 +59,16 @@ export function generateSuggestions(params: {
       );
 
       if (suggestion && suggestion.estimated_gain >= SUGGESTION_THRESHOLDS.min_gain) {
-        suggestions.push(suggestion);
+        suggestions.push(...expandKeywordSuggestion(suggestion));
       }
     }
   }
 
   // Rank and filter suggestions
-  return rankSuggestions(suggestions).slice(0, SUGGESTION_THRESHOLDS.max_suggestions);
+  return rankSuggestions(dedupeKeywordSuggestions(suggestions)).slice(
+    0,
+    SUGGESTION_THRESHOLDS.max_suggestions,
+  );
 }
 
 /**
@@ -142,6 +145,61 @@ function createSuggestion(
     console.error('Failed to create suggestion:', error);
     return null;
   }
+}
+
+function expandKeywordSuggestion(suggestion: Suggestion): Suggestion[] {
+  if (suggestion.action?.type !== 'add_keyword') {
+    return [suggestion];
+  }
+
+  const { keywords, target, source } = suggestion.action.params;
+  if (keywords.length <= 1) {
+    return [suggestion];
+  }
+
+  const gainPerKeyword = Math.max(1, Math.round(suggestion.estimated_gain / keywords.length));
+
+  return keywords.map((keyword) => ({
+    id: `keyword_exact:${slugifyKeyword(keyword)}`,
+    text: `Add "${keyword}" in context on your resume`,
+    estimated_gain: gainPerKeyword,
+    targets: suggestion.targets,
+    quick_win: suggestion.quick_win,
+    category: suggestion.category,
+    action: {
+      type: 'add_keyword' as const,
+      params: { keywords: [keyword], target, source },
+    },
+  }));
+}
+
+function dedupeKeywordSuggestions(suggestions: Suggestion[]): Suggestion[] {
+  const seenKeywords = new Set<string>();
+  const deduped: Suggestion[] = [];
+
+  for (const suggestion of suggestions) {
+    if (suggestion.action?.type !== 'add_keyword') {
+      deduped.push(suggestion);
+      continue;
+    }
+
+    const keyword = suggestion.action.params.keywords[0]?.trim().toLowerCase();
+    if (!keyword || seenKeywords.has(keyword)) {
+      continue;
+    }
+
+    seenKeywords.add(keyword);
+    deduped.push(suggestion);
+  }
+
+  return deduped;
+}
+
+function slugifyKeyword(keyword: string): string {
+  return keyword
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose persisted ATS suggestions as ats_blockers in optimization detail responses
- split bundled keyword_exact suggestions into one add_keyword suggestion per keyword
- add a preview endpoint for per-keyword in-context amendments using the existing amendment generator

## Verification
- npx jest src/lib/ats/__tests__/blocker-mapper.test.ts
- npx jest src/lib/ats/suggestions/__tests__/generator.test.ts
- npx jest src/lib/ats tests/unit
- npm run lint (0 errors, existing warnings only)
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ATS blockers to optimization details, highlighting areas for improvement.
  * Introduced suggestion preview functionality to show potential impact before applying changes.
  * Enhanced keyword suggestions to display individually for better clarity.

* **Tests**
  * Added comprehensive test coverage for suggestion mapping and keyword expansion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->