### PR TITLE
fix(expert-workflows): regenerate on schema-validation failure instead of 500

### DIFF
--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -10,6 +10,7 @@ import { buildScreeningAnswersPrompt } from './prompts/screening-answers';
 import { buildOutreachKitPrompt } from './prompts/outreach-kit';
 import { buildStoryBankPrompt } from './prompts/story-bank';
 import { safeJsonObjectParse, validateWorkflowOutput } from './validators';
+import type { WorkflowValidationResult } from './validators';
 import type {
   ApplicationExpertReport,
   ExpertAtsImpact,
@@ -275,6 +276,58 @@ async function runModelWithRetry(
   throw lastError || new Error('Unknown expert workflow model error.');
 }
 
+/**
+ * Number of full generate-then-validate attempts before giving up. LLMs occasionally
+ * return well-formed JSON that misses the strict schema (e.g. 2 cover-letter variants
+ * instead of exactly 3, or an out-of-enum suggested_placement). Regenerating with the
+ * validation error fed back almost always fixes it on the next pass.
+ */
+export const MAX_VALIDATION_ATTEMPTS = 3;
+
+/**
+ * Return a copy of the prompt with the schema-validation error appended to the user
+ * message so the model can self-correct on the retry attempt.
+ */
+export function withValidationCorrection(prompt: PromptBundle, error: string): PromptBundle {
+  return {
+    ...prompt,
+    user:
+      `${prompt.user}\n\nThe previous response failed schema validation with this error: ` +
+      `"${error}". Return a corrected JSON object that fully satisfies the required schema. ` +
+      `Output only the JSON object, with no commentary.`,
+  };
+}
+
+/**
+ * Generate model output and validate it against the workflow schema, regenerating with a
+ * corrective hint when validation fails. This makes the expert-workflow endpoints resilient
+ * to normal LLM output variance instead of returning a 500 on the first schema miss.
+ *
+ * The generator defaults to {@link runModelWithRetry} (which keeps its own network/timeout
+ * retry) and is injectable so the regeneration loop can be unit-tested without OpenAI.
+ */
+export async function generateValidatedOutput(
+  workflowType: ExpertWorkflowType,
+  prompt: PromptBundle,
+  generate: (p: PromptBundle) => Promise<Record<string, unknown>> = runModelWithRetry,
+  maxAttempts: number = MAX_VALIDATION_ATTEMPTS
+): Promise<{ output: Record<string, unknown>; validation: WorkflowValidationResult }> {
+  let lastError = 'Invalid expert workflow output.';
+  let attemptPrompt = prompt;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const output = await generate(attemptPrompt);
+    const validation = validateWorkflowOutput(workflowType, output);
+    if (validation.valid) {
+      return { output, validation };
+    }
+    lastError = validation.error || lastError;
+    attemptPrompt = withValidationCorrection(prompt, lastError);
+  }
+
+  throw new Error(lastError);
+}
+
 function extractArtifacts(
   workflowType: ExpertWorkflowType,
   output: Record<string, unknown>
@@ -353,12 +406,10 @@ export async function runExpertWorkflow(params: RunWorkflowParams): Promise<Expe
 
   const context = await loadWorkflowContext(params);
   const prompt = extractPromptBundle(context);
-  const parsed = await runModelWithRetry(prompt);
-  const validation = validateWorkflowOutput(context.workflow_type, parsed);
-
-  if (!validation.valid) {
-    throw new Error(validation.error || 'Invalid expert workflow output.');
-  }
+  const { output: parsed, validation } = await generateValidatedOutput(
+    context.workflow_type,
+    prompt
+  );
 
   const status = validation.missingEvidence.length > 0 ? 'needs_user_input' : 'completed';
 

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,9 @@
 # Project Progress
 
+## 2026-06-24 — Expert-workflows 500 on LLM variance fixed (submit pack + cover letter root cause)
+Founder reported submit pack "not working at all" and cover letter "not visible" in the iOS app. Root-caused to the backend: `runExpertWorkflow` (src/lib/expert-workflows/orchestrator.ts) validated model output AFTER the network-retry loop and threw on any schema miss → HTTP 500. Normal LLM output variance (e.g. 2 cover-letter variants instead of exactly 3, or an out-of-enum `suggested_placement`) intermittently 500s. iOS Submit Package requires the cover-letter workflow with no client retry, so one 500 kills the whole flow → no cover letter. Same class as the `suggested_placement is invalid` 500 seen live in the founder's device log.
+Fix (branch `fix/expert-workflows-validation-retry`): `generateValidatedOutput()` regenerates with the validation error fed back into the prompt, up to `MAX_VALIDATION_ATTEMPTS` (3), before failing. Generic across all workflow types — fixes cover-letter/submit-package AND the ATS-report path. Strict validation unchanged; only adds self-correcting retries. Generator injectable for unit tests. New `expert-workflow-validation-retry.test.ts` (5 tests) green; full expert-workflow suite 39/39; changed files lint-clean; pre-existing 23 tsc test-typing errors unaffected. **Awaiting founder approval to merge → auto-deploy to production**, then verify submit-pack/cover-letter end-to-end before the iOS build-6 submission.
+
 Project: ResumeBuilder AI (Web)
 Status: Active
 Current Phase: ATS scoring accuracy — both compounding causes from the 2026-06-21 diagnosis are resolved. PR #80 and PR #81 both merged to main. Story 2's metric-nudge follow-up is parked for a future build (founder decision 2026-06-21/22: leave metrics_presence as-is for now, plan the nudge feature via PM skill before building).

--- a/tests/contracts/expert-workflow-validation-retry.test.ts
+++ b/tests/contracts/expert-workflow-validation-retry.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  generateValidatedOutput,
+  withValidationCorrection,
+} from '@/lib/expert-workflows/orchestrator';
+import type { PromptBundle } from '@/lib/expert-workflows/types';
+
+const basePrompt: PromptBundle = {
+  system: 'system prompt',
+  user: 'generate the cover letter',
+  model: 'gpt-4o',
+  temperature: 0.25,
+  max_tokens: 100,
+};
+
+function reportEnvelope() {
+  return {
+    report: {
+      headline: 'headline',
+      executive_summary: 'summary',
+      priority_actions: [],
+      evidence_gaps: [],
+      ats_impact_estimate: { before: 50, after: 60 },
+    },
+  };
+}
+
+function coverLetterVariant() {
+  return {
+    angle: 'leadership',
+    title: 'Cover Letter',
+    opening_paragraph: 'Dear hiring manager,',
+    letter: 'Full letter body that is sufficiently long.',
+    rationale: 'Why this angle fits.',
+  };
+}
+
+function validCoverLetterOutput() {
+  return {
+    ...reportEnvelope(),
+    cover_letter_variants: [coverLetterVariant(), coverLetterVariant(), coverLetterVariant()],
+    recommended_index: 0,
+    recommended_reason: 'Best balance of fit and tone.',
+  };
+}
+
+// LLM variance: returns only 2 variants instead of the required exactly-3.
+function invalidCoverLetterOutput() {
+  return {
+    ...reportEnvelope(),
+    cover_letter_variants: [coverLetterVariant(), coverLetterVariant()],
+    recommended_index: 0,
+    recommended_reason: 'Best balance of fit and tone.',
+  };
+}
+
+describe('generateValidatedOutput — regenerates on schema-validation failure', () => {
+  it('retries when the first model output fails validation, then returns the valid output', async () => {
+    const generate = jest
+      .fn<(p: PromptBundle) => Promise<Record<string, unknown>>>()
+      .mockResolvedValueOnce(invalidCoverLetterOutput())
+      .mockResolvedValueOnce(validCoverLetterOutput());
+
+    const { output, validation } = await generateValidatedOutput(
+      'cover_letter_architect',
+      basePrompt,
+      generate
+    );
+
+    expect(validation.valid).toBe(true);
+    expect((output.cover_letter_variants as unknown[]).length).toBe(3);
+    expect(generate).toHaveBeenCalledTimes(2);
+  });
+
+  it('feeds the validation error back into the prompt on the retry attempt', async () => {
+    const generate = jest
+      .fn<(p: PromptBundle) => Promise<Record<string, unknown>>>()
+      .mockResolvedValueOnce(invalidCoverLetterOutput())
+      .mockResolvedValueOnce(validCoverLetterOutput());
+
+    await generateValidatedOutput('cover_letter_architect', basePrompt, generate);
+
+    const secondPrompt = generate.mock.calls[1][0];
+    expect(secondPrompt.user).toContain(basePrompt.user);
+    expect(secondPrompt.user).toContain('exactly 3 variants');
+  });
+
+  it('does not retry when the first output is already valid', async () => {
+    const generate = jest
+      .fn<(p: PromptBundle) => Promise<Record<string, unknown>>>()
+      .mockResolvedValueOnce(validCoverLetterOutput());
+
+    const { validation } = await generateValidatedOutput(
+      'cover_letter_architect',
+      basePrompt,
+      generate
+    );
+
+    expect(validation.valid).toBe(true);
+    expect(generate).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the last validation error after exhausting all attempts', async () => {
+    const generate = jest
+      .fn<(p: PromptBundle) => Promise<Record<string, unknown>>>()
+      .mockResolvedValue(invalidCoverLetterOutput());
+
+    await expect(
+      generateValidatedOutput('cover_letter_architect', basePrompt, generate, 3)
+    ).rejects.toThrow('exactly 3 variants');
+    expect(generate).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('withValidationCorrection', () => {
+  it('preserves the original prompt and appends the corrective error', () => {
+    const corrected = withValidationCorrection(basePrompt, 'cover_letter_variants must include exactly 3 variants');
+    expect(corrected.user).toContain(basePrompt.user);
+    expect(corrected.user).toContain('exactly 3 variants');
+    expect(corrected.system).toBe(basePrompt.system);
+    expect(corrected.model).toBe(basePrompt.model);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes the root cause behind **submit pack not working** and **cover letter not appearing** in the iOS app.

`runExpertWorkflow` validated the model output *after* the network-retry loop and threw on any schema miss, returning **HTTP 500** on normal LLM output variance (e.g. 2 cover-letter variants instead of exactly 3, or an out-of-enum `suggested_placement`). iOS Submit Package requires the cover-letter workflow and does not retry, so a single 500 kills the whole flow and no cover letter renders. This is the same class of failure as the `suggested_placement is invalid` 500 seen live in the founder's device log.

**Fix:** `generateValidatedOutput()` regenerates with the validation error fed back into the prompt, up to `MAX_VALIDATION_ATTEMPTS` (3), before failing. It is generic across all workflow types, so cover-letter/submit-package **and** the ATS-report path are both fixed. Strict validation is unchanged — this only adds self-correcting retries. The generator is injectable so the loop is unit-tested without OpenAI.

## Test plan
- [x] New `expert-workflow-validation-retry.test.ts` (5 tests) — red before, green after (TDD)
- [x] Full expert-workflow suite: **39/39 pass** (incl. run-route integration)
- [x] Changed files lint-clean
- [x] Pre-existing 23 tsc test-typing errors unaffected (verified on clean main)

## Deploy / verify
Production auto-deploys from `main`. After merge, verify end-to-end: run an optimization in the iOS app → Submit Package → confirm cover letter renders and `submit_package_saved` fires; confirm ATS-improve no longer 500s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)