### PR TITLE
WP-29 S8: Fix optimization-reviews SectionSelectionProvider crash

### DIFF
--- a/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx
@@ -14,6 +14,7 @@ import type { OptimizationReviewRun, ReviewChangeGroup } from "@/types/optimizat
 import { useTranslations } from "next-intl";
 import { ROUTES } from "@/lib/constants";
 import { stashAtsBootstrap } from "@/lib/ats/resolve-display-scores";
+import { SectionSelectionProvider } from "@/hooks/useSectionSelection";
 
 type ReviewPayload = {
   review: OptimizationReviewRun;
@@ -204,8 +205,9 @@ export default function OptimizationReviewPage() {
   }
 
   return (
-    <div className="min-h-screen bg-muted/40 px-4 py-4 md:px-8 md:py-8">
-      <div className="mx-auto max-w-7xl space-y-6">
+    <SectionSelectionProvider>
+      <div className="min-h-screen bg-muted/40 px-4 py-4 md:px-8 md:py-8">
+        <div className="mx-auto max-w-7xl space-y-6">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
             <Link href={ROUTES.upload} className="text-sm text-muted-foreground hover:text-foreground">
@@ -317,7 +319,8 @@ export default function OptimizationReviewPage() {
             <CardContent className="p-4 text-sm text-red-700">{error}</CardContent>
           </Card>
         )}
+        </div>
       </div>
-    </div>
+    </SectionSelectionProvider>
   );
 }

--- a/tests/app/optimization-reviews-section-provider.test.tsx
+++ b/tests/app/optimization-reviews-section-provider.test.tsx
@@ -1,0 +1,118 @@
+import fs from 'fs';
+import path from 'path';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+function translated(namespace?: string) {
+  const t = ((key: string) => (namespace ? `${namespace}.${key}` : key)) as any;
+  t.rich = (key: string) => (namespace ? `${namespace}.${key}` : key);
+  return t;
+}
+
+function installReviewMocks() {
+  jest.doMock('next-intl', () => ({
+    __esModule: true,
+    useTranslations: (namespace?: string) => translated(namespace),
+  }));
+}
+
+const reviewResumeFixture = {
+  summary: 'Builds reliable iOS apps and product systems for fast-moving teams.',
+  contact: {
+    name: 'Ada Lovelace',
+    email: 'ada@example.com',
+    phone: '+1 555 123 4567',
+    location: 'London',
+    linkedin: 'linkedin.com/in/ada',
+  },
+  skills: {
+    technical: ['Swift', 'React', 'TypeScript'],
+    soft: ['Product judgment'],
+  },
+  experience: [
+    {
+      title: 'Senior iOS Engineer',
+      company: 'Analytical Engines',
+      location: 'London',
+      startDate: '2021',
+      endDate: 'Present',
+      achievements: ['Shipped resilient review flows used by thousands of job seekers.'],
+    },
+  ],
+  education: [
+    {
+      degree: 'BSc Computer Science',
+      institution: 'University of London',
+      location: 'London',
+      graduationDate: '2018',
+    },
+  ],
+  certifications: [],
+  projects: [],
+  matchScore: 82,
+  keyImprovements: ['Tighter role framing', 'Clearer measurable outcomes'],
+  missingKeywords: [],
+};
+
+const OPTIMIZATION_REVIEWS_PAGE = path.join(
+  process.cwd(),
+  'src/app/[locale]/dashboard/optimization-reviews/[id]/page.tsx'
+);
+
+describe('optimization-reviews route section selection provider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    installReviewMocks();
+  });
+
+  it('keeps DesignRenderer inside SectionSelectionProvider on the live optimization-reviews route', () => {
+    const source = fs.readFileSync(OPTIMIZATION_REVIEWS_PAGE, 'utf8');
+
+    expect(source).toContain("from \"@/hooks/useSectionSelection\"");
+
+    const providerStart = source.indexOf('<SectionSelectionProvider>');
+    const providerEnd = source.lastIndexOf('</SectionSelectionProvider>');
+    const designRenderer = source.indexOf('<DesignRenderer');
+
+    expect(providerStart).toBeGreaterThan(-1);
+    expect(providerEnd).toBeGreaterThan(providerStart);
+    expect(designRenderer).toBeGreaterThan(providerStart);
+    expect(designRenderer).toBeLessThan(providerEnd);
+  });
+
+  it('does not treat the decoy optimizations route as the live review entrypoint', () => {
+    const optimizationsPage = path.join(
+      process.cwd(),
+      'src/app/[locale]/dashboard/optimizations/[id]/page.tsx'
+    );
+    const resumeUploadPage = path.join(
+      process.cwd(),
+      'src/app/[locale]/dashboard/resume/page.tsx'
+    );
+
+    const resumeSource = fs.readFileSync(resumeUploadPage, 'utf8');
+    const optimizationsSource = fs.readFileSync(optimizationsPage, 'utf8');
+
+    expect(resumeSource).toContain('ROUTES.optimizationReviews');
+    expect(optimizationsSource).toContain('<SectionSelectionProvider>');
+    expect(optimizationsSource).not.toContain('optimization-reviews');
+  });
+
+  it('renders the optimization-reviews preview consumer with the provider and fails without it', () => {
+    const { SectionSelectionProvider } = require('@/hooks/useSectionSelection');
+    const { DesignRenderer } = require('@/components/design/DesignRenderer');
+
+    const preview = <DesignRenderer resumeData={reviewResumeFixture} refreshKey={2} />;
+
+    expect(() => renderToString(preview)).toThrow(
+      'useSectionSelection must be used within SectionSelectionProvider'
+    );
+
+    const html = renderToString(
+      <SectionSelectionProvider>{preview}</SectionSelectionProvider>
+    );
+
+    expect(html).toContain('dashboard.design.loadingTemplate');
+  });
+});


### PR DESCRIPTION
## Summary
- Wraps the live `/dashboard/optimization-reviews/[id]` route in `SectionSelectionProvider` so `DesignRenderer` no longer crashes with `useSectionSelection must be used within SectionSelectionProvider`
- S1 fixed the sibling `optimizations/[id]` route, but resume upload (`ROUTES.optimizationReviews`) is what real users hit before apply
- Adds `tests/app/optimization-reviews-section-provider.test.tsx` targeting the actual route (fails on `main` without the wrap; passes with it)

## Test plan
- [x] `npx jest tests/app/optimization-reviews-section-provider.test.tsx` (3/3)
- [x] `npx jest tests/app/optimization-review-section-provider.test.tsx` (2/2, S1 regression unchanged)
- [x] `npm run build`
- [ ] Preview: sign in → Start Full Optimization → land on `/dashboard/optimization-reviews/{id}` → page renders on first load and reload (no error boundary)
- [ ] After merge: rerun WP-29 final `/qa-only` on production

## Follow-up (not in this PR)
`optimizations/[id]` is still linked from history/applications post-apply; consider a rename/redirect follow-up to reduce decoy-route confusion.


Made with [Cursor](https://cursor.com)