### PR TITLE
fix(analytics): harden PostHog client init and user identification

### DIFF
--- a/src/components/providers/auth-provider.tsx
+++ b/src/components/providers/auth-provider.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
 import { createClientComponentClient } from "@/lib/supabase";
+import { posthog } from "@/lib/posthog";
 
 interface AuthContextType {
   user: User | null;
@@ -36,14 +37,29 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const { data: { user } } = await supabase.auth.getUser();
       setUser(user ?? null);
       setLoading(false);
+
+      if (user) {
+        posthog.identify(user.id, {
+          email: user.email,
+        });
+      }
     };
 
     getUser();
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange(
       async (event, session) => {
-        setUser(session?.user ?? null);
+        const nextUser = session?.user ?? null;
+        setUser(nextUser);
         setLoading(false);
+
+        if (nextUser && (event === "SIGNED_IN" || event === "INITIAL_SESSION")) {
+          posthog.identify(nextUser.id, {
+            email: nextUser.email,
+          });
+        } else if (event === "SIGNED_OUT") {
+          posthog.reset();
+        }
       }
     );
 

--- a/src/lib/posthog.ts
+++ b/src/lib/posthog.ts
@@ -6,6 +6,7 @@ import posthog from 'posthog-js';
 
 export function initPostHog() {
   if (typeof window === 'undefined') return;
+  if (posthog.__loaded) return;
 
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
   const apiHost = process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
@@ -18,7 +19,7 @@ export function initPostHog() {
   posthog.init(apiKey, {
     api_host: apiHost,
     person_profiles: 'identified_only',
-    capture_pageview: true,
+    capture_pageview: false, // SPA pageviews tracked manually in PostHogProvider
     capture_pageleave: true,
     persistence: 'localStorage+cookie',
     autocapture: false, // Explicit event tracking only


### PR DESCRIPTION
## Summary
- Disable automatic `capture_pageview` in `posthog.init` so SPA pageviews are tracked only by `PostHogProvider` (avoids duplicate pageviews on route changes).
- Add an idempotency guard (`posthog.__loaded`) before init to prevent double-initialization under React Strict Mode.
- Wire `posthog.identify()` on session restore/sign-in and `posthog.reset()` on sign-out so identified users get person profiles under `person_profiles: 'identified_only'`.

## Context
Live production test (incognito-style browser, 2026-07-03) confirmed `/e/` capture requests return **200** and `$pageview` events land in PostHog. These changes are hygiene improvements, not a hotfix for a broken pipeline.

## Test plan
- [ ] Load homepage in incognito — confirm single `$pageview` per navigation (not doubled)
- [ ] Sign in — confirm `posthog.identify` fires and person profile is created
- [ ] Sign out — confirm `posthog.reset()` clears identity
- [ ] Check DevTools Network for `us.i.posthog.com/e/` requests returning 200


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved analytics tracking for user sign-in and sign-out, helping keep user activity reporting accurate.
  * Pageview tracking is now handled more intentionally to avoid duplicate events.

* **Bug Fixes**
  * Prevented analytics from being initialized more than once, reducing the chance of repeated tracking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->