### PR TITLE
WP-45 S1: repair the three dead scoring components

### DIFF
--- a/src/lib/ats/__tests__/scorer-integrity.test.ts
+++ b/src/lib/ats/__tests__/scorer-integrity.test.ts
@@ -1,0 +1,323 @@
+/**
+ * WP-45 S1 — Scorer integrity
+ *
+ * These tests encode the gates from the work packet:
+ *   G1  a perfect-match resume must be able to reach the top band (>= 85)
+ *   G2  every weighted component must be able to vary
+ *   D2  the no-metrics penalty must not fire on top of an already-low component
+ *   D3  format_parseability must be computed per side of the before/after pair
+ *   D4  recency_fit must not compare a real value against a constant fallback
+ *
+ * They are deterministic and require no network: the semantic analyzer falls
+ * back to a fixed neutral score when no OPENAI_API_KEY is present, and every
+ * other analyzer is pure.
+ */
+
+import { aggregateScores } from '../scorers/aggregator';
+import { applyPenalties } from '../scorers/penalties';
+import { SUB_SCORE_WEIGHTS, validateWeights } from '../config/weights';
+import { deriveResumeJsonFromText } from '../extractors/experience-text-extractor';
+import { scoreResume } from '../core';
+import type { AnalyzerResult, SubScoreKey, SubScores, ATSScoreInput, FormatReport } from '../types';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+/** Feed a fixed set of sub-scores through the real aggregation + penalty path. */
+function compositeFor(subscores: SubScores): number {
+  const results = new Map<SubScoreKey, AnalyzerResult>(
+    (Object.entries(subscores) as Array<[SubScoreKey, number]>).map(([key, score]) => [
+      key,
+      { score, evidence: {}, confidence: 1.0, warnings: [] } as AnalyzerResult,
+    ])
+  );
+  const aggregate = aggregateScores(results);
+  return applyPenalties(aggregate.finalScore, aggregate.subscores, {}).penalizedScore;
+}
+
+/**
+ * A flawless candidate for the role.
+ *
+ * Two components are deliberately NOT set to 100, because pinning them there
+ * would test a resume that cannot exist and the gate would pass on a score no
+ * user can reach:
+ *
+ *  - format_parseability is 88, the value a clean, well-structured resume
+ *    actually produces through analyzeFormatWithTemplate (production mean over
+ *    60 days is 87.8).
+ *  - keyword_phrase is 5, its realistic ceiling. It requires verbatim 3-6 word
+ *    job-description reuse, so even an ideal resume scores near zero unless it
+ *    copy-pastes the posting.
+ */
+const PERFECT_MATCH: SubScores = {
+  keyword_exact: 100,
+  keyword_phrase: 5,
+  semantic_relevance: 100,
+  title_alignment: 100,
+  metrics_presence: 100,
+  section_completeness: 100,
+  format_parseability: 88,
+  recency_fit: 100,
+};
+
+/**
+ * The case that actually broke: a candidate who is a genuinely excellent match
+ * on every dimension the product can influence, whose resume simply has no
+ * quantified figures in it.
+ *
+ * This is common — plenty of strong resumes describe scope rather than
+ * percentages — and the optimizer cannot fix it, because stripFabricatedMetrics
+ * (correctly) forbids inventing numbers. Before S1 this candidate scored 72:
+ * metrics_presence contributed 0 of its 10 points AND triggered a further -5
+ * penalty for the same fact, putting "strong" out of reach for someone who
+ * deserved it.
+ */
+const STRONG_CANDIDATE_WITHOUT_METRICS: SubScores = {
+  ...PERFECT_MATCH,
+  metrics_presence: 0,
+};
+
+const CLEAR_MISMATCH: SubScores = {
+  keyword_exact: 5,
+  keyword_phrase: 0,
+  semantic_relevance: 20,
+  title_alignment: 0,
+  metrics_presence: 0,
+  section_completeness: 40,
+  format_parseability: 60,
+  recency_fit: 10,
+};
+
+/**
+ * The shape a real user's resume actually produces today, taken from the
+ * 60-day production means (n=59, optimized side). keyword_phrase and
+ * metrics_presence are the two components the audit found cannot be earned.
+ */
+const TYPICAL_OPTIMIZED: SubScores = {
+  keyword_exact: 39,
+  keyword_phrase: 4,
+  semantic_relevance: 71,
+  title_alignment: 38,
+  metrics_presence: 7,
+  section_completeness: 100,
+  format_parseability: 88,
+  recency_fit: 13,
+};
+
+const NEUTRAL_FORMAT: FormatReport = {
+  has_tables: false,
+  has_images: false,
+  has_headers_footers: false,
+  has_nonstandard_fonts: false,
+  has_odd_glyphs: false,
+  has_multi_column: false,
+  format_safety_score: 90,
+  issues: [],
+};
+
+const RISKY_FORMAT: FormatReport = {
+  has_tables: true,
+  has_images: false,
+  has_headers_footers: false,
+  has_nonstandard_fonts: false,
+  has_odd_glyphs: false,
+  has_multi_column: true,
+  format_safety_score: 30,
+  issues: ['Tables detected', 'Multi-column layout detected'],
+};
+
+// ---------------------------------------------------------------------------
+// G1 — the scale must be able to reach its own top band
+// ---------------------------------------------------------------------------
+
+describe('WP-45 G1: a perfect-match resume can reach the top band', () => {
+  it('scores a flawless candidate at or above the strong threshold of 75', () => {
+    expect(compositeFor(PERFECT_MATCH)).toBeGreaterThanOrEqual(85);
+  });
+
+  it('lets an excellent candidate whose resume has no metrics reach strong', () => {
+    // The gate that matters. Pre-S1 this scored 72 — the component contributed
+    // nothing and then a penalty subtracted 5 more for the same shortcoming,
+    // so a deserving candidate was capped below the strong band by a fact the
+    // product had already decided it would not fix for them.
+    expect(compositeFor(STRONG_CANDIDATE_WITHOUT_METRICS)).toBeGreaterThanOrEqual(75);
+  });
+
+  it('charges a missing-metrics resume once, not twice', () => {
+    // Losing the metrics component is legitimate. Losing it AND taking a
+    // separate penalty for the same fact is double jeopardy.
+    const gap = compositeFor(PERFECT_MATCH) - compositeFor(STRONG_CANDIDATE_WITHOUT_METRICS);
+    expect(gap).toBeLessThanOrEqual(Math.round(SUB_SCORE_WEIGHTS.metrics_presence * 100) + 1);
+  });
+
+  it('still scores a clear mismatch low', () => {
+    // The repairs must not compress the whole scale upward.
+    expect(compositeFor(CLEAR_MISMATCH)).toBeLessThan(35);
+  });
+
+  it('keeps a wide spread between a flawless and a hopeless candidate', () => {
+    expect(compositeFor(PERFECT_MATCH) - compositeFor(CLEAR_MISMATCH)).toBeGreaterThan(50);
+  });
+
+  it('leaves a typical real-world optimized resume below the strong band', () => {
+    // Honesty check: repairing dead components must not hand everybody a
+    // "strong" verdict. A resume that is genuinely a partial match stays a
+    // partial match.
+    const typical = compositeFor(TYPICAL_OPTIMIZED);
+    expect(typical).toBeGreaterThan(30);
+    expect(typical).toBeLessThan(75);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// G2 — no component may sit in the denominator without being earnable
+// ---------------------------------------------------------------------------
+
+describe('WP-45 G2: every weighted component can move the score', () => {
+  const weighted = (Object.keys(SUB_SCORE_WEIGHTS) as SubScoreKey[]).filter(
+    key => SUB_SCORE_WEIGHTS[key] > 0
+  );
+
+  it('has weights that still sum to 1.0', () => {
+    expect(validateWeights().valid).toBe(true);
+  });
+
+  it.each(weighted)('moving %s alone changes the composite', key => {
+    const floor = compositeFor({ ...CLEAR_MISMATCH, [key]: 0 });
+    const ceiling = compositeFor({ ...CLEAR_MISMATCH, [key]: 100 });
+    expect(ceiling - floor).toBeGreaterThanOrEqual(5);
+  });
+
+  it('drops keyword_phrase from the weighting', () => {
+    // The analyzer keeps running so suggestions still work, but a component
+    // that requires verbatim 3-6 word JD reuse cannot be earned without
+    // keyword stuffing, so it must not sit in the composite. See WP-45 D1.
+    expect(SUB_SCORE_WEIGHTS.keyword_phrase).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D2 — the metrics penalty must not double-count
+// ---------------------------------------------------------------------------
+
+describe('WP-45 D2: no double penalty for missing metrics', () => {
+  it('does not subtract a metrics penalty when metrics_presence is already 0', () => {
+    const { appliedPenalties } = applyPenalties(60, { ...PERFECT_MATCH, metrics_presence: 0 }, {});
+    expect(appliedPenalties.map(p => p.reason)).not.toContain(
+      'No quantified metrics found in resume'
+    );
+  });
+
+  it('still penalises genuine format risk', () => {
+    const { appliedPenalties } = applyPenalties(
+      60,
+      { ...PERFECT_MATCH, format_parseability: 20 },
+      {}
+    );
+    expect(appliedPenalties.some(p => p.reason.includes('format risk'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D4 — the original side must not be scored against a constant
+// ---------------------------------------------------------------------------
+
+describe('WP-45 D4: recency is derived from the original resume, not a constant', () => {
+  const RESUME_WITH_DATES = `
+Jane Cohen
+jane@example.com | Tel Aviv
+
+EXPERIENCE
+
+Senior Data Engineer at Nimbus Analytics
+Tel Aviv | Jan 2022 - Present
+• Built streaming pipelines on Kafka and Spark
+• Owned the migration to Snowflake
+
+Data Engineer at Harbor Systems
+Tel Aviv | 2019 - 2021
+• Maintained ETL jobs in Airflow
+
+EDUCATION
+BSc Computer Science - Technion
+`;
+
+  it('derives dated experience from plain resume text', () => {
+    const derived = deriveResumeJsonFromText(RESUME_WITH_DATES);
+    expect(derived).not.toBeNull();
+    expect(derived!.experience.length).toBeGreaterThanOrEqual(2);
+    expect(derived!.experience[0].endDate.toLowerCase()).toContain('present');
+  });
+
+  it('returns null rather than guessing when the text has no dated roles', () => {
+    expect(deriveResumeJsonFromText('Jane Cohen\nSkilled engineer.\n')).toBeNull();
+  });
+
+  it('does not report the 50-point fallback for an original resume that has real dates', async () => {
+    const result = await scoreResume(buildInput({ originalText: RESUME_WITH_DATES }));
+    // 50 is the "no experience data available" constant. Seeing it on the
+    // original side while the optimized side gets a real number is exactly the
+    // asymmetry that made every reported delta ~3 points too small.
+    expect(result.subscores_original.recency_fit).not.toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D3 — format must be measured per side
+// ---------------------------------------------------------------------------
+
+describe('WP-45 D3: format_parseability is computed per side', () => {
+  it('reports different format scores when the two sides have different formats', async () => {
+    const result = await scoreResume(
+      buildInput({
+        formatOriginal: RISKY_FORMAT,
+        formatOptimized: NEUTRAL_FORMAT,
+      })
+    );
+
+    expect(result.subscores_original.format_parseability).toBe(
+      RISKY_FORMAT.format_safety_score
+    );
+    expect(result.subscores.format_parseability).toBe(NEUTRAL_FORMAT.format_safety_score);
+    expect(result.subscores.format_parseability).not.toBe(
+      result.subscores_original.format_parseability
+    );
+  });
+
+  it('falls back to the shared report when no per-side reports are supplied', async () => {
+    const result = await scoreResume(buildInput({}));
+    expect(result.subscores_original.format_parseability).toBe(
+      NEUTRAL_FORMAT.format_safety_score
+    );
+    expect(result.subscores.format_parseability).toBe(NEUTRAL_FORMAT.format_safety_score);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+function buildInput(opts: {
+  originalText?: string;
+  formatOriginal?: FormatReport;
+  formatOptimized?: FormatReport;
+}): ATSScoreInput {
+  return {
+    resume_original_text: opts.originalText ?? 'Jane Cohen\nData engineer with Kafka experience.',
+    resume_optimized_text:
+      'Jane Cohen\nSenior Data Engineer\nKafka, Spark, Snowflake, Airflow, SQL, Python.',
+    job_clean_text:
+      'We are hiring a Senior Data Engineer to build streaming pipelines with Kafka, Spark and Snowflake. SQL and Python required.',
+    job_extracted_json: {
+      title: 'Senior Data Engineer',
+      must_have: ['kafka', 'spark', 'snowflake', 'sql', 'python'],
+      nice_to_have: ['airflow'],
+      responsibilities: ['Build streaming pipelines'],
+      seniority: 'senior',
+software_keywords: [],
+    } as unknown as ATSScoreInput['job_extracted_json'],
+    format_report: NEUTRAL_FORMAT,
+    format_report_original: opts.formatOriginal,
+    format_report_optimized: opts.formatOptimized,
+    timestamp: new Date('2026-07-24T00:00:00Z'),
+  };
+}

--- a/src/lib/ats/__tests__/scorer-integrity.test.ts
+++ b/src/lib/ats/__tests__/scorer-integrity.test.ts
@@ -18,6 +18,7 @@ import { applyPenalties } from '../scorers/penalties';
 import { SUB_SCORE_WEIGHTS, validateWeights } from '../config/weights';
 import { deriveResumeJsonFromText } from '../extractors/experience-text-extractor';
 import { scoreResume } from '../core';
+import { scoreOptimization } from '../integration';
 import type { AnalyzerResult, SubScoreKey, SubScores, ATSScoreInput, FormatReport } from '../types';
 
 // ---------------------------------------------------------------------------
@@ -202,11 +203,24 @@ describe('WP-45 G2: every weighted component can move the score', () => {
 // ---------------------------------------------------------------------------
 
 describe('WP-45 D2: no double penalty for missing metrics', () => {
-  it('does not subtract a metrics penalty when metrics_presence is already 0', () => {
-    const { appliedPenalties } = applyPenalties(60, { ...PERFECT_MATCH, metrics_presence: 0 }, {});
-    expect(appliedPenalties.map(p => p.reason)).not.toContain(
-      'No quantified metrics found in resume'
+  it('applies no penalty at all to a strong candidate who simply lacks metrics', () => {
+    // Asserting on the penalty list rather than on a string literal: the old
+    // reason text no longer exists in the source, so a `not.toContain` on it
+    // would pass even with the penalty fully restored.
+    const { appliedPenalties, penalizedScore } = applyPenalties(
+      60,
+      STRONG_CANDIDATE_WITHOUT_METRICS,
+      {}
     );
+    expect(appliedPenalties).toHaveLength(0);
+    expect(penalizedScore).toBe(60);
+  });
+
+  it('scores the two reference fixtures at their exact expected values', () => {
+    // Absolute values, not band membership. Reverting either D1 (weights) or
+    // D2 (penalty) moves these, which band assertions alone would not catch.
+    expect(compositeFor(STRONG_CANDIDATE_WITHOUT_METRICS)).toBe(87);
+    expect(compositeFor(TYPICAL_OPTIMIZED)).toBe(44);
   });
 
   it('still penalises genuine format risk', () => {
@@ -260,6 +274,159 @@ BSc Computer Science - Technion
     // original side while the optimized side gets a real number is exactly the
     // asymmetry that made every reported delta ~3 points too small.
     expect(result.subscores_original.recency_fit).not.toBe(50);
+  });
+
+  it('scores recency above the old constant, not below it', async () => {
+    // The failure mode this guards: a misparse that finds a role but attributes
+    // no achievements to it drives recency toward 0, which is strictly worse
+    // than the 50 it replaced. "Not 50" alone would pass in that case.
+    const result = await scoreResume(buildInput({ originalText: RESUME_WITH_DATES }));
+    expect(result.subscores_original.recency_fit).toBeGreaterThan(50);
+  });
+
+  it('does not treat education or certification dates as jobs', () => {
+    const derived = deriveResumeJsonFromText(`
+EXPERIENCE
+
+Data Engineer at Harbor Systems
+2019 - 2021
+• Maintained ETL jobs in Airflow
+
+EDUCATION
+BSc Computer Science
+Technion, 2012 - 2016
+
+CERTIFICATIONS
+AWS Solutions Architect, 2020 - 2023
+`);
+    expect(derived).not.toBeNull();
+    expect(derived!.experience).toHaveLength(1);
+    // The recency analyzer treats index 0 as the current role, so a degree
+    // parsed as a job would be read as the candidate's present position.
+    expect(derived!.experience[0].company).toContain('Harbor');
+  });
+
+  it('does not spawn a phantom role from a date range inside a bullet', () => {
+    const derived = deriveResumeJsonFromText(`
+EXPERIENCE
+
+Senior Data Engineer at Nimbus
+Jan 2022 - Present
+• Cut infra spend 30% across the 2019 - 2021 legacy stack
+• Owned the Snowflake migration
+`);
+    expect(derived!.experience).toHaveLength(1);
+    expect(derived!.experience[0].endDate.toLowerCase()).toContain('present');
+  });
+
+  it('captures prose achievements, not only bulleted ones', () => {
+    const derived = deriveResumeJsonFromText(`
+EXPERIENCE
+
+Senior Product Manager
+Acme Corp
+Jan 2020 - Present
+Led the migration of the billing platform to a new vendor.
+Managed a team of six engineers across two time zones.
+
+Product Manager
+Beta Inc
+2017 - 2019
+Owned the onboarding funnel.
+`);
+    expect(derived!.experience).toHaveLength(2);
+    // Empty achievements starve checkLatestRoleRelevance, which is what pushed
+    // recency below the constant it replaced.
+    expect(derived!.experience[0].achievements.length).toBeGreaterThanOrEqual(2);
+    expect(derived!.experience[0].achievements.join(' ')).toContain('billing platform');
+    // ...and they must not leak into the next role.
+    expect(derived!.experience[0].achievements.join(' ')).not.toContain('onboarding funnel');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The regression this whole packet exists to prevent
+// ---------------------------------------------------------------------------
+
+const REAL_RESUME = `Jane Cohen
+jane@example.com | Tel Aviv
+
+PROFESSIONAL SUMMARY
+Data engineer focused on streaming systems.
+
+SKILLS
+Kafka, Spark, SQL, Python
+
+EXPERIENCE
+
+Senior Data Engineer at Nimbus Analytics
+Jan 2022 - Present
+• Built streaming pipelines on Kafka and Spark
+
+EDUCATION
+BSc Computer Science - Technion
+`;
+
+describe('WP-45: the repairs must not widen the delta for the wrong reasons', () => {
+  it('does not deflate the original side just because it lacks structured JSON', async () => {
+    const result = await scoreResume(buildInput({ originalText: REAL_RESUME }));
+
+    // The original resume plainly has a summary, skills, experience and
+    // education. If the derived work-history stub were handed to
+    // section_completeness it would see empty summary/skills/education and
+    // score 25 — pushing the original score down and making the optimization
+    // look better than it was. That is the exact dishonesty WP-45 forbids.
+    expect(result.subscores_original.section_completeness).toBeGreaterThan(70);
+  });
+
+  it('keeps format on the same measurement basis for both sides', async () => {
+    const result = await scoreResume(buildInput({}));
+    expect(result.subscores.format_parseability).toBe(
+      result.subscores_original.format_parseability
+    );
+  });
+
+  it('does not manufacture a format gain on the real optimize path', async () => {
+    // This is the path that ships (optimize-pipeline -> scoreOptimization), and
+    // it is where the fabrication lived: generateFormatReport (base 85) for the
+    // original against analyzeFormatWithTemplate (base 100) for the optimized
+    // resume handed every single optimization ~2.4 points of delta that
+    // reflected which function ran, not the user's formatting.
+    const result = await scoreOptimization({
+      resumeOriginalText: REAL_RESUME,
+      resumeOptimizedJson: {
+        summary: 'Senior data engineer specialising in Kafka and Spark.',
+        contact: { name: 'Jane Cohen', email: 'jane@example.com', phone: '', location: 'Tel Aviv' },
+        skills: { technical: ['Kafka', 'Spark', 'Snowflake', 'SQL', 'Python'], soft: [] },
+        experience: [
+          {
+            title: 'Senior Data Engineer',
+            company: 'Nimbus Analytics',
+            location: 'Tel Aviv',
+            startDate: 'Jan 2022',
+            endDate: 'Present',
+            achievements: ['Built streaming pipelines on Kafka and Spark'],
+          },
+        ],
+        education: [
+          {
+            degree: 'BSc Computer Science',
+            institution: 'Technion',
+            location: 'Haifa',
+            graduationDate: '2016',
+          },
+        ],
+        matchScore: 0,
+        keyImprovements: [],
+        missingKeywords: [],
+      },
+      jobDescriptionText:
+        'Senior Data Engineer to build streaming pipelines with Kafka, Spark and Snowflake. SQL and Python required.',
+    });
+
+    expect(result.subscores.format_parseability).toBe(
+      result.subscores_original.format_parseability
+    );
   });
 });
 

--- a/src/lib/ats/analyzers/recency-fit.ts
+++ b/src/lib/ats/analyzers/recency-fit.ts
@@ -20,12 +20,18 @@ export class RecencyAnalyzer extends BaseAnalyzer {
     try {
       const currentDate = input.timestamp || new Date();
 
-      if (!input.resume_json || !input.resume_json.experience || input.resume_json.experience.length === 0) {
+      // `recency_json` carries work history recovered from a plain-text resume
+      // when no structured JSON exists, so the original and optimized sides of
+      // a comparison are both scored on real dates instead of one of them
+      // falling back to the constant below (WP-45 D4).
+      const resume = input.resume_json ?? input.recency_json;
+
+      if (!resume || !resume.experience || resume.experience.length === 0) {
         return this.createResult(50, { error: 'No experience data available' }, 0.6);
       }
 
       // Analyze latest role
-      const latestRole = getLatestRole(input.resume_json);
+      const latestRole = getLatestRole(resume);
       if (!latestRole) {
         return this.createResult(40, { error: 'Could not extract latest role' }, 0.5);
       }
@@ -38,7 +44,7 @@ export class RecencyAnalyzer extends BaseAnalyzer {
 
       // Calculate temporal decay for older roles
       const experienceDecay = this.calculateExperienceDecay(
-        input.resume_json.experience,
+        resume.experience,
         currentDate
       );
 

--- a/src/lib/ats/config/weights.ts
+++ b/src/lib/ats/config/weights.ts
@@ -11,24 +11,38 @@ import type { SubScoreKey } from '../types';
  * Sub-score weights (must sum to 1.0)
  *
  * Rationale for weight distribution:
- * - keyword_exact (22%): Most critical - ATS primarily keyword-match
- * - semantic_relevance (16%): Important for quality beyond keywords
- * - format_parseability (14%): Critical for ATS systems to parse
- * - keyword_phrase (12%): Captures context beyond single keywords
- * - title_alignment (10%): Important for role match
- * - metrics_presence (10%): Demonstrates impact
- * - section_completeness (8%): Basic hygiene factor
- * - recency_fit (8%): Nice-to-have but not critical
+ * - keyword_exact (25%): Most critical - ATS primarily keyword-match
+ * - semantic_relevance (18.18%): Important for quality beyond keywords
+ * - format_parseability (15.91%): Critical for ATS systems to parse
+ * - title_alignment (11.36%): Important for role match
+ * - metrics_presence (11.36%): Demonstrates impact
+ * - section_completeness (9.09%): Basic hygiene factor
+ * - recency_fit (9.1%): Nice-to-have but not critical
+ * - keyword_phrase (0%): withdrawn, see below
+ *
+ * keyword_phrase was withdrawn from the composite on 2026-07-24 (WP-45 D1).
+ * It measures verbatim 3-6 word n-gram reuse between the job description and
+ * the resume. Over 60 days of production scoring (n=59) it averaged 0.6 on
+ * original resumes and 4.2 on optimized ones, out of 100 — the only way to
+ * move it is to paste job-description sentences into the resume, which is the
+ * keyword-stuffing behavior we do not want to optimize toward. Carrying 12% of
+ * the score on a component nobody can earn cost every user ~11.5 points and
+ * was a large part of why "strong" (>= 75) had never once been awarded.
+ *
+ * The analyzer still runs and still feeds suggestions; it just no longer sits
+ * in the denominator. The remaining weights are the original ratios rescaled
+ * onto the smaller pool (old / 0.88), which preserves the relative ranking
+ * documented above. Final weights are S5's decision, not this file's.
  */
 export const SUB_SCORE_WEIGHTS: Record<SubScoreKey, number> = {
-  keyword_exact: 0.22,
-  keyword_phrase: 0.12,
-  semantic_relevance: 0.16,
-  title_alignment: 0.10,
-  metrics_presence: 0.10,
-  section_completeness: 0.08,
-  format_parseability: 0.14,
-  recency_fit: 0.08,
+  keyword_exact: 0.25,
+  keyword_phrase: 0,
+  semantic_relevance: 0.1818,
+  title_alignment: 0.1136,
+  metrics_presence: 0.1136,
+  section_completeness: 0.0909,
+  format_parseability: 0.1591,
+  recency_fit: 0.091,
 };
 
 /**

--- a/src/lib/ats/config/weights.ts
+++ b/src/lib/ats/config/weights.ts
@@ -29,10 +29,17 @@ import type { SubScoreKey } from '../types';
  * the score on a component nobody can earn cost every user ~11.5 points and
  * was a large part of why "strong" (>= 75) had never once been awarded.
  *
- * The analyzer still runs and still feeds suggestions; it just no longer sits
- * in the denominator. The remaining weights are the original ratios rescaled
- * onto the smaller pool (old / 0.88), which preserves the relative ranking
- * documented above. Final weights are S5's decision, not this file's.
+ * The analyzer still runs and its evidence is still recorded in ats_subscores.
+ * Its user-facing suggestions do drop out, because estimateImpact multiplies
+ * the projected gain by the component's weight and the result then falls under
+ * SUGGESTION_THRESHOLDS.min_gain — which is the honest outcome: advice that
+ * cannot move the score should not be presented as if it can.
+ *
+ * The remaining weights are the original ratios rescaled onto the smaller pool
+ * (old / 0.88), preserving the relative ranking documented above. recency_fit
+ * carries the +0.0001 rounding residue so the set sums to exactly 1.0; it is
+ * otherwise identical to section_completeness as before. Final weights are
+ * S5's decision, not this file's.
  */
 export const SUB_SCORE_WEIGHTS: Record<SubScoreKey, number> = {
   keyword_exact: 0.25,
@@ -94,6 +101,14 @@ export function getAdjustedWeights(failedAnalyzers: SubScoreKey[]): Record<SubSc
 
   // Calculate remaining weight
   const remainingWeight = 1.0 - failedWeight;
+
+  // Every surviving analyzer carries zero weight (possible now that
+  // keyword_phrase is weighted 0 — if it is the only one that succeeded,
+  // failedWeight sums to 1.0). Dividing here would yield NaN and propagate a
+  // NaN score all the way to the database.
+  if (remainingWeight <= 0) {
+    return SUB_SCORE_WEIGHTS;
+  }
 
   // Redistribute proportionally
   const adjusted: Record<string, number> = {};

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -70,7 +70,8 @@ export async function scoreResume(
         ...preparedInput,
         format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: resolveOriginalResumeJson(input),
+        resume_json: input.resume_original_json,
+        recency_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
@@ -244,6 +245,13 @@ async function prepareInput(input: ATSScoreInput) {
  * real number. Deriving a minimal structure from the text makes the two sides
  * comparable. Returns undefined when nothing dated can be read, preserving the
  * previous behavior rather than scoring against a guess (WP-45 D4).
+ *
+ * The result is passed as `recency_json`, never as `resume_json`: the derived
+ * object has no summary, skills or education, and section_completeness,
+ * metrics_presence, title_alignment and semantic all branch on `resume_json`.
+ * Feeding them the stub would read those empty fields as missing sections and
+ * push the ORIGINAL score down, widening the reported improvement for reasons
+ * unrelated to the optimization.
  */
 function resolveOriginalResumeJson(input: ATSScoreInput) {
   if (input.resume_original_json) return input.resume_original_json;

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -22,6 +22,7 @@ import { extractJobData, isJobExtractionComplete } from './extractors/jd-extract
 import { buildJobDataFromExtractedJson } from './job-data-resolver';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
+import { deriveResumeJsonFromText } from './extractors/experience-text-extractor';
 
 /**
  * Normalize ATS score — clamps to valid [0, 100] range.
@@ -58,15 +59,22 @@ export async function scoreResume(
       responsibilities_count: preparedInput.job_data.responsibilities.length,
     });
 
-    // Run all analyzers in parallel for both original and optimized resumes
+    // Run all analyzers in parallel for both original and optimized resumes.
+    //
+    // Each side gets its own format report and its own structured resume, so
+    // format_parseability and recency_fit are measured the same way on both
+    // sides of the comparison (WP-45 D3/D4). Sharing them made 22% of the
+    // weighting either frozen or asymmetric across the before/after pair.
     const [originalResults, optimizedResults] = await Promise.all([
       runAllAnalyzers({
         ...preparedInput,
+        format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: input.resume_original_json,
+        resume_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
+        format_report: preparedInput.format_report_optimized,
         resume_text: input.resume_optimized_text,
         resume_json: input.resume_optimized_json,
       }),
@@ -204,12 +212,42 @@ async function prepareInput(input: ATSScoreInput) {
         issues: [],
       };
 
+  // Resolve a report per side. Callers that supply only the shared
+  // `format_report` keep today's behavior; callers that supply per-side
+  // reports get an honest format comparison (WP-45 D3).
+  const format_report_original =
+    input.format_report_original ??
+    (input.resume_original_json
+      ? analyzeFormatWithTemplate(input.resume_original_json, null)
+      : format_report);
+
+  const format_report_optimized =
+    input.format_report_optimized ??
+    (input.resume_optimized_json
+      ? analyzeFormatWithTemplate(input.resume_optimized_json, null)
+      : format_report);
+
   return {
     job_text: input.job_clean_text,
     job_data,
     format_report,
+    format_report_original,
+    format_report_optimized,
     timestamp: input.timestamp || new Date(),
   };
+}
+
+/**
+ * The original resume usually arrives as plain text with no structured JSON,
+ * which sends the recency analyzer down its "no experience data" path and pins
+ * it at a constant 50 — while the optimized side, which always has JSON, gets a
+ * real number. Deriving a minimal structure from the text makes the two sides
+ * comparable. Returns undefined when nothing dated can be read, preserving the
+ * previous behavior rather than scoring against a guess (WP-45 D4).
+ */
+function resolveOriginalResumeJson(input: ATSScoreInput) {
+  if (input.resume_original_json) return input.resume_original_json;
+  return deriveResumeJsonFromText(input.resume_original_text) ?? undefined;
 }
 
 /**

--- a/src/lib/ats/extractors/experience-text-extractor.ts
+++ b/src/lib/ats/extractors/experience-text-extractor.ts
@@ -1,0 +1,166 @@
+/**
+ * Experience Text Extractor
+ *
+ * Derives a minimal structured experience list from a plain-text resume.
+ *
+ * Why this exists (WP-45 D4): the scoring engine compares an original resume
+ * against an optimized one, but only the optimized side has structured JSON.
+ * The recency analyzer returns a constant 50 when no experience array is
+ * present, so the original side was scored against a placeholder while the
+ * optimized side got a real number — a systematic bias in every reported
+ * before/after delta that had nothing to do with the optimization.
+ *
+ * This extractor is deliberately conservative. It returns null unless it finds
+ * at least one dated role, so a resume it cannot read keeps today's behavior
+ * rather than being scored against a guess.
+ */
+
+import type { OptimizedResume } from '@/lib/ai-optimizer';
+
+const MONTH =
+  '(?:jan|feb|mar|apr|may|jun|jul|aug|sep|sept|oct|nov|dec)[a-z]*\\.?';
+const YEAR = '(?:19|20)\\d{2}';
+const DATE_POINT = `(?:${MONTH}\\s+)?${YEAR}`;
+const RANGE_SEPARATOR = '\\s*(?:-|–|—|to)\\s*';
+
+/** e.g. "Jan 2022 - Present", "2019 – 2021", "March 2020 to Aug 2023" */
+const DATE_RANGE = new RegExp(
+  `(${DATE_POINT})${RANGE_SEPARATOR}(present|current|${DATE_POINT})`,
+  'i'
+);
+
+/** Section headings and contact noise that must never be read as a job title. */
+const NON_TITLE_LINE =
+  /^(experience|work experience|professional experience|employment|education|skills|core competencies|key skills|technical expertise|certifications|projects|summary|professional summary|contact|languages|tools|frameworks)\b/i;
+
+const BULLET = /^\s*(?:[•·▪◦*\-–—]|\d+[.)])\s+/;
+
+const MAX_TITLE_LOOKBACK = 3;
+
+export interface DerivedExperience {
+  title: string;
+  company: string;
+  location: string;
+  startDate: string;
+  endDate: string;
+  achievements: string[];
+  responsibilities?: string[];
+}
+
+/**
+ * Parse a "Title at Company" / "Title, Company" / "Title | Company" line.
+ */
+function splitTitleAndCompany(line: string): { title: string; company: string } {
+  const atMatch = line.match(/^(.+?)\s+(?:at|@)\s+(.+)$/i);
+  if (atMatch) {
+    return { title: atMatch[1].trim(), company: atMatch[2].trim() };
+  }
+
+  const delimited = line.split(/\s*[|,–—]\s*/).filter(Boolean);
+  if (delimited.length >= 2) {
+    return { title: delimited[0].trim(), company: delimited[1].trim() };
+  }
+
+  return { title: line.trim(), company: '' };
+}
+
+function isPlausibleTitleLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed) return false;
+  if (BULLET.test(line)) return false;
+  if (NON_TITLE_LINE.test(trimmed)) return false;
+  if (DATE_RANGE.test(trimmed)) return false;
+  if (trimmed.includes('@') && /\S+@\S+\.\S+/.test(trimmed)) return false; // email
+  // A heading in ALL CAPS with no lowercase is a section marker, not a role.
+  if (trimmed === trimmed.toUpperCase() && /[A-Z]{4,}/.test(trimmed)) return false;
+  return trimmed.length <= 120;
+}
+
+/**
+ * Extract dated roles from plain resume text, most recent first (document
+ * order — the recency analyzer treats index 0 as the current role, which is
+ * the near-universal resume convention).
+ *
+ * Returns an empty array when nothing dated can be read.
+ */
+export function extractExperienceFromText(text: string): DerivedExperience[] {
+  if (!text || !text.trim()) return [];
+
+  const lines = text.split(/\r?\n/);
+  const roles: DerivedExperience[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const dateMatch = lines[i].match(DATE_RANGE);
+    if (!dateMatch) continue;
+
+    // Walk back for the nearest line that looks like a role heading.
+    let titleLine = '';
+    for (let back = 1; back <= MAX_TITLE_LOOKBACK && i - back >= 0; back++) {
+      const candidate = lines[i - back];
+      if (isPlausibleTitleLine(candidate)) {
+        titleLine = candidate;
+        break;
+      }
+    }
+
+    // The date line itself may carry the role ("Data Engineer | 2019 - 2021").
+    if (!titleLine) {
+      const withoutDates = lines[i].replace(DATE_RANGE, '').replace(/[|,–—-]\s*$/, '').trim();
+      if (isPlausibleTitleLine(withoutDates)) {
+        titleLine = withoutDates;
+      }
+    }
+
+    if (!titleLine) continue;
+
+    const { title, company } = splitTitleAndCompany(titleLine);
+
+    // Collect the bullets that follow, until the next blank-line-separated block.
+    const achievements: string[] = [];
+    for (let ahead = i + 1; ahead < lines.length; ahead++) {
+      const line = lines[ahead];
+      if (BULLET.test(line)) {
+        achievements.push(line.replace(BULLET, '').trim());
+        continue;
+      }
+      if (!line.trim()) {
+        if (achievements.length > 0) break;
+        continue;
+      }
+      if (DATE_RANGE.test(line) || isPlausibleTitleLine(line)) break;
+    }
+
+    roles.push({
+      title,
+      company,
+      location: '',
+      startDate: dateMatch[1].trim(),
+      endDate: dateMatch[2].trim(),
+      achievements,
+    });
+  }
+
+  return roles;
+}
+
+/**
+ * Build the minimal OptimizedResume shape the analyzers need from plain text.
+ *
+ * Returns null when no dated role can be read, so callers fall back to today's
+ * behavior instead of scoring against an invented structure.
+ */
+export function deriveResumeJsonFromText(text: string): OptimizedResume | null {
+  const experience = extractExperienceFromText(text);
+  if (experience.length === 0) return null;
+
+  return {
+    summary: '',
+    contact: { name: '', email: '', phone: '', location: '' },
+    skills: { technical: [], soft: [] },
+    experience,
+    education: [],
+    matchScore: 0,
+    keyImprovements: [],
+    missingKeywords: [],
+  };
+}

--- a/src/lib/ats/extractors/experience-text-extractor.ts
+++ b/src/lib/ats/extractors/experience-text-extractor.ts
@@ -33,9 +33,23 @@ const DATE_RANGE = new RegExp(
 const NON_TITLE_LINE =
   /^(experience|work experience|professional experience|employment|education|skills|core competencies|key skills|technical expertise|certifications|projects|summary|professional summary|contact|languages|tools|frameworks)\b/i;
 
+/**
+ * Sections whose date ranges are not employment. Graduation years and
+ * certification dates otherwise parse as jobs, and because the recency analyzer
+ * treats the first entry as the current role, a degree from 2016 can be read as
+ * the candidate's present position.
+ */
+const NON_EMPLOYMENT_SECTION =
+  /^(education|certifications?|licenses?|projects?|publications?|awards?|volunteering|courses?|training)\b/i;
+
+/** Sections that contain employment. Re-entering one resumes parsing. */
+const EMPLOYMENT_SECTION =
+  /^(experience|work experience|professional experience|employment|career history|work history)\b/i;
+
 const BULLET = /^\s*(?:[•·▪◦*\-–—]|\d+[.)])\s+/;
 
 const MAX_TITLE_LOOKBACK = 3;
+const MAX_ACHIEVEMENTS = 12;
 
 export interface DerivedExperience {
   title: string;
@@ -77,6 +91,68 @@ function isPlausibleTitleLine(line: string): boolean {
 }
 
 /**
+ * Does this leftover text read like a job title rather than a location or a
+ * stray fragment? Used to decide whether the date line carries its own role:
+ * "Data Engineer | 2019 - 2021" does, "Tel Aviv | Jan 2022 - Present" does not.
+ */
+function isRoleLike(text: string): boolean {
+  if (!isPlausibleTitleLine(text)) return false;
+  if (/\s+(?:at|@)\s+/i.test(text)) return true;
+  return text.split(/\s+/).filter(Boolean).length >= 3;
+}
+
+/** Does a dated role begin within the next few non-blank lines? */
+function startsNewRole(lines: string[], from: number): boolean {
+  let seen = 0;
+  for (let i = from; i < lines.length && seen < 3; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed) continue;
+    if (NON_TITLE_LINE.test(trimmed)) return true;
+    if (DATE_RANGE.test(lines[i])) return true;
+    seen++;
+  }
+  return false;
+}
+
+/**
+ * Collect what the person did in this role.
+ *
+ * Bulleted resumes are the easy case. Plain-prose resumes are common in PDF
+ * exports, and treating every unbulleted line as the start of the next role
+ * left achievements empty — which drove recency_fit toward 0, strictly worse
+ * than the constant 50 it was meant to replace, because the only text left to
+ * match against the job description was the title.
+ */
+function collectAchievements(lines: string[], dateLineIndex: number): string[] {
+  const achievements: string[] = [];
+
+  for (let ahead = dateLineIndex + 1; ahead < lines.length; ahead++) {
+    if (achievements.length >= MAX_ACHIEVEMENTS) break;
+    const line = lines[ahead];
+    const trimmed = line.trim();
+
+    // A new dated role, or a new section, ends this one.
+    if (DATE_RANGE.test(line)) break;
+    if (trimmed && !BULLET.test(line) && NON_TITLE_LINE.test(trimmed)) break;
+
+    if (BULLET.test(line)) {
+      achievements.push(line.replace(BULLET, '').trim());
+      continue;
+    }
+
+    if (!trimmed) {
+      // A blank line ends the role only when the next role starts right after.
+      if (startsNewRole(lines, ahead + 1)) break;
+      continue;
+    }
+
+    achievements.push(trimmed);
+  }
+
+  return achievements;
+}
+
+/**
  * Extract dated roles from plain resume text, most recent first (document
  * order — the recency analyzer treats index 0 as the current role, which is
  * the near-universal resume convention).
@@ -88,47 +164,51 @@ export function extractExperienceFromText(text: string): DerivedExperience[] {
 
   const lines = text.split(/\r?\n/);
   const roles: DerivedExperience[] = [];
+  let inNonEmploymentSection = false;
 
   for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    // Track which section we are in, so education and certification dates are
+    // never read as jobs.
+    if (trimmed && !BULLET.test(lines[i])) {
+      if (NON_EMPLOYMENT_SECTION.test(trimmed)) {
+        inNonEmploymentSection = true;
+      } else if (EMPLOYMENT_SECTION.test(trimmed)) {
+        inNonEmploymentSection = false;
+      }
+    }
+    if (inNonEmploymentSection) continue;
+
+    // A date range inside a bullet describes the work, it does not start a new
+    // role: "Cut infra spend 30% across the 2019 - 2021 legacy stack" would
+    // otherwise duplicate the role above it with the wrong end date.
+    if (BULLET.test(lines[i])) continue;
+
     const dateMatch = lines[i].match(DATE_RANGE);
     if (!dateMatch) continue;
 
-    // Walk back for the nearest line that looks like a role heading.
-    let titleLine = '';
-    for (let back = 1; back <= MAX_TITLE_LOOKBACK && i - back >= 0; back++) {
-      const candidate = lines[i - back];
-      if (isPlausibleTitleLine(candidate)) {
-        titleLine = candidate;
-        break;
-      }
-    }
+    // The date line may itself carry the role ("Data Engineer | 2019 - 2021").
+    // Prefer it only when the leftover text actually looks like a role — a bare
+    // "Tel Aviv" left over from "Tel Aviv | Jan 2022 - Present" does not.
+    const residual = lines[i].replace(DATE_RANGE, '').replace(/[|,–—-]\s*$/, '').trim();
+    let titleLine = isRoleLike(residual) ? residual : '';
 
-    // The date line itself may carry the role ("Data Engineer | 2019 - 2021").
+    // Otherwise walk back for the nearest line that looks like a role heading.
     if (!titleLine) {
-      const withoutDates = lines[i].replace(DATE_RANGE, '').replace(/[|,–—-]\s*$/, '').trim();
-      if (isPlausibleTitleLine(withoutDates)) {
-        titleLine = withoutDates;
+      for (let back = 1; back <= MAX_TITLE_LOOKBACK && i - back >= 0; back++) {
+        const candidate = lines[i - back];
+        if (isPlausibleTitleLine(candidate)) {
+          titleLine = candidate;
+          break;
+        }
       }
     }
 
+    if (!titleLine && isPlausibleTitleLine(residual)) titleLine = residual;
     if (!titleLine) continue;
 
     const { title, company } = splitTitleAndCompany(titleLine);
-
-    // Collect the bullets that follow, until the next blank-line-separated block.
-    const achievements: string[] = [];
-    for (let ahead = i + 1; ahead < lines.length; ahead++) {
-      const line = lines[ahead];
-      if (BULLET.test(line)) {
-        achievements.push(line.replace(BULLET, '').trim());
-        continue;
-      }
-      if (!line.trim()) {
-        if (achievements.length > 0) break;
-        continue;
-      }
-      if (DATE_RANGE.test(line) || isPlausibleTitleLine(line)) break;
-    }
 
     roles.push({
       title,
@@ -136,7 +216,7 @@ export function extractExperienceFromText(text: string): DerivedExperience[] {
       location: '',
       startDate: dateMatch[1].trim(),
       endDate: dateMatch[2].trim(),
-      achievements,
+      achievements: collectAchievements(lines, i),
     });
   }
 
@@ -144,10 +224,15 @@ export function extractExperienceFromText(text: string): DerivedExperience[] {
 }
 
 /**
- * Build the minimal OptimizedResume shape the analyzers need from plain text.
+ * Build the minimal OptimizedResume shape the recency analyzer needs from
+ * plain text.
  *
  * Returns null when no dated role can be read, so callers fall back to today's
  * behavior instead of scoring against an invented structure.
+ *
+ * The result must be passed as `recency_json`, never as `resume_json` — the
+ * object has no summary, skills or education, and the analyzers that branch on
+ * `resume_json` would read those empty fields as genuinely missing sections.
  */
 export function deriveResumeJsonFromText(text: string): OptimizedResume | null {
   const experience = extractExperienceFromText(text);

--- a/src/lib/ats/index.ts
+++ b/src/lib/ats/index.ts
@@ -71,7 +71,8 @@ export async function scoreResume(
         ...preparedInput,
         format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: resolveOriginalResumeJson(input),
+        resume_json: input.resume_original_json,
+        recency_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
@@ -268,6 +269,13 @@ async function prepareInput(input: ATSScoreInput) {
  * real number. Deriving a minimal structure from the text makes the two sides
  * comparable. Returns undefined when nothing dated can be read, preserving the
  * previous behavior rather than scoring against a guess (WP-45 D4).
+ *
+ * The result is passed as `recency_json`, never as `resume_json`: the derived
+ * object has no summary, skills or education, and section_completeness,
+ * metrics_presence, title_alignment and semantic all branch on `resume_json`.
+ * Feeding them the stub would read those empty fields as missing sections and
+ * push the ORIGINAL score down, widening the reported improvement for reasons
+ * unrelated to the optimization.
  */
 function resolveOriginalResumeJson(input: ATSScoreInput) {
   if (input.resume_original_json) return input.resume_original_json;

--- a/src/lib/ats/index.ts
+++ b/src/lib/ats/index.ts
@@ -22,6 +22,7 @@ import { extractJobData, isJobExtractionComplete } from './extractors/jd-extract
 import { buildJobDataFromExtractedJson } from './job-data-resolver';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
+import { deriveResumeJsonFromText } from './extractors/experience-text-extractor';
 
 /**
  * Normalize ATS score — clamps to valid [0, 100] range.
@@ -59,15 +60,22 @@ export async function scoreResume(
       responsibilities_count: preparedInput.job_data.responsibilities.length,
     });
 
-    // Run all analyzers in parallel for both original and optimized resumes
+    // Run all analyzers in parallel for both original and optimized resumes.
+    //
+    // Each side gets its own format report and its own structured resume, so
+    // format_parseability and recency_fit are measured the same way on both
+    // sides of the comparison (WP-45 D3/D4). Sharing them made 22% of the
+    // weighting either frozen or asymmetric across the before/after pair.
     const [originalResults, optimizedResults] = await Promise.all([
       runAllAnalyzers({
         ...preparedInput,
+        format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: input.resume_original_json,
+        resume_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
+        format_report: preparedInput.format_report_optimized,
         resume_text: input.resume_optimized_text,
         resume_json: input.resume_optimized_json,
       }),
@@ -228,12 +236,42 @@ async function prepareInput(input: ATSScoreInput) {
         issues: [],
       };
 
+  // Resolve a report per side. Callers that supply only the shared
+  // `format_report` keep today's behavior; callers that supply per-side
+  // reports get an honest format comparison (WP-45 D3).
+  const format_report_original =
+    input.format_report_original ??
+    (input.resume_original_json
+      ? analyzeFormatWithTemplate(input.resume_original_json, null)
+      : format_report);
+
+  const format_report_optimized =
+    input.format_report_optimized ??
+    (input.resume_optimized_json
+      ? analyzeFormatWithTemplate(input.resume_optimized_json, null)
+      : format_report);
+
   return {
     job_text: input.job_clean_text,
     job_data,
     format_report,
+    format_report_original,
+    format_report_optimized,
     timestamp: input.timestamp || new Date(),
   };
+}
+
+/**
+ * The original resume usually arrives as plain text with no structured JSON,
+ * which sends the recency analyzer down its "no experience data" path and pins
+ * it at a constant 50 — while the optimized side, which always has JSON, gets a
+ * real number. Deriving a minimal structure from the text makes the two sides
+ * comparable. Returns undefined when nothing dated can be read, preserving the
+ * previous behavior rather than scoring against a guess (WP-45 D4).
+ */
+function resolveOriginalResumeJson(input: ATSScoreInput) {
+  if (input.resume_original_json) return input.resume_original_json;
+  return deriveResumeJsonFromText(input.resume_original_text) ?? undefined;
 }
 
 /**

--- a/src/lib/ats/integration.ts
+++ b/src/lib/ats/integration.ts
@@ -9,6 +9,7 @@ import type { ATSScoreInput, JobExtraction, FormatReport, ATSScoreOutput } from 
 import type { OptimizedResume } from '@/lib/ai-optimizer';
 import { extractJobData } from './extractors/jd-extractor';
 import { buildJobDataFromExtractedJson } from './job-data-resolver';
+import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 
 /**
  * Extract keywords and requirements from job description text
@@ -168,7 +169,10 @@ export async function scoreOptimization(params: {
     ? buildJobDataFromExtractedJson(jobExtractedJson, jobDescriptionText)
     : extractJobRequirements(jobDescriptionText, jobTitle);
 
-  // Generate format reports
+  // Generate format reports — one per side. The original is only available as
+  // text, so it uses the text heuristic; the optimized side is structured, so
+  // it gets the real template-aware analysis. Passing a single shared report
+  // froze format_parseability across the pair (WP-45 D3).
   const formatReport = generateFormatReport(resumeOriginalText);
 
   // Prepare ATS input
@@ -178,7 +182,11 @@ export async function scoreOptimization(params: {
     job_clean_text: jobDescriptionText,
     job_extracted_json: jobExtraction,
     format_report: formatReport,
-    resume_original_json: undefined, // Don't have structured original
+    format_report_original: formatReport,
+    format_report_optimized: analyzeFormatWithTemplate(resumeOptimizedJson, null),
+    // Left undefined on purpose: the scorer derives a minimal structure from
+    // the original text so recency is measured the same way on both sides.
+    resume_original_json: undefined,
     resume_optimized_json: resumeOptimizedJson,
   };
 

--- a/src/lib/ats/integration.ts
+++ b/src/lib/ats/integration.ts
@@ -9,7 +9,6 @@ import type { ATSScoreInput, JobExtraction, FormatReport, ATSScoreOutput } from 
 import type { OptimizedResume } from '@/lib/ai-optimizer';
 import { extractJobData } from './extractors/jd-extractor';
 import { buildJobDataFromExtractedJson } from './job-data-resolver';
-import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 
 /**
  * Extract keywords and requirements from job description text
@@ -169,11 +168,19 @@ export async function scoreOptimization(params: {
     ? buildJobDataFromExtractedJson(jobExtractedJson, jobDescriptionText)
     : extractJobRequirements(jobDescriptionText, jobTitle);
 
-  // Generate format reports — one per side. The original is only available as
-  // text, so it uses the text heuristic; the optimized side is structured, so
-  // it gets the real template-aware analysis. Passing a single shared report
-  // froze format_parseability across the pair (WP-45 D3).
-  const formatReport = generateFormatReport(resumeOriginalText);
+  // Generate format reports — one per side, but from the SAME function.
+  //
+  // Both sides must be measured the same way or the comparison is meaningless.
+  // Running generateFormatReport (text heuristic, base 85) against the original
+  // and analyzeFormatWithTemplate (JSON heuristic, base 100) against the
+  // optimized resume would hand every optimization a free ~15-point format gain
+  // that reflects which function ran, not the user's formatting (WP-45 D3).
+  //
+  // In practice these two reports usually agree, because the optimized resume
+  // is rendered through our own template. That is the honest answer: optimizing
+  // content does not change format safety much.
+  const formatReportOriginal = generateFormatReport(resumeOriginalText);
+  const formatReportOptimized = generateFormatReport(resumeOptimizedText);
 
   // Prepare ATS input
   const atsInput: ATSScoreInput = {
@@ -181,9 +188,9 @@ export async function scoreOptimization(params: {
     resume_optimized_text: resumeOptimizedText,
     job_clean_text: jobDescriptionText,
     job_extracted_json: jobExtraction,
-    format_report: formatReport,
-    format_report_original: formatReport,
-    format_report_optimized: analyzeFormatWithTemplate(resumeOptimizedJson, null),
+    format_report: formatReportOriginal,
+    format_report_original: formatReportOriginal,
+    format_report_optimized: formatReportOptimized,
     // Left undefined on purpose: the scorer derives a minimal structure from
     // the original text so recency is measured the same way on both sides.
     resume_original_json: undefined,
@@ -227,8 +234,10 @@ export async function rescoreAfterTipImplementation(params: {
     ? buildJobDataFromExtractedJson(jobExtractedJson, jobDescriptionText)
     : extractJobRequirements(jobDescriptionText, jobTitle);
 
-  // Generate format reports
-  const formatReport = generateFormatReport(resumeOriginalText);
+  // Same per-side treatment as scoreOptimization, from the same function, so
+  // the two entry points in this file cannot drift apart (WP-45 D3).
+  const formatReportOriginal = generateFormatReport(resumeOriginalText);
+  const formatReportOptimized = generateFormatReport(resumeOptimizedText);
 
   // Prepare ATS input - we only need to score the optimized resume
   const atsInput: ATSScoreInput = {
@@ -236,7 +245,9 @@ export async function rescoreAfterTipImplementation(params: {
     resume_optimized_text: resumeOptimizedText,
     job_clean_text: jobDescriptionText,
     job_extracted_json: jobExtraction,
-    format_report: formatReport,
+    format_report: formatReportOriginal,
+    format_report_original: formatReportOriginal,
+    format_report_optimized: formatReportOptimized,
     resume_original_json: undefined,
     resume_optimized_json: resumeOptimizedJson,
   };

--- a/src/lib/ats/quick-wins/prompt.ts
+++ b/src/lib/ats/quick-wins/prompt.ts
@@ -7,6 +7,7 @@
 
 import type { JobExtraction, SubScores, SubScoreKey } from '../types';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
+import { SUB_SCORE_WEIGHTS } from '../config/weights';
 
 interface QuickWinsPromptParams {
   resume_text: string;
@@ -94,6 +95,10 @@ function identifyWeakSpots(subscores: SubScores): WeakSpot[] {
   const entries = Object.entries(subscores) as Array<[SubScoreKey, number]>;
 
   return entries
+    // Skip components that carry no weight — they are structurally low, so
+    // they would crowd out the fixable dimensions and steer the model at
+    // advice that cannot move the score (WP-45 D1).
+    .filter(([key]) => SUB_SCORE_WEIGHTS[key] > 0)
     .filter(([, score]) => score < 70) // Only include weak scores
     .sort((a, b) => a[1] - b[1]) // Sort ascending (worst first)
     .slice(0, 3) // Top 3 weakest

--- a/src/lib/ats/scorers/penalties.ts
+++ b/src/lib/ats/scorers/penalties.ts
@@ -22,14 +22,18 @@ export function applyPenalties(
   let penalizedScore = score;
   const appliedPenalties: Array<{ reason: string; amount: number }> = [];
 
-  // Penalty 1: No metrics found
-  if (subscores.metrics_presence < 10) {
-    penalizedScore -= PENALTY_THRESHOLDS.no_metrics_penalty;
-    appliedPenalties.push({
-      reason: 'No quantified metrics found in resume',
-      amount: PENALTY_THRESHOLDS.no_metrics_penalty,
-    });
-  }
+  // Penalty 1 (withdrawn 2026-07-24, WP-45 D2): "no quantified metrics".
+  //
+  // metrics_presence is already a weighted component, and it hard-clamps to 0
+  // when a resume has no metrics — so subtracting another 5 points for the same
+  // fact charged every user twice for one shortcoming. Production means were
+  // 6.2 before and 7.2 after optimization, i.e. the < 10 trigger fired on
+  // essentially every scoring run on both sides of the before/after pair. It
+  // could not be escaped either: stripFabricatedMetrics (correctly) stops the
+  // optimizer from inventing figures, so no amount of optimizing cleared it.
+  //
+  // The component still carries the signal, and the suggestion generator still
+  // tells the user to add quantified achievements.
 
   // Penalty 2: Title/seniority mismatch
   if (subscores.title_alignment < 40) {
@@ -75,7 +79,9 @@ export function checkPenaltyRisks(subscores: SubScores): string[] {
   const risks: string[] = [];
 
   if (subscores.metrics_presence < 10) {
-    risks.push('Missing quantified metrics will reduce score');
+    // No longer a separate penalty (WP-45 D2) — it lowers the metrics_presence
+    // component itself, which is already weighted.
+    risks.push('Missing quantified metrics is lowering the impact score');
   }
 
   if (subscores.title_alignment < 40) {

--- a/src/lib/ats/types.ts
+++ b/src/lib/ats/types.ts
@@ -27,8 +27,21 @@ export interface ATSScoreInput {
   /** Structured data extracted from job description */
   job_extracted_json: JobExtraction;
 
-  /** Format analysis report for both resumes */
+  /**
+   * Format analysis report. Used for both resumes unless a per-side report is
+   * supplied below.
+   *
+   * Prefer the per-side fields: sharing one report across the before/after pair
+   * freezes format_parseability so the optimized resume is graded on the
+   * original's formatting (WP-45 D3).
+   */
   format_report: FormatReport;
+
+  /** Format report for the original resume. Wins over `format_report`. */
+  format_report_original?: FormatReport;
+
+  /** Format report for the optimized resume. Wins over `format_report`. */
+  format_report_optimized?: FormatReport;
 
   /** Timestamp for recency calculations (defaults to now) */
   timestamp?: Date;

--- a/src/lib/ats/types.ts
+++ b/src/lib/ats/types.ts
@@ -439,6 +439,18 @@ export interface AnalyzerInput {
   /** Format report */
   format_report?: FormatReport;
 
+  /**
+   * Dated work history recovered from plain resume text, for the recency
+   * analyzer only.
+   *
+   * This is deliberately NOT `resume_json`. Four other analyzers branch on
+   * `resume_json` and would read a derived stub's empty summary/skills/
+   * education as genuinely missing sections, collapsing the original side's
+   * scores and widening the before/after delta for reasons that have nothing
+   * to do with the optimization (WP-45 D4).
+   */
+  recency_json?: OptimizedResume;
+
   /** Timestamp for recency calculations */
   timestamp?: Date;
 }

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,27 @@
 # Project Progress
 
+## 2026-07-24 — WP-45 S1: repair the three dead scoring components (PR #119)
+
+Backend-only scorer integrity pass. Triggered by a moderated user session (Meirav) that showed a fit score of 45, then 42 before / 44 after optimizing. The audit found the composite was structurally incapable of doing better.
+
+**Evidence (privacy-safe aggregates, 60 days, pulled 2026-07-24):** free checker `anonymous_ats_scores` n=67, mean 34.5, max 51, zero at or above 75. Authenticated `optimizations` n=59, 32.2 -> 41.6, max after 62, and 24 of 59 (41%) ended at +4 or worse. Across all non-tester `fit_check_completed` events, `strong` has never once been emitted against its own >= 75 threshold.
+
+**Four defects, all confirmed in code and in the subscore means:**
+- `keyword_phrase` (12% weight): 0.6 -> 4.2. Scores verbatim 3-6 word JD reuse, so only keyword stuffing moves it. Withdrawn from the weighting; remaining weights rescaled old/0.88. Analyzer still runs.
+- `metrics_presence` (10%): 6.2 -> 7.2. Clamps to 0 without metrics and `penalties.ts` subtracted another 5 for the same fact, on both sides of every pair, unescapable because `stripFabricatedMetrics` correctly forbids inventing figures. Penalty removed.
+- `format_parseability` (14%): 87.8 -> 87.8, identical on all 59 rows. `core.ts` and `index.ts` built one `format_report` and passed it to both analyzer runs. Now resolved per side, in both orchestrators.
+- `recency_fit` (8%): 50.0 -> 12.7. The original arrives as raw text and hits the constant-50 fallback while the optimized side has JSON. New conservative text extractor derives dated roles, returning null rather than guessing.
+
+**Effect:** an excellent candidate whose resume has no quantified metrics scored 72, now 87 — `strong` is reachable for someone who deserves it. A typical resume moves 33 -> 44 and stays below the strong band. A clear mismatch stays low.
+
+**The review pass mattered.** An adversarial review of the first commit found two own-goals that would have inflated the delta: the derived work history was reaching four analyzers that branch on `resume_json`, collapsing the original side's `section_completeness` from ~100 to 25; and `integration.ts` compared `generateFormatReport` (base 85) against `analyzeFormatWithTemplate` (base 100), manufacturing ~+2.4 points on every run. Both corrected in the second commit, plus a NaN path in `getAdjustedWeights` newly reachable via the zero weight.
+
+**Validation:** 30 new deterministic tests, no network. 6 gates verified to fail on the pre-fix source, 5 further regression gates verified to fail on the first commit. Reference fixtures pinned to exact composite values so reverting D1 or D2 fails loudly. Full suite 17 pre-existing suite failures before and after (identical on origin/main), passing 171 -> 201. eslint clean. tsc 26 errors before and after, 0 in `src/lib/ats`. `next build` passes on a clean checkout.
+
+**Not done:** `core.ts`/`index.ts` remain duplicate orchestrators (both patched identically). `SubScoreBreakdown.tsx` still renders `keyword_phrase` as a normal bar. Historical `ats_score_original` rows are not comparable to new ones — that is WP-45 S9 and rescoring needs separate approval. Free-checker scores rise ~11-13 points, so the >= 75 "Strong" verdict may start firing there; band calibration is WP-45 S5.
+
+**Open question:** 15 distinct non-tester people recorded a fit score of exactly 51 and 17 recorded exactly 68. Identical scores across many people suggests a cached or default value; worth 30 minutes before S5 calibration.
+
 ## 2026-07-11 — WP-43: Free ATS Checker entry-funnel activation (Tier A), merged PR #115
 
 Shipped all 6 Tier A stories from a live cold first-time-user walkthrough of resumelybuilderai.com. Copy/design + client-only, no backend changes.


### PR DESCRIPTION
Executes **S1** of [WP-45 v2](https://github.com/nadavyigal/Agentic-OS/blob/main/executive-os/work-packets/WP-45-resumely-direct-optimize-and-score-calibration.md). Backend only — no iOS change, no user-visible copy change, no migration.

## Why

A moderated session on 2026-07-24 showed a fit score of **45**, then **42 before → 44 after** optimizing. The audit found the composite was structurally incapable of doing better: over 60 days, `strong` (≥75) had **never once** been awarded, the observed maxima were 51 (free checker, n=67) and 62 (optimizations, n=59), and **41% of optimizations ended at +4 or worse**.

## The four defects

| | weight | before → after (n=59) | problem |
|---|---|---|---|
| `keyword_phrase` | 12% | 0.6 → 4.2 | needs verbatim 3–6 word JD reuse — only earnable by keyword stuffing |
| `metrics_presence` | 10% | 6.2 → 7.2 | clamps to 0 without metrics **and** triggered a further −5 penalty for the same fact |
| `format_parseability` | 14% | 87.8 → **87.8** | one `format_report` was shared across both analyzer runs — identical on all 59 rows |
| `recency_fit` | 8% | 50.0 → **12.7** | original scored from raw text (constant 50), optimized from JSON (real value) |

## What changed

- `keyword_phrase` withdrawn from the weighting; remaining weights rescaled `old / 0.88`. The analyzer still runs and its evidence is still recorded.
- The `no_metrics_penalty` removed as double-counting. The component keeps the signal and suggestions still tell users to add quantified achievements.
- Per-side format reports, in **both** orchestrators (`core.ts` and `index.ts` are near-duplicate copies serving different call paths).
- A conservative text extractor recovers dated roles from the original resume, returning `null` rather than guessing.

**Effect:** an excellent candidate whose resume has no quantified metrics scored **72**, now **87** — `strong` is reachable for someone who deserves it. A typical real-world resume moves **33 → 44** and stays well below the strong band. A clear mismatch stays low. This removes an unintended deflation; it does not add uplift.

## Second commit: the review caught two own-goals

An adversarial review of the first commit found that two repairs had replaced a frozen-identical artifact with a frozen-**asymmetric** one — widening the reported improvement for reasons unrelated to the optimization, which is exactly what the packet forbids:

1. The derived work history was passed as `resume_json`, but four other analyzers branch on that field. `section_completeness` fell from ~100 to 25 on the original side and `metrics_presence` roughly halved — pushing the *before* score down ~7 points. It now travels as a dedicated `recency_json` that only the recency analyzer reads.
2. `integration.ts` compared `generateFormatReport` (base 85) against `analyzeFormatWithTemplate` (base 100, every risk flag hardcoded `false`) — a free ~15-point format subscore, roughly **+2.4 points of manufactured delta on every run**. Both sides now use the same function.

Also fixed: a newly-reachable `NaN` path in `getAdjustedWeights`; the quick-wins prompt steering the model at a zero-weight component; and a comment claiming `keyword_phrase` "still feeds suggestions" when its weight-scaled `estimated_gain` is filtered out.

## Verification

- **30 tests**, deterministic, no network (the semantic analyzer falls back to a neutral score without an API key).
- 6 gates verified to fail on the pre-fix source; 5 further regression gates verified to fail on the first commit.
- Reference fixtures pinned to **exact composite values**, so reverting D1 or D2 fails loudly rather than sliding within a band.
- Full suite: **17 pre-existing suite failures before and after** (identical on `origin/main`); passing count 171 → 201.
- `eslint` clean. `tsc`: 26 errors before and after, **0** in `src/lib/ats`.
- `next build` passes on a clean checkout of the branch.

## Not done

- `core.ts` / `index.ts` are still duplicate orchestrators. Deduplicating them is follow-up work; both are patched identically here.
- `SubScoreBreakdown.tsx` still renders `keyword_phrase` as a normal bar with no indication it is informational.
- Historical `ats_score_original` rows predate this change and are not comparable to new ones. That is **S9** in the packet, and rescoring is a production data change requiring separate approval.
- The free checker's scores rise ~11–13 points from D1+D2, so the `>= 75` "Strong" verdict may start firing there. Band calibration is **S5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)