### PR TITLE
Fix metric fabrication in resume optimizer — eval now 100%

### DIFF
--- a/evals/resume-optimizer/BASELINE.md
+++ b/evals/resume-optimizer/BASELINE.md
@@ -36,12 +36,26 @@ With the harness corrected, the real finding surfaced cleanly:
   no real metric is available to draw from.
 - All other 6 cases: 0 fabrication, judge pass.
 
-## Remediation (not yet done — recommended next story)
+## Run 3 (2026-06-26, after production fix) — judgePassRate 100%, 0 critical
 
-Mirror the RunSmart Story 1b fix: don't trust the prompt alone for the
-fabrication-prone case (no source metric available). Either deterministically
-strip/flag invented percentages from `experience[].achievements` in
-`optimize-pipeline.ts` post-processing (parallel to RunSmart's
-`enforcePlanSafety`), or add a second self-check pass that rejects/regenerates
-when a generated metric has no traceable source. Re-run with `npm run
-eval:resume` after the fix and update this file.
+Fixed: `stripFabricatedMetrics()` added to `optimize-pipeline.ts`, applied to
+every candidate (gap-prompt path, fallback path, and pass 2) before scoring or
+returning. Mirrors RunSmart's `enforcePlanSafety` — deterministic enforcement,
+not prompt-only. It removes any `\d+%` figure in achievement bullets that
+doesn't exact-match a percentage already present in the original resume text,
+then collapses leftover dangling connector words ("by by", "by through") so
+the bullet still reads cleanly.
+
+Verified on `no-quantified-metrics`: the optimizer's invented "20%"/"15%" are
+now gone and the bullets read naturally ("Led a team to reduce ticket
+resolution time through process streamlining...", "Improved CSAT scores by
+training new hires..."). Judge: truthfulness 4, overallPass true, "No
+fabricated claims were found."
+
+Unit-tested directly in `tests/unit/optimize-pipeline.test.ts` (`describe('stripFabricatedMetrics')`,
+5 cases: fabricated removal, multiple fabrications, genuine metric preserved,
+no-percentage passthrough, percentage-only-bullet edge case).
+
+This baseline is now green at 100% / 0 critical. Re-run with `npm run
+eval:resume` after any future change to the pipeline or prompt, and update
+this file if the result changes.

--- a/src/lib/ai-optimizer/optimize-pipeline.ts
+++ b/src/lib/ai-optimizer/optimize-pipeline.ts
@@ -74,6 +74,63 @@ async function callOpenAIWithGapPrompt(
   }
 }
 
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const PERCENT_PATTERN = /\d+(?:\.\d+)?%/g;
+
+/**
+ * Deterministically removes any percentage figure in an achievement bullet
+ * that the model invented (i.e. does not appear anywhere in the candidate's
+ * original resume text). The system prompt already instructs "if no metric
+ * exists, keep impact statements non-numeric" — proven, by the eval harness
+ * (evals/resume-optimizer/, 2026-06-26), that gpt-4o violates this under
+ * pressure when the source resume has zero metrics to draw from. Mirrors
+ * RunSmart's enforcePlanSafety: enforce deterministically, don't trust the
+ * prompt alone for the fabrication-prone case.
+ */
+export function stripFabricatedMetrics(resume: OptimizedResume, originalResumeText: string): OptimizedResume {
+  const experience = (resume.experience ?? []).map((entry) => {
+    const achievements = (entry.achievements ?? []).map((bullet) => {
+      const percentages = [...new Set(bullet.match(PERCENT_PATTERN) ?? [])];
+      const fabricated = percentages.filter((pct) => !originalResumeText.includes(pct));
+      if (fabricated.length === 0) return bullet;
+
+      let cleaned = bullet;
+      for (const pct of fabricated) {
+        const escaped = escapeRegExp(pct);
+        cleaned = cleaned
+          // "by 20%", "to 20%"
+          .replace(new RegExp(`\\s*(?:by|to)\\s+${escaped}\\b`, 'gi'), '')
+          // "20% improvement/increase/reduction/growth/gain (in/to)"
+          .replace(new RegExp(`${escaped}\\s+(?:improvement|increase|reduction|growth|gain)\\s*(?:in|to)?`, 'gi'), '')
+          // leftover bare percentage
+          .replace(new RegExp(escaped, 'g'), '');
+      }
+      // Tidy artifacts left by removal: collapse adjacent duplicate/connector
+      // words ("by by", "by through" -> "through"), strip a connector word
+      // left dangling before punctuation, and collapse whitespace.
+      const CONNECTORS = '(?:by|to|through|via)';
+      let prevCleaned: string;
+      do {
+        prevCleaned = cleaned;
+        cleaned = cleaned
+          .replace(new RegExp(`\\b${CONNECTORS}\\s+${CONNECTORS}\\b`, 'gi'), (m) => m.split(/\s+/).pop() ?? m)
+          .replace(new RegExp(`\\s+${CONNECTORS}\\s*([.,;]|$)`, 'gi'), '$1');
+      } while (cleaned !== prevCleaned);
+      cleaned = cleaned
+        .replace(/\s{2,}/g, ' ')
+        .replace(/\s+([,.;])/g, '$1')
+        .trim();
+      return cleaned || bullet.replace(PERCENT_PATTERN, '').trim();
+    });
+    return { ...entry, achievements };
+  });
+
+  return { ...resume, experience };
+}
+
 function buildInitialGaps(resumeText: string, mustHave: string[]): ResumeOptimizationGaps {
   const resumeLower = resumeText.toLowerCase();
   const missingKeywords = mustHave.filter(term => {
@@ -161,6 +218,8 @@ export async function runOptimizePipeline(
     candidate1 = fallbackResult.optimizedResume;
   }
 
+  candidate1 = stripFabricatedMetrics(candidate1, resumeText);
+
   // Step 3: Score pass 1 candidate
   const score1 = await scoreOptimization({
     resumeOriginalText: resumeText,
@@ -193,16 +252,18 @@ export async function runOptimizePipeline(
   const candidate1Text = resumeJsonToText(candidate1);
   const gapPrompt2 = RESUME_OPTIMIZATION_GAP_PROMPT(candidate1Text, jobDescription, gaps2);
 
-  const candidate2: OptimizedResume | null = await callOpenAIWithGapPrompt(
+  const candidate2Raw: OptimizedResume | null = await callOpenAIWithGapPrompt(
     gapPrompt2,
     RESUME_OPTIMIZATION_SYSTEM_PROMPT,
     isHebrew
   );
 
-  if (!candidate2) {
+  if (!candidate2Raw) {
     console.warn('Pipeline pass 2 failed, keeping pass 1 candidate');
     return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1 };
   }
+
+  const candidate2 = stripFabricatedMetrics(candidate2Raw, resumeText);
 
   // Score pass 2 candidate
   const score2 = await scoreOptimization({

--- a/tests/unit/optimize-pipeline.test.ts
+++ b/tests/unit/optimize-pipeline.test.ts
@@ -61,7 +61,7 @@ jest.mock('@/lib/ats/extractors/jd-extractor', () => {
 // ---------------------------------------------------------------------------
 // Imports after mocks
 // ---------------------------------------------------------------------------
-import { runOptimizePipeline } from '@/lib/ai-optimizer/optimize-pipeline';
+import { runOptimizePipeline, stripFabricatedMetrics } from '@/lib/ai-optimizer/optimize-pipeline';
 import OpenAI from 'openai';
 import * as atsIntegration from '@/lib/ats/integration';
 import * as jdExtractorModule from '@/lib/ats/extractors/jd-extractor';
@@ -371,5 +371,68 @@ describe('normalizeATSScore — honest scoring', () => {
   // Test 2a: MIN_IMPROVEMENT constant must not exist in the ats module
   it('2a: does not export MIN_IMPROVEMENT (forced boost is gone)', () => {
     expect((atsModule as any).MIN_IMPROVEMENT).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Suite 3: stripFabricatedMetrics — the fix for the fabrication bug found by
+// evals/resume-optimizer (2026-06-26): gpt-4o invents percentages in
+// achievement bullets when the source resume has zero metrics, violating its
+// own system prompt's "keep impact non-numeric" instruction. This is the
+// deterministic guardrail (parallel to RunSmart's enforcePlanSafety) that
+// makes the safety guarantee real instead of prompt-only.
+// ---------------------------------------------------------------------------
+describe('stripFabricatedMetrics', () => {
+  const ORIGINAL_NO_METRICS = 'Led a team handling customer tickets. Trained new hires on support tools.';
+
+  it('removes a fabricated percentage not present in the original resume', () => {
+    const resume = makeResumeJson();
+    resume.experience[0].achievements = ['Led a team, reducing resolution time by 20% through process improvements.'];
+
+    const cleaned = stripFabricatedMetrics(resume, ORIGINAL_NO_METRICS);
+
+    expect(cleaned.experience[0].achievements[0]).not.toMatch(/20%/);
+  });
+
+  it('removes multiple fabricated percentages across achievements', () => {
+    const resume = makeResumeJson();
+    resume.experience[0].achievements = [
+      'Reduced resolution time by 20% through efficient process implementation.',
+      'Improved CSAT scores by 15% via better training.',
+    ];
+
+    const cleaned = stripFabricatedMetrics(resume, ORIGINAL_NO_METRICS);
+
+    const allText = cleaned.experience[0].achievements.join(' ');
+    expect(allText).not.toMatch(/20%/);
+    expect(allText).not.toMatch(/15%/);
+  });
+
+  it('leaves a percentage untouched when it is genuinely present in the original resume', () => {
+    const resume = makeResumeJson();
+    resume.experience[0].achievements = ['Led a migration, cutting page load time by 35%.'];
+    const original = 'Led migration of a legacy app to React, cutting page load time by 35%.';
+
+    const cleaned = stripFabricatedMetrics(resume, original);
+
+    expect(cleaned.experience[0].achievements[0]).toContain('35%');
+  });
+
+  it('leaves achievements with no percentages untouched', () => {
+    const resume = makeResumeJson();
+    resume.experience[0].achievements = ['Built systems used by the team.'];
+
+    const cleaned = stripFabricatedMetrics(resume, ORIGINAL_NO_METRICS);
+
+    expect(cleaned.experience[0].achievements[0]).toBe('Built systems used by the team.');
+  });
+
+  it('does not crash on an achievement that is ONLY a fabricated percentage', () => {
+    const resume = makeResumeJson();
+    resume.experience[0].achievements = ['40%'];
+
+    const cleaned = stripFabricatedMetrics(resume, ORIGINAL_NO_METRICS);
+
+    expect(cleaned.experience[0].achievements[0]).not.toMatch(/40%/);
   });
 });


### PR DESCRIPTION
Fixes the real finding from PR #91's eval baseline: the resume optimizer (`src/lib/ai-optimizer/optimize-pipeline.ts`) was 86% / 1 critical — it invented percentage metrics ("20% reduction", "15% improvement") when the candidate's source resume had zero numbers, violating its own system prompt's "keep impact non-numeric when no metric exists" instruction.

## What
`stripFabricatedMetrics(resume, originalResumeText)` — deterministic post-processing (mirrors RunSmart's `enforcePlanSafety`: enforce, don't trust the prompt alone):
- Removes any `\d+%` figure in achievement bullets that doesn't exact-match a percentage already present in the original resume text.
- Collapses leftover dangling connector words ("by by", "by through") so the bullet still reads cleanly — verified against the actual real-world fabricated text from the eval run, not just synthetic fixtures.
- Applied to **every** code path that can return a resume: the gap-prompt path, the `optimizeResume` fallback path, and pass 2 — before scoring or returning.

## Verified
- 5 new unit tests for `stripFabricatedMetrics` in `tests/unit/optimize-pipeline.test.ts` (fabricated removal, multiple fabrications, genuine metric preserved, no-percentage passthrough, edge case). **12/12 pass** (7 existing regression + 5 new).
- Typecheck clean, lint clean (0 new errors/warnings).
- **Live eval re-run against the real production pipeline**: 86% → **100% judge pass, 0 critical failures** across all 7 golden cases (`npm run eval:resume`).
- Spot-checked the previously-fabricating case's actual output: "Led a team to reduce ticket resolution time through process streamlining..." — no invented numbers, reads naturally.

`evals/resume-optimizer/BASELINE.md` updated with Run 3 (the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)