### PR TITLE
Fix stale resume-builder-ai/ reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Source of truth hierarchy:
 
 ## Development Commands
 
-Run from the `resume-builder-ai/` subdirectory (the actual Next.js app):
+Run from the repo root (the Next.js app lives at the repo root — there is no `resume-builder-ai/` subdirectory):
 
 ```bash
 npm run dev      # Start dev server at http://localhost:3000
@@ -67,24 +67,31 @@ AI Resume Optimizer — a Next.js application that analyzes resumes against job 
 ### Directory Structure
 
 ```
-resume-builder-ai/          ← run all commands from here
-└── src/
-    ├── app/                # Next.js App Router
-    │   ├── auth/           # Signin, signup pages
-    │   ├── dashboard/      # Main app
-    │   ├── layout.tsx
-    │   └── page.tsx        # Landing page
-    ├── components/
-    │   ├── auth/
-    │   ├── layout/
-    │   ├── providers/
-    │   └── ui/             # shadcn/ui components
-    ├── lib/
-    │   ├── constants.ts
-    │   ├── supabase.ts     # Browser Supabase client
-    │   ├── supabase-server.ts  # Server Supabase client
-    │   └── utils.ts
-    └── types/
+.                            ← repo root, run all commands from here
+├── src/
+│   ├── app/                # Next.js App Router
+│   │   ├── api/            # API routes
+│   │   ├── auth/           # Signin, signup pages
+│   │   ├── dashboard/      # Main app
+│   │   ├── layout.tsx
+│   │   └── page.tsx        # Landing page
+│   ├── components/
+│   │   ├── auth/
+│   │   ├── layout/
+│   │   ├── providers/
+│   │   └── ui/             # shadcn/ui components
+│   ├── lib/
+│   │   ├── ai-optimizer/   # Resume optimization pipeline (runOptimizePipeline)
+│   │   ├── ats/            # ATS scoring
+│   │   ├── prompts/        # AI prompts
+│   │   ├── constants.ts
+│   │   ├── supabase.ts     # Browser Supabase client
+│   │   ├── supabase-server.ts  # Server Supabase client
+│   │   └── utils.ts
+│   └── types/
+├── evals/resume-optimizer/  # LM-judge eval for the AI optimizer (npm run eval:resume)
+├── tests/                   # Jest unit/contract/api/agent tests
+└── .claude/agents/          # Subagents (architect, code-reviewer, qa-tdd, etc.)
 ```
 
 ### API Routes


### PR DESCRIPTION
Flagged during the subagent scaffolding work (PR #94) but left out of scope there. CLAUDE.md told Claude to run commands from a `resume-builder-ai/` subdirectory that doesn't exist — the app has always lived at the repo root in this checkout (`jest.config.js` already excludes that path as a stale duplicate-tree guard, which is how the discrepancy was first noticed).

Two fixes:
1. The "Development Commands" instruction now says repo root, explicitly noting the subdirectory doesn't exist.
2. The directory structure diagram is corrected to repo-root layout, and updated to include what was actually built today: `src/lib/ai-optimizer/`, `evals/resume-optimizer/`, `.claude/agents/`.

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development instructions to clarify commands should be run from the repository root.
  * Refreshed the project directory overview to match the current root-level layout and paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->