### PR TITLE
fix: add web export funnel observability

### DIFF
--- a/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
+++ b/src/app/[locale]/dashboard/optimizations/[id]/page.tsx
@@ -32,6 +32,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { useLocale, useTranslations } from "next-intl";
+import { posthog } from "@/lib/posthog";
 
 
 // Disable static generation for this dynamic page
@@ -48,6 +49,7 @@ export default function OptimizationPage() {
   const [fabPosition, setFabPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
   const dragOffset = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
+  const exportVisibilityTrackedRef = useRef<string | null>(null);
 
   // ATS v2 state
   const [atsV2Data, setAtsV2Data] = useState<ResolvedAtsDisplay | null>(null);
@@ -338,6 +340,27 @@ export default function OptimizationPage() {
     fetchOptimizationData();
   }, [fetchOptimizationData]);
 
+  useEffect(() => {
+    const optimizationId = String(params.id || "");
+    if (
+      !optimizationId ||
+      !optimizedResume ||
+      isDemoOptimization ||
+      exportVisibilityTrackedRef.current === optimizationId
+    ) {
+      return;
+    }
+
+    exportVisibilityTrackedRef.current = optimizationId;
+    const properties = {
+      optimization_id: optimizationId,
+      platform: 'web',
+      source: 'web_optimization_page',
+    };
+    posthog.capture('optimized_viewed', properties);
+    posthog.capture('export_cta_seen', properties);
+  }, [isDemoOptimization, optimizedResume, params.id]);
+
   // Refresh resume data and design when chat sends a message
   const handleChatMessageSent = async (immediateAts?: {
     original?: number | null;
@@ -612,7 +635,16 @@ export default function OptimizationPage() {
   };
 
   const handleDownloadPDF = () => {
-    window.location.href = `/api/download/${params.id}?fmt=pdf`;
+    const optimizationId = String(params.id || "");
+    if (!optimizationId) return;
+
+    posthog.capture('export_pdf_tapped', {
+      optimization_id: optimizationId,
+      format: 'pdf',
+      platform: 'web',
+      source: 'web_optimization_page',
+    });
+    window.location.href = `/api/download/${optimizationId}?fmt=pdf`;
   };
 
 

--- a/src/app/api/download/[id]/route.ts
+++ b/src/app/api/download/[id]/route.ts
@@ -5,6 +5,7 @@ import { resolvePdfDesignContext, type PdfDesignContext } from "@/lib/pdf-design
 import { callPDFService } from "@/lib/pdf-service-client";
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { logger } from "@/lib/agent/utils/logger";
+import { captureServerEvent } from "@/lib/posthog-server";
 
 export const runtime = "nodejs";
 
@@ -48,6 +49,14 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   }
 
   logger.info('Optimization data fetched successfully for download', { optimizationId: id, userId: user.id });
+
+  const analyticsProperties = {
+    optimization_id: id,
+    format,
+    platform: "web",
+    source: "web_download_route",
+  };
+  await captureServerEvent(user.id, "export_started", analyticsProperties);
 
   const resumeData = optimizationData.rewrite_data as OptimizedResume;
 
@@ -139,6 +148,10 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
       errorDetails.stack = error.stack;
     }
     logger.error('Error generating download file', errorDetails, error);
+    await captureServerEvent(user.id, "export_failed", {
+      ...analyticsProperties,
+      error_code: "generation_failed",
+    });
     throw error;
   }
 
