### PR TITLE
Grandfather existing free users before monetization

### DIFF
--- a/docs/comms/legacy-user-grandfathering-announcement.md
+++ b/docs/comms/legacy-user-grandfathering-announcement.md
@@ -1,0 +1,36 @@
+# Legacy User Grandfathering Announcement (Draft — Do Not Send)
+
+> Status: Draft only. Sending requires explicit founder approval at ship time.
+> Replace `[DATE]` with the monetization cutoff date before use.
+
+---
+
+## In-App Banner / Modal
+
+**Headline:** Your free access stays the same
+
+**Body:**
+
+Resumely is introducing pricing for new users starting [DATE]. If you signed up before [DATE], your account keeps full free access — nothing changes for you. You can keep optimizing, exporting, and using every feature you use today at no cost. New users after [DATE] will see our updated pricing. Thank you for being an early Resumely user.
+
+**CTA:** Got it
+
+---
+
+## Email
+
+**Subject:** Your Resumely access isn't changing
+
+**Body:**
+
+Hi [First name],
+
+We're writing to let you know that Resumely is introducing pricing for new users starting [DATE].
+
+Because you signed up before [DATE], your account keeps full free access — nothing changes for you. You can keep optimizing resumes, running ATS checks, and exporting without any new limits or charges.
+
+New users who join after [DATE] will be on our updated pricing plan. We're grateful you were here early.
+
+If you have questions, reply to this email — we're happy to help.
+
+— The Resumely team

--- a/scripts/backfill-legacy-free-access.sql
+++ b/scripts/backfill-legacy-free-access.sql
@@ -1,0 +1,22 @@
+-- One-time backfill: grandfather existing users before monetization ships.
+-- Run at ship time only — NOT during development.
+--
+-- Usage:
+--   1. Replace <CUTOFF_TIMESTAMP> with the exact timestamptz when paywall goes live.
+--   2. Review the row count before committing.
+--   3. Run against production only with explicit founder approval.
+--
+-- Example cutoff: '2026-07-15 00:00:00+00'
+
+begin;
+
+update public.profiles
+set legacy_free_access = true,
+    updated_at = now()
+where created_at < '<CUTOFF_TIMESTAMP>'::timestamptz
+  and legacy_free_access = false;
+
+-- Verify:
+-- select count(*) from public.profiles where legacy_free_access = true;
+
+commit;

--- a/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
@@ -132,10 +132,12 @@ export default function OptimizationPage() {
 
         const { data: profile } = await supabase
           .from("profiles")
-          .select("plan_type")
+          .select("plan_type, legacy_free_access")
           .eq("user_id", authUser.id)
           .maybeSingle();
-        setIsPremium(profile?.plan_type === "premium");
+        setIsPremium(
+          profile?.plan_type === "premium" || profile?.legacy_free_access === true
+        );
       } catch (planError) {
         console.error("Failed to resolve premium status:", planError);
       }

--- a/src/app/api/v1/chat/route.ts
+++ b/src/app/api/v1/chat/route.ts
@@ -7,6 +7,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
+import { hasUnlimitedAccess } from '@/lib/entitlements';
 import { getActiveSession } from '@/lib/supabase/chat-sessions';
 import { processUnifiedMessage } from '@/lib/chat-manager/unified-processor';
 import type { ChatSendMessageRequest, ChatSendMessageResponse, ChatSession } from '@/types/chat';
