### PR TITLE
WP-29 S2: Add EN funnel conversion messages

### DIFF
--- a/src/messages-overrides/funnel/en.json
+++ b/src/messages-overrides/funnel/en.json
@@ -142,7 +142,21 @@
       "lockedTitle": "Unlock {count} more high-impact fixes",
       "lockedDescription": "Create a free account to unlock the full action plan, editable examples, and one-click continuation.",
       "lockedCta": "Create Free Account",
-      "checkAnother": "Check another resume"
+      "checkAnother": "Check another resume",
+      "mainIssues": {
+        "title": "Your 3 highest-impact gaps",
+        "subtitle": "These are the biggest blockers for role fit, parsing, and recruiter clarity. Start here.",
+        "exampleLabel": "Example you can adapt",
+        "continueTitle": "Want the full fix plan?",
+        "continueDescription": "Create a free account to unlock every gap, tailored examples, and one-click improvements."
+      }
+    },
+    "popup": {
+      "title": "Want the full fix plan?",
+      "description": "Create a free account to unlock every issue, save your progress, and continue into full optimization.",
+      "primaryCta": "Create Free Account",
+      "secondaryCta": "Not now",
+      "privacyNote": "No spam. Unsubscribe anytime."
     }
   },
   "auth": {

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,26 @@
 # Project Progress
 
+## 2026-07-03 — WP-29 S2 missing EN funnel messages
+WP-29 S2 completed on branch `codex/wp29-s2-en-funnel-messages`.
+
+Completed:
+- Added EN funnel override copy for `landing.score.mainIssues.*` and `landing.popup.*` in `src/messages-overrides/funnel/en.json`.
+- Copy follows Fit/Match positioning: role fit, parsing, recruiter clarity, full fix plan. It does not use "ATS score", "pass ATS", "beat bots", or guaranteed-outcome framing.
+- Added `tests/contracts/funnel-i18n-parity.test.ts` so the critical funnel namespaces keep matching EN/HE leaf keys after runtime message merging.
+
+Validation:
+- `jq . src/messages-overrides/funnel/en.json` passed.
+- `npm test -- tests/contracts/funnel-i18n-parity.test.ts --runInBand` passed, 2/2 tests.
+- `npm run check:i18n` passed with 0 missing HE strings and 0 invalid strings.
+- `npx eslint tests/contracts/funnel-i18n-parity.test.ts` passed.
+- `git diff --check` passed.
+- `npm run lint` passed with existing warnings only.
+- `npm run build` passed.
+- `npx tsc --noEmit` still fails on pre-existing contract/security test typing and stale export errors, none in touched S2 files.
+
+Not done:
+- Did not start WP-29 S3.
+
 ## 2026-07-03 — WP-29 S1 optimization review crash guard
 WP-29 S1 completed on branch `codex/wp29-s1-optimization-review-crash`.
 
@@ -27,14 +48,14 @@ Fix (branch `fix/expert-workflows-validation-retry`): `generateValidatedOutput()
 
 Project: ResumeBuilder AI (Web)
 Status: Active
-Current Phase: WP-29 Resumely web funnel P0 fixes — S1 optimization review crash guard completed against current `origin/main`; S2 missing EN funnel messages is next.
-Active Story: WP-29 S2 — add missing EN funnel messages and locale key parity guard. Do not start S3 until S2 is implemented, verified, and reported.
-Last Completed Story: WP-29 S1 — optimization review route already wraps `DesignRenderer` and `ChatSidebar` in `SectionSelectionProvider`; added regression coverage proving the real consumers fail without the provider and render with it. Branch `codex/wp29-s1-optimization-review-crash`.
-Next Recommended Story: WP-29 S2 — create the EN sibling for `src/messages-overrides/funnel/he.json` keys (`landing.score.mainIssues.*`, `landing.popup.*`) using Fit/Match positioning, then add a key-parity guard so EN/HE funnel override keys cannot diverge again.
+Current Phase: WP-29 Resumely web funnel P0 fixes — S1 and S2 completed; S3 word-count/error-preservation is next.
+Active Story: WP-29 S3 — align word-count validation at 100 words, surface server errors verbatim, and preserve uploaded file/JD input on ats-check failure. Do not start S4 until S3 is implemented, verified, and reported.
+Last Completed Story: WP-29 S2 — added EN `landing.score.mainIssues.*` and `landing.popup.*` funnel copy, plus a focused EN/HE key-parity test for those critical namespaces. Branch `codex/wp29-s2-en-funnel-messages`.
+Next Recommended Story: WP-29 S3 — use a single 100-word minimum shared by the public ATS widget and API route, surface server `error` strings in the widget, and stop resetting input on check failures.
 Estimated Completion: Web is live; scoring-accuracy work is incremental
 Blockers: WP-29 S4 still needs a founder decision before implementation because the upgrade CTA touches the monetization gate. No blocker for S2.
 Risks: `npx tsc --noEmit` still has pre-existing test typing/export failures; keep reporting them separately from WP-29 regressions until cleaned up. Do not wire Stripe or open the monetization gate while fixing P0 funnel bugs.
-Last Validation: WP-29 S1 branch `codex/wp29-s1-optimization-review-crash` — focused regression 2/2 passed, targeted eslint passed, `git diff --check` passed, full `npm run lint` passed with existing warnings only, `npm run build` passed. `npx tsc --noEmit` still fails on pre-existing contract/security test typing and stale export errors, none in touched S1 files.
+Last Validation: WP-29 S2 branch `codex/wp29-s2-en-funnel-messages` — JSON parse passed, focused parity test 2/2 passed, `npm run check:i18n` passed, targeted eslint passed, `git diff --check` passed, full `npm run lint` passed with existing warnings only, `npm run build` passed. `npx tsc --noEmit` still fails on pre-existing contract/security test typing and stale export errors, none in touched S2 files.
 Last Updated: 2026-07-03
 Latest QA Report: tasks/2026-06-08-smoke-test-upload-backend.md (plan; execution pending)
 

--- a/tests/contracts/funnel-i18n-parity.test.ts
+++ b/tests/contracts/funnel-i18n-parity.test.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from '@jest/globals';
+
+type JsonObject = Record<string, unknown>;
+
+const ROOT = process.cwd();
+const CRITICAL_FUNNEL_PATHS = ['landing.score.mainIssues', 'landing.popup'];
+
+function readJson(relativePath: string): JsonObject {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, relativePath), 'utf8')) as JsonObject;
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeMessages(base: JsonObject, overrides: JsonObject): JsonObject {
+  const result: JsonObject = { ...base };
+
+  for (const [key, value] of Object.entries(overrides)) {
+    const current = result[key];
+    if (isPlainObject(value) && isPlainObject(current)) {
+      result[key] = mergeMessages(current, value);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function getAtPath(obj: JsonObject, dotPath: string): unknown {
+  return dotPath.split('.').reduce<unknown>((current, part) => {
+    if (!isPlainObject(current)) return undefined;
+    return current[part];
+  }, obj);
+}
+
+function collectLeafKeys(value: unknown, basePath = ''): string[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => collectLeafKeys(item, `${basePath}[${index}]`));
+  }
+
+  if (isPlainObject(value)) {
+    return Object.entries(value).flatMap(([key, child]) => {
+      const nextPath = basePath ? `${basePath}.${key}` : key;
+      return collectLeafKeys(child, nextPath);
+    });
+  }
+
+  return [basePath];
+}
+
+describe('funnel i18n critical namespace parity', () => {
+  it.each(CRITICAL_FUNNEL_PATHS)('%s has matching EN and HE leaf keys', (namespace) => {
+    const en = mergeMessages(
+      readJson('src/messages/en.json'),
+      readJson('src/messages-overrides/funnel/en.json')
+    );
+    const he = mergeMessages(
+      mergeMessages(en, readJson('src/messages/he.json')),
+      readJson('src/messages-overrides/funnel/he.json')
+    );
+
+    const enKeys = collectLeafKeys(getAtPath(en, namespace)).sort();
+    const heKeys = collectLeafKeys(getAtPath(he, namespace)).sort();
+
+    expect(enKeys).toEqual(heKeys);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds missing EN copy for `landing.score.mainIssues.*` and `landing.popup.*`.
- Keeps copy aligned to Fit/Match positioning: role fit, parsing, recruiter clarity, and full fix plan.
- Adds a focused runtime-message parity test so the critical EN/HE funnel namespaces cannot diverge again.
- Records S2 completion and S3 as next in `tasks/progress.md`.

## Validation
- `jq . src/messages-overrides/funnel/en.json` passed locally.
- `npm test -- tests/contracts/funnel-i18n-parity.test.ts --runInBand` passed locally.
- `npm run check:i18n` passed locally with 0 missing HE strings and 0 invalid strings.
- `npx eslint tests/contracts/funnel-i18n-parity.test.ts` passed locally.
- `git diff --check` passed locally.
- `npm run lint` passed locally with existing warnings only.
- `npm run build` passed locally.
- `npx tsc --noEmit` still fails locally on pre-existing contract/security test typing and stale export errors, none in touched S2 files.

## Notes
- Does not touch S3 word-count behavior or S4 monetization/upgrade CTA.