### PR TITLE
Add nightly/pre-release eval-resume GitHub Action

### DIFF
--- a/.github/workflows/eval-resume-nightly.yml
+++ b/.github/workflows/eval-resume-nightly.yml
@@ -1,0 +1,43 @@
+name: Resume-optimizer eval (nightly + pre-release)
+
+# Paid LM-judge eval for the resume optimizer.
+# Runs nightly and on-demand. Tag it as a required check on release branches to
+# make it a pre-release gate. Not run per-PR to control OpenAI token cost.
+
+on:
+  schedule:
+    # 02:30 UTC nightly
+    - cron: '30 2 * * *'
+  workflow_dispatch: {}
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  resume-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.13.0
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run resume-optimizer eval (LM-judge)
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: npm run eval:resume
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: resume-eval-report
+          path: evals/resume-optimizer/report.json
+          if-no-files-found: warn


### PR DESCRIPTION
Unblocks the nightly LM-judge eval gate for the resume optimizer, now that the `workflow` OAuth scope has been granted.

This file was written during the eval-harness work (PR #91) but couldn't be pushed at the time — the push token lacked the `workflow` scope required for files under `.github/workflows/`. Same content, reviewed at the time.

Mirrors RunSmart's plan-generator eval cadence: nightly (02:30 UTC) + on push to `release/**` branches, not per-PR, to control OpenAI token cost. Uploads `evals/resume-optimizer/report.json` as a build artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)