@@ -168,18 +169,7 @@ function detectExpertWorkflowType(message: string): SurfacedExpertWorkflowType |
 }
 
 async function isPremiumUser(supabase: any, user: any): Promise<boolean> {
-  const metadata = user?.user_metadata || {};
-  if (metadata.is_premium === true || metadata.plan_type === 'premium') {
-    return true;
-  }
-
-  const { data } = await supabase
-    .from('profiles')
-    .select('plan_type')
-    .eq('user_id', user.id)
-    .maybeSingle();
-
-  return data?.plan_type === 'premium';
+  return hasUnlimitedAccess(supabase, user.id, user?.user_metadata);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/v1/expert-workflows/run/route.ts
+++ b/src/app/api/v1/expert-workflows/run/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
+import { hasUnlimitedAccess } from '@/lib/entitlements';
 import { captureServerEvent } from '@/lib/posthog-server';
 import { runExpertWorkflow } from '@/lib/expert-workflows/orchestrator';
 import {
@@ -27,18 +28,7 @@ function getLockedPreview(workflowType: SurfacedExpertWorkflowType) {
 }
 
 async function isPremiumUser(supabase: any, userId: string, user: any): Promise<boolean> {
-  const metadata = user?.user_metadata || {};
-  if (metadata.is_premium === true || metadata.plan_type === 'premium') {
-    return true;
-  }
-
-  const { data } = await supabase
-    .from('profiles')
-    .select('plan_type')
-    .eq('user_id', userId)
-    .maybeSingle();
-
-  return data?.plan_type === 'premium';
+  return hasUnlimitedAccess(supabase, userId, user?.user_metadata);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/lib/credits.ts
+++ b/src/lib/credits.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { hasLegacyFreeAccess } from '@/lib/entitlements';
 
 export type CreditConsumeResult =
   | { ok: true; remaining: number | null }
@@ -10,6 +11,11 @@ export async function consumeCredit(
   userId: string,
   reason: string
 ): Promise<CreditConsumeResult> {
+  if (await hasLegacyFreeAccess(supabase, userId)) {
+    const balance = await getCreditBalance(supabase, userId);
+    return { ok: true, remaining: balance };
+  }
+
   const { data, error } = await (supabase as any).rpc('consume_credit', {
     p_user_id: userId,
     p_reason: reason,

--- a/src/lib/entitlements.ts
+++ b/src/lib/entitlements.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type ProfileEntitlementRow = {
+  plan_type?: string | null;
+  legacy_free_access?: boolean | null;
+};
+
+/**
+ * Returns true when the user was grandfathered before monetization cutoff.
+ * Legacy users skip all paywall and credit enforcement unconditionally.
+ */
+export async function hasLegacyFreeAccess(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('legacy_free_access')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return false;
+  }
+
+  return (data as { legacy_free_access?: boolean }).legacy_free_access === true;
+}
+
+/**
+ * Returns true when paywall/credit checks should be skipped (premium or legacy grandfathered).
+ * Model-agnostic: works regardless of flat-fee vs credit pricing.
+ */
+export async function hasUnlimitedAccess(
+  supabase: SupabaseClient,
+  userId: string,
+  userMetadata?: Record<string, unknown> | null
+): Promise<boolean> {
+  if (userMetadata?.is_premium === true || userMetadata?.plan_type === 'premium') {
+    return true;
+  }
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('plan_type, legacy_free_access')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return false;
+  }
+
+  const profile = data as ProfileEntitlementRow;
+  return profile.plan_type === 'premium' || profile.legacy_free_access === true;
+}

--- a/src/lib/supabase/auth.ts
+++ b/src/lib/supabase/auth.ts
@@ -273,7 +273,10 @@ export async function requireSubscription(
   }
 
   if (tier === 'premium' && profile.plan_type !== 'premium') {
-    throw new Error('Premium subscription required')
+    const legacyFreeAccess = (profile as { legacy_free_access?: boolean }).legacy_free_access === true;
+    if (!legacyFreeAccess) {
+      throw new Error('Premium subscription required')
+    }
   }
 
   return profile

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -26,6 +26,8 @@ export interface Database {
           plan_type: 'free' | 'premium';
           optimizations_used: number;
           max_optimizations: number;
+          credit_balance: number;
+          legacy_free_access: boolean;
           created_at: string;
           updated_at: string;
         },
@@ -37,6 +39,8 @@ export interface Database {
           plan_type?: 'free' | 'premium';
           optimizations_used?: number;
           max_optimizations?: number;
+          credit_balance?: number;
+          legacy_free_access?: boolean;
           created_at?: string;
           updated_at?: string;
         },
@@ -48,6 +52,8 @@ export interface Database {
           plan_type?: 'free' | 'premium';
           optimizations_used?: number;
           max_optimizations?: number;
+          credit_balance?: number;
+          legacy_free_access?: boolean;
           created_at?: string;
           updated_at?: string;
         }

--- a/supabase/migrations/20260702000000_legacy_free_access.sql
+++ b/supabase/migrations/20260702000000_legacy_free_access.sql
@@ -1,0 +1,56 @@
+-- Grandfather existing free users before monetization (EXD-009 companion).
+-- Do not apply to production without explicit founder go-ahead.
+-- Backfill: run scripts/backfill-legacy-free-access.sql at ship time.
+
+alter table public.profiles
+  add column if not exists legacy_free_access boolean not null default false;
+
+comment on column public.profiles.legacy_free_access is
+  'When true, user keeps full free access regardless of paywall/credit enforcement. Set via one-time backfill for accounts created before monetization cutoff.';
+
+create or replace function public.consume_credit(
+  p_user_id uuid,
+  p_reason text default 'usage'
+)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_remaining integer;
+begin
+  insert into public.profiles (id, user_id, plan_type, optimizations_used, credit_balance)
+  values (gen_random_uuid(), p_user_id, 'free', 0, 3)
+  on conflict (user_id) do nothing;
+
+  -- Legacy grandfathered users: skip deduction, return current balance.
+  select credit_balance
+    into v_remaining
+  from public.profiles
+  where user_id = p_user_id
+    and legacy_free_access = true;
+
+  if found then
+    return v_remaining;
+  end if;
+
+  update public.profiles
+  set credit_balance = credit_balance - 1,
+      updated_at = now()
+  where user_id = p_user_id
+    and credit_balance > 0
+  returning credit_balance into v_remaining;
+
+  if not found then
+    return null;
+  end if;
+
+  insert into public.credit_transactions (user_id, delta, reason, source)
+  values (p_user_id, -1, coalesce(nullif(trim(p_reason), ''), 'usage'), 'usage');
+
+  return v_remaining;
+end;
+$$;
+
+grant execute on function public.consume_credit(uuid, text) to authenticated;

--- a/tests/unit/entitlements.test.ts
+++ b/tests/unit/entitlements.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { hasLegacyFreeAccess, hasUnlimitedAccess } from '@/lib/entitlements';
+import { consumeCredit } from '@/lib/credits';
+
+function createMockSupabase(profile: Record<string, unknown> | null, rpcResult?: unknown) {
+  const maybeSingle = jest.fn().mockResolvedValue({ data: profile, error: null });
+  const eq = jest.fn().mockReturnValue({ maybeSingle });
+  const select = jest.fn().mockReturnValue({ eq });
+  const from = jest.fn().mockReturnValue({ select });
+  const rpc = jest.fn().mockResolvedValue({ data: rpcResult, error: null });
+
+  return {
+    from,
+    rpc,
+    _maybeSingle: maybeSingle,
+  } as unknown as SupabaseClient;
+}
+
+describe('entitlements', () => {
+  describe('hasLegacyFreeAccess', () => {
+    it('returns true when legacy_free_access is true', async () => {
+      const supabase = createMockSupabase({ legacy_free_access: true });
+      await expect(hasLegacyFreeAccess(supabase, 'user-1')).resolves.toBe(true);
+    });
+
+    it('returns false when legacy_free_access is false', async () => {
+      const supabase = createMockSupabase({ legacy_free_access: false });
+      await expect(hasLegacyFreeAccess(supabase, 'user-1')).resolves.toBe(false);
+    });
+
+    it('returns false when profile is missing', async () => {
+      const supabase = createMockSupabase(null);
+      await expect(hasLegacyFreeAccess(supabase, 'user-1')).resolves.toBe(false);
+    });
+  });
+
+  describe('hasUnlimitedAccess', () => {
+    it('returns true for premium metadata without profile lookup', async () => {
+      const supabase = createMockSupabase(null);
+      await expect(
+        hasUnlimitedAccess(supabase, 'user-1', { plan_type: 'premium' })
+      ).resolves.toBe(true);
+      expect(supabase.from).not.toHaveBeenCalled();
+    });
+
+    it('returns true for legacy grandfathered profile', async () => {
+      const supabase = createMockSupabase({
+        plan_type: 'free',
+        legacy_free_access: true,
+      });
+      await expect(hasUnlimitedAccess(supabase, 'user-1')).resolves.toBe(true);
+    });
+
+    it('returns false for standard free profile', async () => {
+      const supabase = createMockSupabase({
+        plan_type: 'free',
+        legacy_free_access: false,
+      });
+      await expect(hasUnlimitedAccess(supabase, 'user-1')).resolves.toBe(false);
+    });
+  });
+});
+
+describe('consumeCredit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('skips RPC and does not deduct for legacy grandfathered users', async () => {
+    const supabase = createMockSupabase(
+      { legacy_free_access: true, credit_balance: 2 },
+      null
+    );
+
+    const result = await consumeCredit(supabase, 'user-legacy', 'ats_score');
+
+    expect(result).toEqual({ ok: true, remaining: 2 });
+    expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  it('calls consume_credit RPC for non-legacy users', async () => {
+    const supabase = createMockSupabase(
+      { legacy_free_access: false, credit_balance: 1 },
+      0
+    );
+
+    const result = await consumeCredit(supabase, 'user-new', 'ats_score');
+
+    expect(result).toEqual({ ok: true, remaining: 0 });
+    expect(supabase.rpc).toHaveBeenCalledWith('consume_credit', {
+      p_user_id: 'user-new',
+      p_reason: 'ats_score',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `profiles.legacy_free_access` column and updates `consume_credit` SQL to skip deductions for grandfathered users
- Introduces model-agnostic entitlement guards (`hasLegacyFreeAccess`, `hasUnlimitedAccess`) wired into credit consumption, expert workflows, chat, and dashboard premium checks
- Includes ship-time backfill script and draft comms announcement (not sent)

## Test plan
- [x] `npm run lint` passes (pre-existing warnings only)
- [x] `npm test -- tests/unit` — 59/59 passed (including 8 new entitlement tests)
- [ ] Migration NOT applied to production (schema change only, per work pack)
- [ ] Backfill script run at ship time with explicit founder approval

## Ship-time checklist
1. Set cutoff timestamp in `scripts/backfill-legacy-free-access.sql`
2. Apply migration `20260702000000_legacy_free_access.sql` to production
3. Run backfill script
4. Review and send `docs/comms/legacy-user-grandfathering-announcement.md`


Made with [Cursor](https://cursor.com)