### PR TITLE
Carry anonymous ATS checks through signup

### DIFF
--- a/src/app/[locale]/dashboard/page.tsx
+++ b/src/app/[locale]/dashboard/page.tsx
@@ -9,9 +9,14 @@ import { Badge } from "@/components/ui/badge";
 import { Link } from "@/navigation";
 import { Upload, Palette, Briefcase, TrendingUp, Sparkles, CheckCircle } from "@/lib/icons";
 import { ROUTES } from "@/lib/constants";
-import { createClientComponentClient } from "@/lib/supabase";
 import { useTranslations } from "next-intl";
 import { posthog } from "@/lib/posthog";
+
+type ConvertedScore = {
+  ats_score: number;
+  ats_suggestions: unknown;
+  converted_at: string | null;
+};
 
 export default function DashboardPage() {
   const t = useTranslations("dashboard.home");
@@ -26,19 +31,13 @@ export default function DashboardPage() {
   useEffect(() => {
     if (!user) return;
 
-    const supabase = createClientComponentClient();
     const loadConvertedScore = async () => {
-      const { data } = await supabase
-        .from("anonymous_ats_scores")
-        .select("ats_score, ats_suggestions, converted_at")
-        .eq("user_id", user.id)
-        .not("converted_at", "is", null)
-        .order("converted_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
+      const response = await fetch("/api/public/convert-session");
+      if (!response.ok) return;
 
-      if (data) {
-        setConvertedScore(data);
+      const payload = await response.json();
+      if (payload?.scoreData) {
+        setConvertedScore(payload.scoreData as ConvertedScore);
       }
     };
 

--- a/src/app/api/public/convert-session/route.ts
+++ b/src/app/api/public/convert-session/route.ts
@@ -3,16 +3,68 @@ import { createRouteHandlerClient, createServiceRoleClient } from '@/lib/supabas
 
 export const runtime = 'nodejs';
 
-export async function POST(request: NextRequest) {
+type AnonymousAtsScoreRow = {
+  id: number;
+  session_id?: string | null;
+  ats_score: number;
+  ats_suggestions: unknown;
+  created_at: string;
+  converted_at?: string | null;
+};
+
+function serializeScoreData(score: AnonymousAtsScoreRow) {
+  return {
+    session_id: score.session_id,
+    ats_score: score.ats_score,
+    ats_suggestions: score.ats_suggestions,
+    converted_at: score.converted_at ?? null,
+    score: score.ats_score,
+    suggestions: score.ats_suggestions,
+  };
+}
+
+async function getAuthenticatedUser() {
   const supabase = await createRouteHandlerClient();
   const { data: { user } } = await supabase.auth.getUser();
 
   if (!user) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return { user: null, response: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) };
   }
 
+  return { user, response: null };
+}
+
+export async function GET() {
+  const { user, response } = await getAuthenticatedUser();
+  if (!user) return response;
+
+  const serviceRole = createServiceRoleClient();
+  const { data: convertedScore, error } = await serviceRole
+    .from('anonymous_ats_scores')
+    .select('id, session_id, ats_score, ats_suggestions, created_at, converted_at')
+    .eq('user_id', user.id)
+    .not('converted_at', 'is', null)
+    .order('converted_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    console.error('Converted session lookup error:', error);
+    return NextResponse.json({ error: 'Failed to load converted session.' }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    success: true,
+    scoreData: convertedScore ? serializeScoreData(convertedScore as AnonymousAtsScoreRow) : null,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  const { user, response } = await getAuthenticatedUser();
+  if (!user) return response;
+
   const body = await request.json().catch(() => null);
-  const sessionId = body?.sessionId as string | undefined;
+  const sessionId = typeof body?.sessionId === 'string' ? body.sessionId.trim() : '';
 
   if (!sessionId) {
     return NextResponse.json({ error: 'Session ID is required.' }, { status: 400 });
@@ -21,7 +73,7 @@ export async function POST(request: NextRequest) {
   const serviceRole = createServiceRoleClient();
   const { data: anonScore, error: lookupError } = await serviceRole
     .from('anonymous_ats_scores')
-    .select('id, ats_score, ats_suggestions, created_at')
+    .select('id, session_id, ats_score, ats_suggestions, created_at, converted_at')
     .eq('session_id', sessionId)
     .is('user_id', null)
     .order('created_at', { ascending: false })
@@ -34,14 +86,38 @@ export async function POST(request: NextRequest) {
   }
 
   if (!anonScore) {
+    const { data: convertedScore, error: convertedLookupError } = await serviceRole
+      .from('anonymous_ats_scores')
+      .select('id, session_id, ats_score, ats_suggestions, created_at, converted_at')
+      .eq('session_id', sessionId)
+      .eq('user_id', user.id)
+      .not('converted_at', 'is', null)
+      .order('converted_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (convertedLookupError) {
+      console.error('Converted session lookup error:', convertedLookupError);
+      return NextResponse.json({ error: 'Failed to find session.' }, { status: 500 });
+    }
+
+    if (convertedScore) {
+      return NextResponse.json({
+        success: true,
+        alreadyConverted: true,
+        scoreData: serializeScoreData(convertedScore as AnonymousAtsScoreRow),
+      });
+    }
+
     return NextResponse.json({ error: 'Session not found.' }, { status: 404 });
   }
 
+  const convertedAt = new Date().toISOString();
   const { error: updateError } = await serviceRole
     .from('anonymous_ats_scores')
     .update({
       user_id: user.id,
-      converted_at: new Date().toISOString(),
+      converted_at: convertedAt,
     })
     .eq('id', anonScore.id);
 
@@ -52,9 +128,9 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({
     success: true,
-    scoreData: {
-      score: anonScore.ats_score,
-      suggestions: anonScore.ats_suggestions,
-    },
+    scoreData: serializeScoreData({
+      ...(anonScore as AnonymousAtsScoreRow),
+      converted_at: convertedAt,
+    }),
   });
 }

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -17,6 +17,40 @@ interface AuthFormProps {
   mode: "signin" | "signup";
 }
 
+const ATS_SESSION_STORAGE_KEY = "ats_session_id";
+
+function getSafeRelativePath(value: string | null) {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) {
+    return null;
+  }
+  return value;
+}
+
+async function convertPendingAtsSession(sessionId: string | null, accessToken?: string | null) {
+  if (!sessionId) return;
+
+  try {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    if (accessToken) {
+      headers.Authorization = `Bearer ${accessToken}`;
+    }
+
+    const response = await fetch("/api/public/convert-session", {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ sessionId }),
+    });
+
+    if (!response.ok) {
+      console.error("Anonymous ATS session conversion failed:", await response.text());
+    }
+  } catch (conversionError) {
+    console.error("Anonymous ATS session conversion error:", conversionError);
+  }
+}
+
 export function AuthForm({ mode }: AuthFormProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -57,15 +91,21 @@ export function AuthForm({ mode }: AuthFormProps) {
         // Get the current origin for the redirect URL
         const origin = typeof window !== 'undefined' ? window.location.origin : '';
         const localePrefix = locale === defaultLocale ? '' : `/${locale}`;
+        const querySessionId = searchParams.get("session_id")?.trim() || null;
         const storedSessionId = typeof window !== 'undefined'
-          ? localStorage.getItem('ats_session_id')
+          ? localStorage.getItem(ATS_SESSION_STORAGE_KEY)
           : null;
-        const nextParam = searchParams.get("next");
-        const callbackQuery = new URLSearchParams();
-        if (storedSessionId) {
-          callbackQuery.set("session_id", storedSessionId);
+        const pendingSessionId = querySessionId ?? storedSessionId;
+        if (querySessionId && typeof window !== 'undefined') {
+          localStorage.setItem(ATS_SESSION_STORAGE_KEY, querySessionId);
         }
-        if (nextParam && nextParam.startsWith("/")) {
+
+        const nextParam = getSafeRelativePath(searchParams.get("next"));
+        const callbackQuery = new URLSearchParams();
+        if (pendingSessionId) {
+          callbackQuery.set("session_id", pendingSessionId);
+        }
+        if (nextParam) {
           callbackQuery.set("next", nextParam);
         }
         const callbackPath = `${localePrefix}/auth/callback`;
@@ -113,7 +153,8 @@ export function AuthForm({ mode }: AuthFormProps) {
             ...utmParams,
           });
 
-          router.push(ROUTES.dashboard);
+          await convertPendingAtsSession(pendingSessionId, data.session?.access_token);
+          router.push(nextParam ?? ROUTES.dashboard);
         }
       } else {
         const { data, error } = await supabase.auth.signInWithPassword({

--- a/src/components/landing/FreeATSChecker.tsx
+++ b/src/components/landing/FreeATSChecker.tsx
@@ -10,6 +10,7 @@ import { LoadingState } from "@/components/landing/LoadingState";
 import { ATSScoreDisplay } from "@/components/landing/ATSScoreDisplay";
 import { RateLimitMessage } from "@/components/landing/RateLimitMessage";
 import { Badge } from "@/components/ui/badge";
+import { ROUTES } from "@/lib/constants";
 import type { SuggestionAction } from "@/lib/ats/types";
 
 const SESSION_KEY = "ats_session_id";
@@ -179,6 +180,8 @@ export function FreeATSChecker() {
   };
 
   const handleSignup = () => {
+    const activeSessionId = scoreData?.sessionId ?? sessionId;
+
     if (scoreData) {
       posthog.capture("ats_checker_signup_clicked", {
         score: scoreData.score.overall,
@@ -186,7 +189,14 @@ export function FreeATSChecker() {
       });
     }
 
-    router.push("/auth/signup");
+    const signupParams = new URLSearchParams({
+      next: ROUTES.dashboard,
+    });
+    if (activeSessionId) {
+      signupParams.set("session_id", activeSessionId);
+    }
+
+    router.push(`/auth/signup?${signupParams.toString()}`);
   };
 
   const handleBackToChecker = () => {

--- a/tests/api/convert-session-route.test.ts
+++ b/tests/api/convert-session-route.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+type ScoreRow = {
+  id: number;
+  session_id: string;
+  user_id: string | null;
+  ats_score: number;
+  ats_suggestions: unknown[];
+  created_at: string;
+  converted_at: string | null;
+};
+
+function makeRequest(body: unknown) {
+  return {
+    json: async () => body,
+  } as any;
+}
+
+function createServiceRoleStore(rows: ScoreRow[]) {
+  return {
+    rows,
+    updates: [] as Array<{ id: number; values: Partial<ScoreRow> }>,
+    from: jest.fn((table: string) => {
+      if (table !== 'anonymous_ats_scores') {
+        throw new Error(`Unexpected table: ${table}`);
+      }
+
+      const buildQuery = () => {
+        const filters: Array<(row: ScoreRow) => boolean> = [];
+        const query = {
+          select: jest.fn(() => query),
+          eq: jest.fn((column: keyof ScoreRow, value: unknown) => {
+            filters.push((row) => row[column] === value);
+            return query;
+          }),
+          is: jest.fn((column: keyof ScoreRow, value: unknown) => {
+            filters.push((row) => row[column] === value);
+            return query;
+          }),
+          not: jest.fn((column: keyof ScoreRow, operator: string, value: unknown) => {
+            if (operator === 'is') {
+              filters.push((row) => row[column] !== value);
+            }
+            return query;
+          }),
+          order: jest.fn((column: keyof ScoreRow, options: { ascending: boolean }) => {
+            rows.sort((a, b) => {
+              const left = String(a[column] ?? '');
+              const right = String(b[column] ?? '');
+              return options.ascending ? left.localeCompare(right) : right.localeCompare(left);
+            });
+            return query;
+          }),
+          limit: jest.fn(() => query),
+          maybeSingle: jest.fn(async () => ({
+            data: rows.find((row) => filters.every((filter) => filter(row))) ?? null,
+            error: null,
+          })),
+        };
+        return query;
+      };
+
+      return {
+        select: jest.fn(() => buildQuery()),
+        update: jest.fn((values: Partial<ScoreRow>) => ({
+          eq: jest.fn(async (column: keyof ScoreRow, value: unknown) => {
+            const row = rows.find((candidate) => candidate[column] === value);
+            if (row) {
+              Object.assign(row, values);
+              store.updates.push({ id: row.id, values });
+            }
+            return { error: null };
+          }),
+        })),
+      };
+    }),
+  };
+}
+
+let store: ReturnType<typeof createServiceRoleStore>;
+let authUser: { id: string } | null;
+
+function loadRoute(rows: ScoreRow[]) {
+  jest.resetModules();
+  store = createServiceRoleStore(rows);
+  authUser = { id: 'user-1' };
+
+  jest.doMock('next/server', () => ({
+    __esModule: true,
+    NextResponse: class {
+      status: number;
+      private body: unknown;
+
+      constructor(body: unknown, init?: { status?: number }) {
+        this.body = body;
+        this.status = init?.status ?? 200;
+      }
+
+      static json(body: unknown, init?: { status?: number }) {
+        return new this(body, init);
+      }
+
+      async json() {
+        return this.body;
+      }
+    },
+  }));
+
+  jest.doMock('@/lib/supabase-server', () => ({
+    __esModule: true,
+    createRouteHandlerClient: jest.fn(async () => ({
+      auth: {
+        getUser: jest.fn(async () => ({ data: { user: authUser }, error: null })),
+      },
+    })),
+    createServiceRoleClient: jest.fn(() => store),
+  }));
+
+  return require('@/app/api/public/convert-session/route');
+}
+
+describe('/api/public/convert-session', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('attaches an unclaimed anonymous score to the signed-in user', async () => {
+    const { POST } = loadRoute([
+      {
+        id: 1,
+        session_id: 'session-1',
+        user_id: null,
+        ats_score: 43,
+        ats_suggestions: [{ text: 'Add impact metrics' }],
+        created_at: '2026-07-03T09:00:00.000Z',
+        converted_at: null,
+      },
+    ]);
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(store.rows[0].user_id).toBe('user-1');
+    expect(store.rows[0].converted_at).toEqual(expect.any(String));
+    expect(payload.scoreData.ats_score).toBe(43);
+    expect(payload.scoreData.score).toBe(43);
+  });
+
+  it('returns an already converted score without failing the signup flow', async () => {
+    const { POST } = loadRoute([
+      {
+        id: 2,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        ats_score: 43,
+        ats_suggestions: [],
+        created_at: '2026-07-03T09:00:00.000Z',
+        converted_at: '2026-07-03T09:01:00.000Z',
+      },
+    ]);
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.alreadyConverted).toBe(true);
+    expect(payload.scoreData.ats_score).toBe(43);
+    expect(store.updates).toHaveLength(0);
+  });
+
+  it('loads the latest converted score for the dashboard', async () => {
+    const { GET } = loadRoute([
+      {
+        id: 2,
+        session_id: 'session-1',
+        user_id: 'user-1',
+        ats_score: 43,
+        ats_suggestions: [],
+        created_at: '2026-07-03T09:00:00.000Z',
+        converted_at: '2026-07-03T09:01:00.000Z',
+      },
+    ]);
+
+    const response = await GET();
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.scoreData.ats_score).toBe(43);
+  });
+
+  it('rejects conversion when no user is signed in', async () => {
+    const { POST } = loadRoute([]);
+    authUser = null;
+
+    const response = await POST(makeRequest({ sessionId: 'session-1' }));
+    const payload = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(payload.error).toBe('Unauthorized');
+  });
+});

--- a/tests/app/auth-form-session-handoff.test.tsx
+++ b/tests/app/auth-form-session-handoff.test.tsx
@@ -1,0 +1,153 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const push = jest.fn();
+const signUp = jest.fn();
+let searchParams = new URLSearchParams();
+
+const translations: Record<string, string> = {
+  'auth.form.title.signup': 'Create your account',
+  'auth.form.subtitle.signup': 'Save your ATS checks and continue with full optimization',
+  'auth.form.labels.fullName': 'Full name',
+  'auth.form.labels.email': 'Email',
+  'auth.form.labels.password': 'Password',
+  'auth.form.placeholders.fullName': 'Nadav Yigal',
+  'auth.form.placeholders.email': 'you@example.com',
+  'auth.form.buttons.createAccount': 'Create account',
+  'auth.form.processing': 'Creating account',
+  'auth.form.switchPrompt.hasAccount': 'Already have an account?',
+  'auth.form.switchButtons.signIn': 'Sign in',
+  'auth.form.errorGeneric': 'Something went wrong',
+};
+
+function t(namespace?: string) {
+  return (key: string) => translations[namespace ? `${namespace}.${key}` : key] ?? key;
+}
+
+function changeValue(element: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(element, value);
+  element.dispatchEvent(new Event('input', { bubbles: true }));
+  element.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+async function flushReact() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  useSearchParams: () => searchParams,
+}));
+
+jest.mock('next-intl', () => ({
+  __esModule: true,
+  useLocale: () => 'en',
+  useTranslations: (namespace?: string) => t(namespace),
+}));
+
+jest.mock('@/navigation', () => ({
+  __esModule: true,
+  Link: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>{children}</a>
+  ),
+  useRouter: () => ({ push }),
+}));
+
+jest.mock('@/lib/posthog', () => ({
+  __esModule: true,
+  posthog: {
+    alias: jest.fn(),
+    capture: jest.fn(),
+    identify: jest.fn(),
+  },
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  __esModule: true,
+  createClientComponentClient: () => ({
+    auth: { signUp },
+  }),
+}));
+
+describe('AuthForm anonymous ATS session handoff', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    push.mockClear();
+    signUp.mockReset();
+    searchParams = new URLSearchParams('session_id=session-1&next=/dashboard');
+    window.localStorage.clear();
+    global.fetch = jest.fn(async () => ({
+      ok: true,
+      text: async () => '',
+    } as Response)) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    jest.restoreAllMocks();
+  });
+
+  it('passes the anonymous session through email callback and converts it for immediate signups', async () => {
+    (signUp as any).mockResolvedValue({
+      data: {
+        user: {
+          id: 'user-1',
+          email: 'nadav@example.com',
+          created_at: '2026-07-03T09:00:00.000Z',
+          email_confirmed_at: '2026-07-03T09:00:00.000Z',
+        },
+        session: {
+          access_token: 'access-token-1',
+        },
+      },
+      error: null,
+    });
+
+    const { AuthForm } = require('@/components/auth/auth-form');
+    await act(async () => {
+      root.render(<AuthForm mode="signup" />);
+    });
+
+    await act(async () => {
+      changeValue(container.querySelector('#fullName') as HTMLInputElement, 'Nadav Yigal');
+      changeValue(container.querySelector('#email') as HTMLInputElement, 'nadav@example.com');
+      changeValue(container.querySelector('#password') as HTMLInputElement, 'password123');
+    });
+
+    await act(async () => {
+      container.querySelector('form')?.dispatchEvent(new Event('submit', {
+        bubbles: true,
+        cancelable: true,
+      }));
+    });
+    await flushReact();
+
+    const signUpArgs = (signUp as any).mock.calls[0][0];
+    expect(signUpArgs.options.emailRedirectTo).toContain('/auth/callback?');
+    expect(signUpArgs.options.emailRedirectTo).toContain('session_id=session-1');
+    expect(signUpArgs.options.emailRedirectTo).toContain('next=%2Fdashboard');
+    expect(window.localStorage.getItem('ats_session_id')).toBe('session-1');
+    expect(global.fetch).toHaveBeenCalledWith('/api/public/convert-session', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer access-token-1',
+      },
+      body: JSON.stringify({ sessionId: 'session-1' }),
+    });
+    expect(push).toHaveBeenCalledWith('/dashboard');
+  });
+});


### PR DESCRIPTION
## Summary
- Pass the anonymous ATS session id from the free checker into signup.
- Convert the anonymous score for immediately confirmed signups, with bearer-token fallback so conversion is not dependent on cookie timing.
- Make `/api/public/convert-session` idempotent and add an authenticated GET path for dashboard loading.
- Load the converted score on the dashboard through the API instead of direct table reads.

## Validation
- `npm test -- tests/api/convert-session-route.test.ts tests/app/auth-form-session-handoff.test.tsx --runInBand`
- `npm run check:i18n`
- `npx eslint src/components/landing/FreeATSChecker.tsx src/components/auth/auth-form.tsx src/app/api/public/convert-session/route.ts 'src/app/[locale]/dashboard/page.tsx' tests/api/convert-session-route.test.ts tests/app/auth-form-session-handoff.test.tsx`
- `git diff --check`
- `npm run lint` (passes with existing warnings)
- `npm run build`
- `npx tsc --noEmit` still fails on pre-existing contract/security test typing and stale export errors, none in S5 files.

## Notes
- `npm run eval:resume` is a paid live eval (`RUN_LIVE_EVAL=1`) and was not run without explicit approval.