### PR TITLE
fix(analytics): dedupe legacy expert workflow PostHog events (WP-30 S3)

### DIFF
--- a/src/app/api/v1/expert-workflows/run/route.ts
+++ b/src/app/api/v1/expert-workflows/run/route.ts
@@ -82,12 +82,6 @@ export async function POST(request: NextRequest) {
       source: 'api_v1_expert_workflows_run',
       is_premium: premium,
     });
-    await captureServerEvent(user.id, 'expert_run_started', {
-      workflow_type: workflowType,
-      optimization_id: optimizationId,
-      source: 'api_v1_expert_workflows_run',
-      is_premium: premium,
-    });
     if (!premium) {
       await captureServerEvent(user.id, 'expert_mode_locked', {
         workflow_type: workflowType,
@@ -117,14 +111,6 @@ export async function POST(request: NextRequest) {
     });
 
     await captureServerEvent(user.id, 'expert_mode_run_completed', {
-      workflow_type: workflowType,
-      optimization_id: optimizationId,
-      run_id: result.run_id,
-      status: result.status,
-      needs_user_input: result.needs_user_input,
-      is_premium: true,
-    });
-    await captureServerEvent(user.id, 'expert_run_completed', {
       workflow_type: workflowType,
       optimization_id: optimizationId,
       run_id: result.run_id,

--- a/tests/contracts/expert-workflow-run-route.test.ts
+++ b/tests/contracts/expert-workflow-run-route.test.ts
@@ -160,7 +160,8 @@ describe('POST /api/v1/expert-workflows/run', () => {
   });
 
   it('returns structured workflow status for surfaced workflows', async () => {
-    const { POST, createRouteHandlerClient, runExpertWorkflow } = loadRouteHarness();
+    const { POST, createRouteHandlerClient, captureServerEvent, runExpertWorkflow } =
+      loadRouteHarness();
     createRouteHandlerClient.mockResolvedValue(
       buildSupabaseClient({
         user: { id: 'user-1', user_metadata: { is_premium: true } },
@@ -199,5 +200,11 @@ describe('POST /api/v1/expert-workflows/run', () => {
         },
       })
     );
+
+    const capturedEvents = captureServerEvent.mock.calls.map((call) => call[1]);
+    expect(capturedEvents.filter((event) => event === 'expert_mode_run_started')).toHaveLength(1);
+    expect(capturedEvents.filter((event) => event === 'expert_mode_run_completed')).toHaveLength(1);
+    expect(capturedEvents).not.toContain('expert_run_started');
+    expect(capturedEvents).not.toContain('expert_run_completed');
   });
 });


### PR DESCRIPTION
## Summary
- Removes duplicate `expert_run_started` / `expert_run_completed` server captures from `POST /api/v1/expert-workflows/run` — identical payloads to the `expert_mode_*` events on the same call path.
- Keeps `expert_mode_run_started` and `expert_mode_run_completed` for consistency with `expert_mode_locked`.
- Leaves `expert_apply_clicked` and `expert_mode_apply_completed` untouched — they fire at different lifecycle steps (pre-apply intent vs post-apply completion) in the apply route.

Builds on #109 (merged).

## Event decisions

| Pair | Kept | Removed |
|------|------|---------|
| Run started | `expert_mode_run_started` | `expert_run_started` |
| Run completed | `expert_mode_run_completed` | `expert_run_completed` |
| Apply flow | `expert_apply_clicked` + `expert_mode_apply_completed` (both kept — distinct steps) | — |

## Test plan
- [x] `npm test -- tests/contracts/expert-workflow-run-route.test.ts --runInBand` — asserts one `expert_mode_run_*` event each, zero legacy names
- [ ] Run expert workflow on staging — confirm single PostHog event per action in network tab


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated premium expert workflow events to use clearer event names during run start and completion.
  * Kept the workflow flow, access checks, and response behavior unchanged.
* **Tests**
  * Adjusted contract coverage to verify the new event names are emitted and the older names are no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->