### PR TITLE
fix(upload-resume): strip NUL bytes from extracted resume text

### DIFF
--- a/src/lib/markitdown-client.ts
+++ b/src/lib/markitdown-client.ts
@@ -7,6 +7,16 @@ export interface ConversionResult {
   char_count: number;
 }
 
+const NUL_BYTE_PATTERN = new RegExp(String.fromCharCode(0), "g");
+
+// Postgres `text` columns reject the NUL byte with "unsupported Unicode
+// escape sequence" (22P05). Some PDF encoders emit stray NUL bytes in
+// extracted text, which would otherwise crash the resumes insert with a
+// generic 500 well after parsing succeeded.
+export function sanitizeExtractedText(text: string): string {
+  return text.replace(NUL_BYTE_PATTERN, "").trim();
+}
+
 export async function convertResumeBuffer(
   fileBuffer: Buffer,
   fileName: string
@@ -15,13 +25,13 @@ export async function convertResumeBuffer(
 
   if (name.endsWith(".pdf")) {
     const data = await pdfParse(fileBuffer);
-    const markdown = data.text.trim();
+    const markdown = sanitizeExtractedText(data.text);
     return { markdown, format: "pdf", char_count: markdown.length };
   }
 
   if (name.endsWith(".docx")) {
     const result = await mammoth.extractRawText({ buffer: fileBuffer });
-    const markdown = result.value.trim();
+    const markdown = sanitizeExtractedText(result.value);
     return { markdown, format: "docx", char_count: markdown.length };
   }
 

--- a/tests/unit/markitdown-client.test.ts
+++ b/tests/unit/markitdown-client.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from '@jest/globals';
+import { sanitizeExtractedText } from '@/lib/markitdown-client';
+
+const NUL = String.fromCharCode(0);
+
+describe('sanitizeExtractedText', () => {
+  it('strips embedded NUL bytes', () => {
+    const input = `Jane Doe ${NUL}\nSenior Engineer${NUL}${NUL}`;
+    expect(sanitizeExtractedText(input).includes(NUL)).toBe(false);
+    expect(sanitizeExtractedText(input)).toBe('Jane Doe \nSenior Engineer');
+  });
+
+  it('leaves clean text untouched', () => {
+    const input = 'Jane Doe\nSenior Engineer';
+    expect(sanitizeExtractedText(input)).toBe(input);
+  });
+});


### PR DESCRIPTION
## Summary
- Root-caused the production 500 on `/api/upload-resume` ("Something went wrong. Please try again.") reported during an iOS smoke test today.
- Confirmed via production Postgres logs: the `resumes` insert failed with `22P05 unsupported Unicode escape sequence` (the NUL byte is not representable in a Postgres `text` column), while the parallel `job_descriptions` insert succeeded — exactly matching the symptom (3 failed attempts, 3 orphaned `job_descriptions` rows, 0 new `resumes` rows).
- Some PDF encoders emit a stray NUL byte in `pdf-parse`/`mammoth` output. `src/lib/markitdown-client.ts` now strips it (`sanitizeExtractedText`) right after extraction, before it ever reaches the database.

## Test plan
- [x] New unit test `tests/unit/markitdown-client.test.ts` (TDD red → green): strips embedded NUL bytes, leaves clean text untouched.
- [x] Full unit suite: 46/46 passing.
- [x] `npm run lint`: 0 errors (pre-existing warnings only, none in touched files).
- [x] `tsc --noEmit`: pre-existing test-typing errors only, none in touched files.
- [x] Reproduced the original failure end-to-end against production (Postgres logs + a live insert with an embedded NUL byte via the real account's RLS session), confirmed it matches `22P05`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume text cleanup by removing hidden NUL characters before trimming.
  * Ensured extracted text length is calculated from the cleaned content, helping avoid inaccurate counts.
* **Tests**
  * Added coverage for text sanitization to confirm NUL bytes are removed and normal text remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->