### PR TITLE
fix: expose optimization_id on saved-resume API responses

### DIFF
--- a/src/app/api/v1/resumes/[id]/route.ts
+++ b/src/app/api/v1/resumes/[id]/route.ts
@@ -56,7 +56,7 @@ export async function PATCH(
     .update({ display_name: displayName, filename, updated_at: new Date().toISOString() })
     .eq('id', id)
     .eq('user_id', user.id)
-    .select('id, filename, display_name, size_bytes, created_at')
+    .select('id, filename, display_name, size_bytes, created_at, optimization_id')
     .single();
 
   if (error) {
@@ -71,6 +71,7 @@ export async function PATCH(
       display_name: updated.display_name,
       created_at: updated.created_at,
       size_bytes: updated.size_bytes,
+      optimization_id: updated.optimization_id,
     },
   });
 }

--- a/src/app/api/v1/resumes/[id]/save/route.ts
+++ b/src/app/api/v1/resumes/[id]/save/route.ts
@@ -43,7 +43,7 @@ export async function POST(
       filename,
       display_name: displayName ?? null,
     })
-    .select('id, filename, display_name, size_bytes, created_at')
+    .select('id, filename, display_name, size_bytes, created_at, optimization_id')
     .single();
 
   if (insertError) {
@@ -58,6 +58,7 @@ export async function POST(
       display_name: saved.display_name,
       created_at: saved.created_at,
       size_bytes: saved.size_bytes,
+      optimization_id: saved.optimization_id,
     },
   });
 }

--- a/src/app/api/v1/resumes/route.ts
+++ b/src/app/api/v1/resumes/route.ts
@@ -11,7 +11,7 @@ export async function GET(request: NextRequest) {
 
   const { data, error } = await supabase
     .from('saved_resumes')
-    .select('id, filename, display_name, size_bytes, created_at')
+    .select('id, filename, display_name, size_bytes, created_at, optimization_id')
     .eq('user_id', user.id)
     .order('created_at', { ascending: false });
 
@@ -25,6 +25,7 @@ export async function GET(request: NextRequest) {
     display_name: r.display_name ?? null,
     created_at: r.created_at,
     size_bytes: r.size_bytes ?? null,
+    optimization_id: r.optimization_id ?? null,
   }));
 
   return NextResponse.json({ resumes });


### PR DESCRIPTION
## Summary
- The iOS app's saved-resume download picker calls `/api/download/{id}` with the `saved_resumes` row id, but that endpoint regenerates a PDF from an `optimizations` row by id and has nothing to do with `saved_resumes` — every download attempt fails with 404 "Optimization not found", confirmed live on-device.
- `saved_resumes.optimization_id` is the correct id (set at insert time in the save route) but was never returned by the list/save/rename responses, so no client could construct a working request.
- Adds `optimization_id` to all three response shapes: `GET /api/v1/resumes`, `POST /api/v1/resumes/{id}/save`, `PATCH /api/v1/resumes/{id}`. No schema change — the column already existed.

## Test plan
- [x] `npx eslint` on the 3 changed files — clean
- [x] `npx tsc --noEmit` — zero new errors (pre-existing failures are in unrelated contract/security test files)
- [x] `npm run build` — succeeds, all 3 `/api/v1/resumes*` routes compile
- [ ] Companion iOS fix (ResumeBuilder-IOS-APP PR #108) confirms end-to-end on physical device after this deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resume API responses now include the associated optimization ID when available.
  * Saving, retrieving, and updating resumes consistently return optimization details.
  * Resumes without an optimization ID return a clear `null` value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->