### PR TITLE
fix: reset loading state on refine/apply-refinement failure

### DIFF
--- a/src/components/chat/ChatSidebar.tsx
+++ b/src/components/chat/ChatSidebar.tsx
@@ -162,32 +162,38 @@ export function ChatSidebar({
         const lower = message.trim().toLowerCase();
         // If user types an apply intent while a suggestion exists, apply it
         if (refineResult && (lower === 'apply' || lower === 'apply suggestion' || lower.startsWith('apply ') || lower.startsWith('amend') || lower.startsWith('update'))) {
-          setIsLoading(true);
-          const res = await applyRefinement({
-            optimizationId,
-            selection,
-            suggestion: refineResult,
-          });
-          setIsLoading(false);
-          if (!res.ok) {
-            throw new Error(res.reason || t('errors.applyRefinement'));
+          try {
+            setIsLoading(true);
+            const res = await applyRefinement({
+              optimizationId,
+              selection,
+              suggestion: refineResult,
+            });
+            if (!res.ok) {
+              throw new Error(res.reason || t('errors.applyRefinement'));
+            }
+            setRefineResult(null);
+            // Trigger refresh
+            if (onMessageSent) onMessageSent();
+          } finally {
+            setIsLoading(false);
           }
-          setRefineResult(null);
-          // Trigger refresh
-          if (onMessageSent) onMessageSent();
           return;
         }
 
-        setIsLoading(true);
-        setRefineResult(null);
-        const payload: RefineSectionRequest = {
-          resumeId: optimizationId,
-          selection,
-          instruction: message,
-        };
-        const result = await refineSection(payload);
-        setRefineResult(result.suggestion);
-        setIsLoading(false);
+        try {
+          setIsLoading(true);
+          setRefineResult(null);
+          const payload: RefineSectionRequest = {
+            resumeId: optimizationId,
+            selection,
+            instruction: message,
+          };
+          const result = await refineSection(payload);
+          setRefineResult(result.suggestion);
+        } finally {
+          setIsLoading(false);
+        }
         return;
       }
 


### PR DESCRIPTION
## Summary
- Fixes the "refine does nothing" bug: any text selection on the resume preview (even an accidental double-click) silently routes the next chat message into the refine-section flow instead of normal chat.
- If that refine or apply-refinement request then failed, `setIsLoading(false)` was never reached (no `finally`), leaving the chat input permanently disabled with no visible feedback.

## Fix
Wrap both the refine-section and apply-refinement branches of `handleSendMessage` in `src/components/chat/ChatSidebar.tsx` in `try/finally` so the loading state always resets on success or failure.

## Validation
- `npx eslint src/components/chat/ChatSidebar.tsx` — clean
- `npx tsc --noEmit --pretty false` — no new errors in this file

## Notes
Separately, refine's discoverability relies entirely on manually selecting resume text before typing an instruction (no dedicated button) — flagging as a possible follow-up UX improvement, not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message handling so loading states now reset reliably even if a refinement or apply action fails.
  * Made the chat sidebar more resilient when applying or refining section suggestions, reducing cases where the interface could get stuck loading.
  * After a successful apply action, the current suggestion is now cleared and the message send flow continues smoothly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->