### PR TITLE
fix: surface expert apply finalize DB errors instead of false success

### DIFF
--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -796,7 +796,7 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
       .eq('optimization_id', optimization.id);
   }
 
-  await db
+  const { error: finalizeError } = await db
     .from('expert_workflow_runs')
     .update({
       status: 'completed',
@@ -810,6 +810,10 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
     })
     .eq('id', runRow.id)
     .eq('user_id', params.userId);
+
+  if (finalizeError) {
+    throw new Error(finalizeError.message || 'Failed to finalize expert workflow run.');
+  }
 
   return {
     success: true,

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -176,6 +176,16 @@ Ties to the Resumely activation funnel re-read scheduled 2026-07-18 (minimum che
 
 **Not deployed:** branch `codex/fix-web-export-observability` remains local for review; no production deployment was authorized in this story.
 
+## 2026-07-09 — WP-39 S4 post-migration re-test PASS + P1 finalize error handling
+**Part 1 (go/no-go): PASS** — after production migration `20260303000000_expert_workflow_assets_and_new_types` (`applied_assets_json` column live).
+
+- Retried Apply on existing run `4102da8d-0bde-4692-a133-321f396e3f20` (optimization `5d6b526e-6ce9-42fc-995b-84cae5d9227e`) via authenticated production `POST .../apply` (`apply_mode: skills_only`).
+- **HTTP 200** `{ success: true, apply_mode: "skills_only", ... }`.
+- **DB after:** `applied_at` = `2026-07-09 11:18:34.446+00`, `status` = `completed`, `apply_mode` = `skills_only`, `applied_assets_json` = `[]`.
+- **Supabase REST:** `PATCH expert_workflow_runs` → **204** (was **400** pre-migration on 2026-07-09 morning test).
+
+**Part 2 (P1):** `applyExpertWorkflowRun()` now checks `{ error }` on the finalize `expert_workflow_runs` UPDATE and throws (apply route returns **500** / `success: false`) instead of swallowing PostgREST failures. Regression test added in `tests/contracts/expert-workflow-apply-behavior.test.ts` (mock finalize PATCH error → expect throw, not success). **Branch:** `fix/expert-apply-finalize-error-handling`.
+
 ## 2026-07-09 — WP-39 S4 live smoke test: Expert Apply regression confirmed (Outcome B)
 Live production test on `main` @ `1a37fc4`. **Verdict: Outcome (B) — API returns `success: true` but `expert_workflow_runs.applied_at` stays NULL.**
 

--- a/tests/contracts/expert-workflow-apply-behavior.test.ts
+++ b/tests/contracts/expert-workflow-apply-behavior.test.ts
@@ -2,12 +2,12 @@ import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 type QueryResult = { data: any; error: any };
 
-function buildUpdateChain() {
+function buildUpdateChain(finalizeError: QueryResult['error'] = null) {
   return {
     eq() {
       return {
         error: null,
-        eq: async () => ({ error: null }),
+        eq: async () => ({ error: finalizeError }),
       };
     },
   };
@@ -42,6 +42,7 @@ function buildSupabaseMock(config: {
   optimizationResult: QueryResult;
   resumeResult: QueryResult;
   jobDescriptionResult: QueryResult;
+  finalizeRunUpdateError?: QueryResult['error'];
 }) {
   const optimizationUpdates: Record<string, unknown>[] = [];
   const applicationUpdates: Record<string, unknown>[] = [];
@@ -56,7 +57,7 @@ function buildSupabaseMock(config: {
           },
           update(payload: Record<string, unknown>) {
             runUpdates.push(payload);
-            return buildUpdateChain();
+            return buildUpdateChain(config.finalizeRunUpdateError ?? null);
           },
         };
       }
@@ -123,7 +124,7 @@ function loadApplyHarness() {
     scoreOptimization,
   }));
 
-  const { applyExpertWorkflowRun } = require('@/lib/expert-workflows');
+  const { applyExpertWorkflowRun } = require('@/lib/expert-workflows/orchestrator');
   return { applyExpertWorkflowRun, scoreOptimization };
 }
 
@@ -413,5 +414,66 @@ describe('expert workflow apply behavior', () => {
 
     expect((supabase as any).getOptimizationUpdates()).toHaveLength(0);
     expect((supabase as any).getRunUpdates()).toHaveLength(0);
+  });
+
+  it('throws when expert_workflow_runs finalize update fails instead of reporting success', async () => {
+    const { applyExpertWorkflowRun } = loadApplyHarness();
+
+    const supabase = buildSupabaseMock({
+      runResult: {
+        data: {
+          id: 'run-finalize-fail',
+          user_id: 'user-1',
+          optimization_id: 'opt-1',
+          workflow_type: 'cover_letter_architect',
+          output_json: {
+            recommended_index: 0,
+            cover_letter_variants: [
+              { angle: 'concise', title: 'A', opening_paragraph: 'A', letter: 'L1', rationale: 'R1' },
+            ],
+          },
+        },
+        error: null,
+      },
+      optimizationResult: {
+        data: {
+          id: 'opt-1',
+          rewrite_data: { summary: 'No change' },
+          resume_id: 'resume-1',
+          jd_id: 'jd-1',
+          ats_score_optimized: 62,
+          match_score: 62,
+        },
+        error: null,
+      },
+      resumeResult: {
+        data: { raw_text: 'Original resume text' },
+        error: null,
+      },
+      jobDescriptionResult: {
+        data: { raw_text: 'JD raw', clean_text: 'JD clean', title: 'Engineer' },
+        error: null,
+      },
+      finalizeRunUpdateError: {
+        message: 'Could not find the applied_assets_json column of expert_workflow_runs in the schema cache',
+        code: 'PGRST204',
+      },
+    });
+
+    await expect(
+      applyExpertWorkflowRun({
+        supabase,
+        userId: 'user-1',
+        runId: 'run-finalize-fail',
+        applyMode: 'select_cover_letter_variant',
+        selectionIndex: 0,
+      })
+    ).rejects.toThrow('Could not find the applied_assets_json column');
+
+    expect((supabase as any).getRunUpdates()).toHaveLength(1);
+    expect((supabase as any).getRunUpdates()[0]).toMatchObject({
+      status: 'completed',
+      apply_mode: 'select_cover_letter_variant',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Part 1 live re-test (post-migration): **PASS** — `applied_at` now sets on production Apply (`4102da8d-...`, `PATCH expert_workflow_runs` → 204).
- Part 2 P1: `applyExpertWorkflowRun()` checks `{ error }` on the finalize `expert_workflow_runs` UPDATE and throws so the apply route returns 500/`success: false` instead of reporting success after a silent PATCH failure.
- Regression test mocks a finalize PATCH error (the `applied_assets_json` schema-drift case) and asserts the orchestrator throws rather than returning success.

## Test plan
- [x] `npm test -- tests/contracts/expert-workflow-apply-behavior.test.ts --runInBand` (5/5 pass)
- [x] Production go/no-go: retry Apply on QA run `4102da8d-0bde-4692-a133-321f396e3f20` — `applied_at` populated, `status=completed`, REST PATCH 204


Made with [Cursor](https://cursor.com)