@@ -162,6 +175,10 @@ export async function GET(req: NextRequest, { params }: { params: Promise<{ id: 
   }
 
   logger.info('Sending download response', { optimizationId: id, filename, contentType });
+  await captureServerEvent(user.id, "export_success", {
+    ...analyticsProperties,
+    renderer: format === "pdf" ? pdfResult?.renderer ?? "unknown" : "docx",
+  });
   const body = fileBuffer as unknown as BodyInit;
   return new NextResponse(body, { headers });
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -4,6 +4,22 @@
 
 ---
 
+## Jest 30 async mocks can infer `never` in contract tests
+
+**Symptom:** `npx tsc --noEmit` reports `TS2345` because values passed to `mockResolvedValue` or `mockRejectedValue` are not assignable to `never`, even though Jest executes the test successfully.
+**Root cause:** An untyped `jest.fn()` does not provide enough return-type context for Jest 30's resolved/rejected value helpers under this repo's TypeScript configuration.
+**Fix:** Define the async implementation directly, for example `jest.fn(async () => value)` or `jest.fn(async () => { throw error; })`, so TypeScript infers the promise result from the function body. When matcher typing also needs argument types, use a typed rest tuple and `void args`; underscore-prefixed unused parameters still trigger this repo's ESLint rule.
+
+---
+
+## `status` is a read-only parameter in zsh
+
+**Symptom:** A verification wrapper exits immediately with `zsh: read-only variable: status` before it can inspect the command result.
+**Root cause:** zsh reserves `status` for the previous command's exit code.
+**Fix:** Store exit codes in a neutral variable such as `exit_code` rather than assigning to `status`.
+
+---
+
 ## ATS keyword extractor matched tech terms as substrings (fabricated skills → low scores)
 
 **Symptom:** Non-technical roles (Business Development, Partnership Manager) scored ~34 even with a fully-scraped 6KB JD. `must_have` for a Fresha BD role came out as `["rust","express","api","Fresha\nAbout","Trusted"]`.

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,21 @@
 # Project Progress
 
+## 2026-07-10 — Web export wall diagnosis + observability fix
+
+**Verdict:** production PDF export is functional; the proven web defect was a complete analytics blind spot around the export action, not a universal paywall/auth/PDF failure.
+
+- Fresh production QA flow completed signup → upload → optimization review → approved draft → PDF download. Production optimization: `d4f0ff18-871b-483a-a5af-843c2f361f9a`; browser observed a real download with no console error.
+- Supabase/PostHog reconciliation found seven organic web users from February reached `/dashboard/optimizations/{id}` but had no export events. Historical session replay is outside the 30-day retention window, and the web button used a raw `window.location.href`, so past click-vs-abandonment cannot be distinguished.
+- The cited 2026-07-06 iOS zero-export result is now stale: refreshed founder-excluded iOS funnel through 2026-07-10 is 9 `resume_uploaded` people → 2 `optimization_completed` → 1 `export_success`.
+- Fix: the optimization page now emits `optimized_viewed`, `export_cta_seen`, and `export_pdf_tapped` with `optimization_id`, `platform=web`, and source. The authenticated download route now emits `export_started`, terminal `export_success`, or `export_failed` with format and renderer/error code.
+- QA exclusion: `nadav.yigal+export-wall-qa-jul10@gmail.com` / user `fe2cc2bc-75e6-4b64-8036-a2aac07f4917` is tagged in PostHog with `is_internal_tester=true`, `qa_account=true`, purpose `export_wall_jul10`; founder-excluded queries also retain the `-qa-` email convention exclusion.
+- TDD: `tests/contracts/web-export-observability.test.ts` failed 3/3 before implementation and passes 3/3 after. Targeted eslint clean; full lint 0 errors / 11 pre-existing warnings; production build succeeded. `npx tsc --noEmit` retains only documented pre-existing test errors and has no story-file errors.
+- Post-fix local smoke against the real QA optimization: authenticated route loaded the row, generated a 7,328-byte PDF through the jsPDF fallback, and logged `Sending download response`.
+
+**Expected funnel movement:** `optimization_completed` → `optimized_viewed` → `export_cta_seen` becomes measurable on web; a click then resolves to `export_pdf_tapped` → `export_started` → exactly one of `export_success` / `export_failed`.
+
+**Not deployed:** branch `codex/fix-web-export-observability` remains local for review; no production deployment was authorized in this story.
+
 ## 2026-07-09 — WP-39 S4 live smoke test: Expert Apply regression confirmed (Outcome B)
 Live production test on `main` @ `1a37fc4`. **Verdict: Outcome (B) — API returns `success: true` but `expert_workflow_runs.applied_at` stays NULL.**
 

--- a/tests/contracts/web-export-observability.test.ts
+++ b/tests/contracts/web-export-observability.test.ts
@@ -1,0 +1,197 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const optimizationPagePath = path.join(
+  process.cwd(),
+  'src/app/[locale]/dashboard/optimizations/[id]/page.tsx'
+);
+
+function buildSupabaseClient() {
+  const query: any = {
+    select: jest.fn(() => query),
+    eq: jest.fn(() => query),
+    maybeSingle: jest.fn(async () => ({
+      data: {
+        rewrite_data: {
+          contact: { name: 'Test Candidate' },
+        },
+      },
+      error: null,
+    })),
+  };
+
+  return {
+    auth: {
+      getUser: jest.fn(async () => ({
+        data: { user: { id: 'user-1' } },
+        error: null,
+      })),
+    },
+    from: jest.fn(() => query),
+  };
+}
+
+function loadDownloadRoute({ failLocalPdf = false }: { failLocalPdf?: boolean } = {}) {
+  jest.resetModules();
+
+  const createRouteHandlerClient = jest.fn(async () => buildSupabaseClient());
+  const captureServerEvent = jest.fn(
+    async (...args: [string, string, Record<string, unknown>?]) => {
+      void args;
+      return undefined;
+    }
+  );
+  const generatePdfWithDesign = failLocalPdf
+    ? jest.fn(async () => {
+        throw new Error('local renderer failed');
+      })
+    : jest.fn(async () => ({
+        buffer: Buffer.from('%PDF-test'),
+        renderer: 'local',
+        templateSlug: 'minimal-serif',
+        usedDesignAssignment: false,
+      }));
+  const callPDFService = failLocalPdf
+    ? jest.fn(async () => {
+        throw new Error('docker renderer failed');
+      })
+    : jest.fn(async () => ({
+        success: true,
+        pdfBase64: Buffer.from('%PDF-test').toString('base64'),
+        metadata: { templateSlug: 'minimal-serif' },
+      }));
+
+  jest.doMock('next/server', () => ({
+    __esModule: true,
+    NextResponse: class {
+      status: number;
+      headers: Headers;
+      body: unknown;
+
+      constructor(body: unknown, init?: { status?: number; headers?: Headers }) {
+        this.body = body;
+        this.status = init?.status ?? 200;
+        this.headers = init?.headers ?? new Headers();
+      }
+
+      static json(body: unknown, init?: { status?: number }) {
+        return new this(body, init);
+      }
+
+      async json() {
+        return this.body;
+      }
+    },
+  }));
+
+  jest.doMock('@/lib/supabase-server', () => ({
+    __esModule: true,
+    createRouteHandlerClient,
+  }));
+  jest.doMock('@/lib/posthog-server', () => ({
+    __esModule: true,
+    captureServerEvent,
+  }));
+  jest.doMock('@/lib/export', () => ({
+    __esModule: true,
+    cleanResumeData: jest.fn((value) => value),
+    generatePdfWithDesign,
+    generateDocxWithDesign: jest.fn(),
+  }));
+  jest.doMock('@/lib/pdf-design-context', () => ({
+    __esModule: true,
+    resolvePdfDesignContext: jest.fn(async () => ({
+      templateSlug: 'minimal-serif',
+      customization: {},
+      usedDesignAssignment: false,
+    })),
+  }));
+  jest.doMock('@/lib/pdf-service-client', () => ({
+    __esModule: true,
+    callPDFService,
+  }));
+  jest.doMock('@/lib/agent/utils/logger', () => ({
+    __esModule: true,
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    },
+  }));
+
+  const { GET } = require('@/app/api/download/[id]/route');
+  return { GET, captureServerEvent };
+}
+
+describe('web export observability', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('tracks optimization visibility and the web export click with an optimization id', () => {
+    const source = fs.readFileSync(optimizationPagePath, 'utf8');
+
+    expect(source).toContain("posthog.capture('optimized_viewed'");
+    expect(source).toContain("posthog.capture('export_cta_seen'");
+    expect(source).toContain("posthog.capture('export_pdf_tapped'");
+    expect(source).toContain('optimization_id: optimizationId');
+    expect(source).toContain("platform: 'web'");
+    expect(source).toContain('window.location.href = `/api/download/${optimizationId}?fmt=pdf`');
+  });
+
+  it('records authenticated PDF generation start and success on the server', async () => {
+    const { GET, captureServerEvent } = loadDownloadRoute();
+
+    const response = await GET(
+      { url: 'https://www.resumelybuilderai.com/api/download/opt-1?fmt=pdf' } as any,
+      { params: Promise.resolve({ id: 'opt-1' }) }
+    );
+
+    expect(response.status).toBe(200);
+    expect(captureServerEvent).toHaveBeenNthCalledWith(
+      1,
+      'user-1',
+      'export_started',
+      expect.objectContaining({
+        optimization_id: 'opt-1',
+        format: 'pdf',
+        platform: 'web',
+      })
+    );
+    expect(captureServerEvent).toHaveBeenNthCalledWith(
+      2,
+      'user-1',
+      'export_success',
+      expect.objectContaining({
+        optimization_id: 'opt-1',
+        format: 'pdf',
+        platform: 'web',
+      })
+    );
+    expect(captureServerEvent.mock.calls.map((call) => call[1])).not.toContain('export_failed');
+  });
+
+  it('records a terminal server failure after export starts', async () => {
+    const { GET, captureServerEvent } = loadDownloadRoute({ failLocalPdf: true });
+
+    await expect(
+      GET(
+        { url: 'https://www.resumelybuilderai.com/api/download/opt-2?fmt=pdf' } as any,
+        { params: Promise.resolve({ id: 'opt-2' }) }
+      )
+    ).rejects.toThrow('local renderer failed');
+
+    expect(captureServerEvent).toHaveBeenCalledWith(
+      'user-1',
+      'export_failed',
+      expect.objectContaining({
+        optimization_id: 'opt-2',
+        format: 'pdf',
+        platform: 'web',
+        error_code: 'generation_failed',
+      })
+    );
+    expect(captureServerEvent.mock.calls.map((call) => call[1])).not.toContain('export_success');
+  });
+});


### PR DESCRIPTION
## Summary
- Emit `optimized_viewed`, `export_cta_seen`, and `export_pdf_tapped` on the web optimization page with `optimization_id`, `platform=web`, and source metadata.
- Emit `export_started`, `export_success`, and `export_failed` from the authenticated download route so server-side PDF generation is measurable.
- Add contract tests (`tests/contracts/web-export-observability.test.ts`) and document the diagnosis in `tasks/progress.md`.

## Test plan
- [x] `npm test -- tests/contracts/web-export-observability.test.ts` (3/3 pass)
- [ ] Merge and deploy to production
- [ ] PostHog: watch founder-excluded web funnel `optimized_viewed → export_cta_seen → export_pdf_tapped → export_started → export_success/export_failed` for first 5 real completers


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PDF export navigation to consistently use the selected optimization.
  * Enhanced monitoring for export actions, including viewed export options, download attempts, successful exports, and failures.
  * Export failures now provide more detailed diagnostic information for troubleshooting.

* **Documentation**
  * Added lessons learned covering TypeScript test mocks and shell scripting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->