### PR TITLE
Fit-First: accept saved resume id in public ATS check

### DIFF
--- a/src/app/api/public/ats-check/route.ts
+++ b/src/app/api/public/ats-check/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { parsePdf } from '@/lib/pdf-parser';
 import { scoreResume } from '@/lib/ats';
 import type { ATSScoreInput, JobExtraction } from '@/lib/ats/types';
-import { createServiceRoleClient } from '@/lib/supabase-server';
+import { createRouteHandlerClient, createServiceRoleClient } from '@/lib/supabase-server';
 import { checkRateLimit } from '@/lib/rate-limiting/check-rate-limit';
 import { getClientIP } from '@/lib/rate-limiting/get-client-ip';
 import { hashContent } from '@/lib/utils/hash-content';
@@ -71,16 +71,10 @@ export async function POST(request: NextRequest) {
 
   const formData = await request.formData();
   const resumeFile = formData.get('resume');
+  const resumeIdRaw = formData.get('resumeId') ?? formData.get('resume_id');
   const jobDescriptionRaw = formData.get('jobDescription');
   const jobDescriptionUrlRaw = formData.get('jobDescriptionUrl');
-
-  if (!(resumeFile instanceof File)) {
-    return NextResponse.json({ error: 'Resume file is required.' }, { status: 400 });
-  }
-
-  if (resumeFile.size > MAX_FILE_SIZE) {
-    return NextResponse.json({ error: 'Resume file must be under 10MB.' }, { status: 400 });
-  }
+  const resumeId = typeof resumeIdRaw === 'string' ? resumeIdRaw.trim() : '';
 
   let jobDescription = typeof jobDescriptionRaw === 'string' ? jobDescriptionRaw.trim() : '';
   const jobDescriptionUrl = typeof jobDescriptionUrlRaw === 'string' ? jobDescriptionUrlRaw.trim() : '';
@@ -109,22 +103,61 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const fileBuffer = Buffer.from(await resumeFile.arrayBuffer());
-  if (!isPdfUpload(resumeFile, fileBuffer)) {
-    return NextResponse.json({ error: 'Only PDF resumes are supported.' }, { status: 400 });
-  }
+  let resumeText = '';
+  if (resumeId) {
+    const authSupabase = await createRouteHandlerClient(request);
+    const {
+      data: { user },
+      error: authError,
+    } = await authSupabase.auth.getUser();
 
-  let pdfData;
-  try {
-    pdfData = await parsePdf(fileBuffer);
-  } catch (error) {
-    console.error('PDF parse error:', error);
-    return NextResponse.json(
-      { error: 'We could not read your resume. Try exporting it as a text-based PDF.' },
-      { status: 400 }
-    );
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { data: resumeData, error: resumeError } = await authSupabase
+      .from('resumes')
+      .select('raw_text')
+      .eq('id', resumeId)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (resumeError) {
+      console.error('Resume lookup error:', resumeError);
+      return NextResponse.json({ error: 'Failed to load resume.' }, { status: 500 });
+    }
+
+    if (!resumeData) {
+      return NextResponse.json({ error: 'Resume not found.' }, { status: 404 });
+    }
+
+    resumeText = (resumeData as { raw_text?: string | null }).raw_text?.trim() || '';
+  } else {
+    if (!(resumeFile instanceof File)) {
+      return NextResponse.json({ error: 'Resume file is required.' }, { status: 400 });
+    }
+
+    if (resumeFile.size > MAX_FILE_SIZE) {
+      return NextResponse.json({ error: 'Resume file must be under 10MB.' }, { status: 400 });
+    }
+
+    const fileBuffer = Buffer.from(await resumeFile.arrayBuffer());
+    if (!isPdfUpload(resumeFile, fileBuffer)) {
+      return NextResponse.json({ error: 'Only PDF resumes are supported.' }, { status: 400 });
+    }
+
+    let pdfData;
+    try {
+      pdfData = await parsePdf(fileBuffer);
+    } catch (error) {
+      console.error('PDF parse error:', error);
+      return NextResponse.json(
+        { error: 'We could not read your resume. Try exporting it as a text-based PDF.' },
+        { status: 400 }
+      );
+    }
+    resumeText = pdfData?.text?.trim() || '';
   }
-  const resumeText = pdfData?.text?.trim();
 
   if (!resumeText) {
     return NextResponse.json(

--- a/tests/api/ats-check-resume-id-route.test.ts
+++ b/tests/api/ats-check-resume-id-route.test.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const longJobDescription = Array(24)
+  .fill('Senior product engineer role requiring SwiftUI, TypeScript, analytics, experimentation, collaboration, and shipped customer impact.')
+  .join(' ');
+
+function buildRequest(fields: Record<string, string>, file?: File) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    formData.append(key, value);
+  }
+  if (file) {
+    formData.append('resume', file);
+  }
+
+  return {
+    headers: {
+      get: (name: string) => (name.toLowerCase() === 'x-session-id' ? 'session-1' : null),
+    },
+    formData: async () => formData,
+  } as any;
+}
+
+function createAnonymousScoreStore() {
+  return {
+    from: jest.fn((table: string) => {
+      if (table !== 'anonymous_ats_scores') {
+        throw new Error(`Unexpected service-role table: ${table}`);
+      }
+
+      return {
+        select: jest.fn(() => ({
+          eq: jest.fn(() => ({
+            eq: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                gt: jest.fn(() => ({
+                  order: jest.fn(() => ({
+                    limit: jest.fn(() => ({
+                      maybeSingle: jest.fn(async () => ({ data: null, error: null })),
+                    })),
+                  })),
+                })),
+              })),
+            })),
+          })),
+        })),
+        insert: jest.fn(() => ({
+          select: jest.fn(() => ({
+            single: jest.fn(async () => ({
+              data: {
+                ats_score: 78,
+                created_at: '2026-06-28T00:00:00.000Z',
+                ats_suggestions: [],
+                ats_quick_wins: [],
+              },
+              error: null,
+            })),
+          })),
+        })),
+      };
+    }),
+  };
+}
+
+function createAuthClient({
+  user = { id: 'user-1' },
+  resumeData = { raw_text: 'Resume text with SwiftUI, TypeScript, analytics, and shipped impact.' },
+}: {
+  user?: { id: string } | null;
+  resumeData?: { raw_text: string } | null;
+}) {
+  const eq = jest.fn(function (...args: [string, string]) {
+    void args;
+    return query;
+  });
+  const maybeSingle = jest.fn(async () => ({ data: resumeData, error: null }));
+  const query = {
+    select: jest.fn(() => query),
+    eq,
+    maybeSingle,
+  };
+
+  return {
+    query,
+    client: {
+      auth: {
+        getUser: jest.fn(async () => ({ data: { user }, error: null })),
+      },
+      from: jest.fn((table: string) => {
+        if (table !== 'resumes') {
+          throw new Error(`Unexpected auth table: ${table}`);
+        }
+        return query;
+      }),
+    },
+  };
+}
+
+function loadRouteHarness(authClient: ReturnType<typeof createAuthClient>['client']) {
+  jest.resetModules();
+
+  const anonymousStore = createAnonymousScoreStore();
+  const createRouteHandlerClient = jest.fn(async () => authClient);
+  const createServiceRoleClient = jest.fn(() => anonymousStore);
+  const parsePdf = jest.fn(async () => ({ text: 'PDF resume text with SwiftUI and analytics.' }));
+  const isPdfUpload = jest.fn(() => true);
+  const scoreResume = jest.fn(async () => ({
+    ats_score_optimized: 78,
+    subscores: {},
+    suggestions: [],
+    quick_wins: [],
+  }));
+  const extractJob = jest.fn(async () => ({
+    job_title: 'Senior Product Engineer',
+    requirements: ['SwiftUI', 'TypeScript', 'analytics'],
+    nice_to_have: [],
+    responsibilities: [],
+  }));
+
+  jest.doMock('next/server', () => ({
+    __esModule: true,
+    NextResponse: class {
+      status: number;
+      private body: unknown;
+
+      constructor(body: unknown, init?: { status?: number }) {
+        this.body = body;
+        this.status = init?.status ?? 200;
+      }
+
+      static json(body: unknown, init?: { status?: number }) {
+        return new this(body, init);
+      }
+
+      async json() {
+        return this.body;
+      }
+    },
+  }));
+
+  jest.doMock('@/lib/supabase-server', () => ({
+    __esModule: true,
+    createRouteHandlerClient,
+    createServiceRoleClient,
+  }));
+  jest.doMock('@/lib/pdf-parser', () => ({ __esModule: true, parsePdf }));
+  jest.doMock('@/lib/utils/pdf-validation', () => ({ __esModule: true, isPdfUpload }));
+  jest.doMock('@/lib/ats', () => ({ __esModule: true, scoreResume }));
+  jest.doMock('@/lib/scraper/jobExtractor', () => ({
+    __esModule: true,
+    extractJob,
+  }));
+  jest.doMock('@/lib/rate-limiting/check-rate-limit', () => ({
+    __esModule: true,
+    checkRateLimit: jest.fn(async () => ({
+      allowed: true,
+      remaining: 4,
+      resetAt: new Date('2026-06-28T01:00:00.000Z'),
+    })),
+  }));
+  jest.doMock('@/lib/rate-limiting/get-client-ip', () => ({
+    __esModule: true,
+    getClientIP: jest.fn(() => '127.0.0.1'),
+  }));
+
+  const { POST } = require('@/app/api/public/ats-check/route');
+  return {
+    POST,
+    anonymousStore,
+    createRouteHandlerClient,
+    createServiceRoleClient,
+    parsePdf,
+    isPdfUpload,
+    scoreResume,
+  };
+}
+
+describe('POST /api/public/ats-check resumeId input', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('accepts an authenticated resumeId and skips PDF parsing', async () => {
+    const auth = createAuthClient({});
+    const { POST, parsePdf, isPdfUpload, scoreResume } = loadRouteHarness(auth.client);
+
+    const response = await POST(buildRequest({
+      resumeId: 'resume-1',
+      jobDescription: longJobDescription,
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.fit.verdict).toBe('Strong');
+    expect(parsePdf).not.toHaveBeenCalled();
+    expect(isPdfUpload).not.toHaveBeenCalled();
+    expect(auth.query.eq).toHaveBeenCalledWith('id', 'resume-1');
+    expect(auth.query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(scoreResume as any).toHaveBeenCalledWith(
+      (expect as any).objectContaining({
+        resume_original_text: (expect as any).stringContaining('SwiftUI'),
+        resume_optimized_text: (expect as any).stringContaining('SwiftUI'),
+        job_clean_text: longJobDescription,
+      }),
+      { generateQuickWins: true }
+    );
+  });
+
+  it('rejects resumeId without auth', async () => {
+    const auth = createAuthClient({ user: null });
+    const { POST, scoreResume } = loadRouteHarness(auth.client);
+
+    const response = await POST(buildRequest({
+      resumeId: 'resume-1',
+      jobDescription: longJobDescription,
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe('Unauthorized');
+    expect(scoreResume).not.toHaveBeenCalled();
+  });
+
+  it('rejects a resumeId that is not owned by the authenticated user', async () => {
+    const auth = createAuthClient({ resumeData: null });
+    const { POST, scoreResume } = loadRouteHarness(auth.client);
+
+    const response = await POST(buildRequest({
+      resumeId: 'other-user-resume',
+      jobDescription: longJobDescription,
+    }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(payload.error).toBe('Resume not found.');
+    expect(auth.query.eq).toHaveBeenCalledWith('id', 'other-user-resume');
+    expect(auth.query.eq).toHaveBeenCalledWith('user_id', 'user-1');
+    expect(scoreResume).not.toHaveBeenCalled();
+  });
+
+  it('keeps the existing anonymous PDF upload path working when resumeId is absent', async () => {
+    const auth = createAuthClient({});
+    const { POST, parsePdf, isPdfUpload, createRouteHandlerClient } = loadRouteHarness(auth.client);
+    const resumeFile = new File(['%PDF test'], 'resume.pdf', { type: 'application/pdf' });
+    Object.defineProperty(resumeFile, 'arrayBuffer', {
+      value: async () => Buffer.from('%PDF test').buffer,
+    });
+
+    const response = await POST(buildRequest(
+      { jobDescription: longJobDescription },
+      resumeFile
+    ));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.fit.verdict).toBe('Strong');
+    expect(createRouteHandlerClient).not.toHaveBeenCalled();
+    expect(isPdfUpload).toHaveBeenCalledTimes(1);
+    expect(parsePdf).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds authenticated `resumeId` / `resume_id` support to the existing `POST /api/public/ats-check` route.
- Keeps the anonymous PDF-upload path unchanged when no resume id is present.
- Adds focused route coverage for authenticated success, unauthenticated rejection, ownership filtering, and the legacy PDF path.

## Validation
- `npm test -- tests/api/ats-check-resume-id-route.test.ts --runInBand`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `git diff --check`
- `npx tsc --noEmit` still fails on pre-existing contract-test mock typing and env-export errors unrelated to this change.