### PR TITLE
WP-45 S2: symmetric comparison + no-regression invariant

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import { runOptimizePipeline } from "@/lib/ai-optimizer/optimize-pipeline";
+import { captureServerEvent } from "@/lib/posthog-server";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { checkRateLimit, getRateLimitHeaders, RATE_LIMITS } from "@/lib/utils/rate-limit";
 import { logger } from "@/lib/agent/utils/logger";
@@ -99,6 +100,16 @@ export async function POST(req: NextRequest) {
       },
     );
     const optimizedResume = pipelineResult.optimizedResume;
+
+    // An optimization that did not meaningfully improve on the user's starting
+    // resume is a failure worth counting, not a quiet +2 (WP-45 S2). Payload is
+    // bucketed and carries no resume or job content.
+    if (!pipelineResult.lift.meaningful) {
+      await captureServerEvent(user.id, 'optimization_no_lift', {
+        ...pipelineResult.lift.analyticsProperties,
+        platform: 'web',
+      });
+    }
 
     const { reviewId } = await createOptimizationReviewRun({
       supabase,

--- a/src/app/api/upload-resume/route.ts
+++ b/src/app/api/upload-resume/route.ts
@@ -19,6 +19,7 @@ export const runtime = 'nodejs';
 // Allow up to 120 s: PDF parse + job scrape + gpt-4o optimization + ATS embedding calls
 export const maxDuration = 120;
 import { runOptimizePipeline } from "@/lib/ai-optimizer/optimize-pipeline";
+import { captureServerEvent } from "@/lib/posthog-server";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 
@@ -248,6 +249,15 @@ export async function POST(req: NextRequest) {
       },
     });
     const optimizedResume = pipelineResult.optimizedResume;
+
+    // See WP-45 S2 — count runs that failed to improve on the starting resume.
+    if (!pipelineResult.lift.meaningful) {
+      await captureServerEvent(user.id, 'optimization_no_lift', {
+        ...pipelineResult.lift.analyticsProperties,
+        platform: 'web',
+        source: 'upload-resume',
+      });
+    }
 
     const { reviewId, reviewRun } = await createOptimizationReviewRun({
       supabase,

--- a/src/lib/ai-optimizer/optimize-pipeline.ts
+++ b/src/lib/ai-optimizer/optimize-pipeline.ts
@@ -8,6 +8,7 @@ import {
 } from '../prompts/resume-optimizer';
 import { optimizeResume, type OptimizedResume } from './index';
 import { scoreOptimization, resumeJsonToText } from '@/lib/ats/integration';
+import { assessLift, MIN_MEANINGFUL_LIFT, type LiftAssessment } from '@/lib/ats/lift';
 import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
 import { buildJobDataFromExtractedJson } from '@/lib/ats/job-data-resolver';
 import type { ATSScoreOutput } from '@/lib/ats/types';
@@ -16,6 +17,15 @@ export interface OptimizationPipelineResult {
   optimizedResume: OptimizedResume;
   atsResult: ATSScoreOutput;
   passesUsed: number;
+  /**
+   * Whether this run actually improved on where the user started (WP-45 S2).
+   *
+   * The pipeline previously compared pass 1 against pass 2 and never against
+   * the original, so a run that moved the score by +2 — or moved it down —
+   * was returned as a result. Callers must consult `lift.displayScores` before
+   * showing a before/after pair.
+   */
+  lift: LiftAssessment;
 }
 
 type OptimizationPipelineOptions = {
@@ -247,13 +257,19 @@ export async function runOptimizePipeline(
     console.warn('Pipeline: scoring returned zero-confidence fallback, pass 2 will likely also fail');
   }
 
+  const lift1 = liftFor(score1, 1);
+
+  // Run the second pass when the result is weak in absolute terms, when the
+  // gain is thin, or — the case the old condition missed entirely — when the
+  // run has not meaningfully beaten the resume the user started with.
   const shouldRunPass2 =
     score1.ats_score_optimized < 75 ||
-    score1.ats_score_optimized - score1.ats_score_original < 10;
+    score1.ats_score_optimized - score1.ats_score_original < 10 ||
+    !lift1.meaningful;
 
   if (!shouldRunPass2) {
     console.log('Pipeline: pass 2 not needed, returning pass 1 result');
-    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1 };
+    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1, lift: lift1 };
   }
 
   // Step 4: Conditional pass 2
@@ -271,7 +287,7 @@ export async function runOptimizePipeline(
 
   if (!candidate2Raw) {
     console.warn('Pipeline pass 2 failed, keeping pass 1 candidate');
-    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1 };
+    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1, lift: lift1 };
   }
 
   const candidate2 = stripFabricatedMetrics(candidate2Raw, resumeText);
@@ -291,15 +307,43 @@ export async function runOptimizePipeline(
 
   if (score2.ats_score_optimized === 0 && score2.confidence === 0) {
     console.warn('Pipeline pass 2: scoring returned zero-confidence fallback, keeping pass 1 result');
-    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 2 };
+    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 2, lift: liftFor(score1, 2) };
   }
 
   // Keep the winner
   if (score2.ats_score_optimized >= score1.ats_score_optimized) {
     console.log('Pipeline: pass 2 wins');
-    return { optimizedResume: candidate2, atsResult: score2, passesUsed: 2 };
+    return { optimizedResume: candidate2, atsResult: score2, passesUsed: 2, lift: liftFor(score2, 2) };
   }
 
   console.log('Pipeline: pass 1 wins over pass 2');
-  return { optimizedResume: candidate1, atsResult: score1, passesUsed: 2 };
+  return { optimizedResume: candidate1, atsResult: score1, passesUsed: 2, lift: liftFor(score1, 2) };
+}
+
+/**
+ * Judge a scored candidate against the resume the user started with.
+ *
+ * Note what this does NOT do: it never raises a score, never clamps the delta
+ * positive, and never applies a minimum. A run that failed to improve the
+ * resume stays reported as a run that failed to improve the resume — the
+ * caller decides how to say so (WP-45 S2).
+ */
+function liftFor(score: ATSScoreOutput, passesUsed: number): LiftAssessment {
+  const lift = assessLift({
+    original: score.ats_score_original,
+    optimized: score.ats_score_optimized,
+    subscoresOriginal: score.subscores_original,
+    subscores: score.subscores,
+    passesUsed,
+  });
+
+  if (!lift.meaningful) {
+    console.warn('Pipeline: no meaningful lift', {
+      delta: lift.delta,
+      floor: MIN_MEANINGFUL_LIFT,
+      stalled: lift.stalledComponents,
+    });
+  }
+
+  return lift;
 }

--- a/src/lib/ats/__tests__/symmetric-comparison.test.ts
+++ b/src/lib/ats/__tests__/symmetric-comparison.test.ts
@@ -1,0 +1,269 @@
+/**
+ * WP-45 S2 — Symmetric before/after and the no-regression invariant
+ *
+ * Two promises:
+ *
+ *   1. The two sides of a before/after comparison are measured by the SAME
+ *      function. Four analyzers branch on `resume_json`, and in the shipping
+ *      path only the optimized side has it — so section_completeness,
+ *      title_alignment, metrics_presence and semantic_relevance each compared
+ *      a JSON measurement against a text measurement. Production shows the
+ *      cost: section_completeness reads 99.7 on the optimized side with 58 of
+ *      59 rows at >= 99, against 66.5 on the original.
+ *
+ *   2. A result whose optimized score is not meaningfully above the original
+ *      is a pipeline failure, not a number to show the user. This is the
+ *      42 -> 44 the moderated session surfaced.
+ *
+ * Deterministic, no network.
+ */
+
+import { scoreResume } from '../core';
+import { assessLift, MIN_MEANINGFUL_LIFT } from '../lift';
+import type { ATSScoreInput, FormatReport } from '../types';
+import type { OptimizedResume } from '@/lib/ai-optimizer';
+
+const FORMAT: FormatReport = {
+  has_tables: false,
+  has_images: false,
+  has_headers_footers: false,
+  has_nonstandard_fonts: false,
+  has_odd_glyphs: false,
+  has_multi_column: false,
+  format_safety_score: 85,
+  issues: [],
+};
+
+/**
+ * A messy but complete original resume — the shape a PDF extractor produces.
+ * It has every section a resume should have; it just is not structured JSON.
+ */
+const ORIGINAL_TEXT = `Jane Cohen
+jane@example.com | Tel Aviv
+
+PROFESSIONAL SUMMARY
+Data engineer building streaming systems.
+
+SKILLS
+Kafka, Spark, SQL, Python
+
+EXPERIENCE
+
+Senior Data Engineer at Nimbus Analytics
+Jan 2022 - Present
+• Built streaming pipelines on Kafka and Spark
+
+EDUCATION
+BSc Computer Science - Technion
+`;
+
+/**
+ * The same person, as a PDF extractor actually delivers them: no clean section
+ * headers. This is the common case — the 60-day production mean for
+ * section_completeness on the original side is 66.5, not 100.
+ */
+const MESSY_ORIGINAL_TEXT = `Jane Cohen
+jane@example.com | Tel Aviv
+Data engineer building streaming systems.
+Kafka, Spark, SQL, Python
+Senior Data Engineer at Nimbus Analytics
+Jan 2022 - Present
+Built streaming pipelines on Kafka and Spark
+BSc Computer Science - Technion
+`;
+
+const OPTIMIZED_JSON: OptimizedResume = {
+  summary: 'Senior data engineer specialising in Kafka, Spark and Snowflake.',
+  contact: { name: 'Jane Cohen', email: 'jane@example.com', phone: '', location: 'Tel Aviv' },
+  skills: { technical: ['Kafka', 'Spark', 'Snowflake', 'SQL', 'Python'], soft: [] },
+  experience: [
+    {
+      title: 'Senior Data Engineer',
+      company: 'Nimbus Analytics',
+      location: 'Tel Aviv',
+      startDate: 'Jan 2022',
+      endDate: 'Present',
+      achievements: ['Built streaming pipelines on Kafka and Spark'],
+    },
+  ],
+  education: [
+    {
+      degree: 'BSc Computer Science',
+      institution: 'Technion',
+      location: 'Haifa',
+      graduationDate: '2016',
+    },
+  ],
+  matchScore: 0,
+  keyImprovements: [],
+  missingKeywords: [],
+};
+
+function inputWith(overrides: Partial<ATSScoreInput> = {}): ATSScoreInput {
+  return {
+    resume_original_text: ORIGINAL_TEXT,
+    resume_optimized_text: ORIGINAL_TEXT,
+    job_clean_text:
+      'Senior Data Engineer to build streaming pipelines with Kafka, Spark and Snowflake. SQL and Python required.',
+    job_extracted_json: {
+      title: 'Senior Data Engineer',
+      must_have: ['kafka', 'spark', 'snowflake', 'sql', 'python'],
+      nice_to_have: [],
+      responsibilities: ['Build streaming pipelines'],
+    } as ATSScoreInput['job_extracted_json'],
+    format_report: FORMAT,
+    timestamp: new Date('2026-07-24T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Same function on both sides
+// ---------------------------------------------------------------------------
+
+describe('WP-45 S2: both sides are measured by the same function', () => {
+  it('does not hand the optimized side the JSON path while the original gets the text path', async () => {
+    // The defect: supplying resume_optimized_json but not resume_original_json
+    // sent section_completeness down hasRequiredSections() for one side and a
+    // header regex for the other. A messy original is the point — its text path
+    // scores low while the optimized side's JSON path scores near 100 on field
+    // presence alone. Identical content must score identically; any gap here is
+    // measurement, not improvement.
+    const result = await scoreResume(
+      inputWith({
+        resume_original_text: MESSY_ORIGINAL_TEXT,
+        resume_optimized_text: MESSY_ORIGINAL_TEXT,
+        resume_optimized_json: OPTIMIZED_JSON,
+      })
+    );
+
+    expect(result.subscores.section_completeness).toBe(
+      result.subscores_original.section_completeness
+    );
+    expect(result.subscores.metrics_presence).toBe(
+      result.subscores_original.metrics_presence
+    );
+    expect(result.subscores.title_alignment).toBe(
+      result.subscores_original.title_alignment
+    );
+  });
+
+  it('scores identical input to an identical composite', async () => {
+    const result = await scoreResume(
+      inputWith({
+        resume_original_text: MESSY_ORIGINAL_TEXT,
+        resume_optimized_text: MESSY_ORIGINAL_TEXT,
+        resume_optimized_json: OPTIMIZED_JSON,
+      })
+    );
+    expect(result.ats_score_optimized).toBe(result.ats_score_original);
+  });
+
+  it('still uses the JSON path when BOTH sides have structured resumes', async () => {
+    // Symmetry is the requirement, not the text path. When both sides are
+    // structured, both get the richer measurement.
+    const result = await scoreResume(
+      inputWith({
+        resume_original_json: OPTIMIZED_JSON,
+        resume_optimized_json: OPTIMIZED_JSON,
+        resume_optimized_text: ORIGINAL_TEXT,
+      })
+    );
+    expect(result.subscores.section_completeness).toBe(
+      result.subscores_original.section_completeness
+    );
+    // hasRequiredSections gives a complete resume full marks; the text-header
+    // path cannot reach 100 on this fixture, so this pins the JSON path.
+    expect(result.subscores.section_completeness).toBeGreaterThanOrEqual(100);
+  });
+
+  it('still reports a real improvement when the content genuinely improves', async () => {
+    // The guard against over-correcting: making the measurement symmetric must
+    // not flatten genuine gains. Snowflake is a must-have the original lacks.
+    const result = await scoreResume(
+      inputWith({
+        resume_optimized_text: `${ORIGINAL_TEXT}\nSnowflake data warehouse migration. Snowflake, Airflow.`,
+        resume_optimized_json: OPTIMIZED_JSON,
+      })
+    );
+    expect(result.subscores.keyword_exact).toBeGreaterThan(
+      result.subscores_original.keyword_exact
+    );
+    expect(result.ats_score_optimized).toBeGreaterThan(result.ats_score_original);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. The no-regression invariant
+// ---------------------------------------------------------------------------
+
+describe('WP-45 S2: a non-improvement is a failure, not a result', () => {
+  it('treats a 2-point gain as no lift', () => {
+    // Exactly the case the moderated session hit: 42 before, 44 after.
+    const lift = assessLift({ original: 42, optimized: 44 });
+    expect(lift.meaningful).toBe(false);
+    expect(lift.delta).toBe(2);
+    expect(lift.displayScores).toBe(false);
+  });
+
+  it('treats a drop as no lift', () => {
+    const lift = assessLift({ original: 50, optimized: 47 });
+    expect(lift.meaningful).toBe(false);
+    expect(lift.delta).toBe(-3);
+    expect(lift.displayScores).toBe(false);
+  });
+
+  it('accepts a genuine improvement', () => {
+    const lift = assessLift({ original: 33, optimized: 52 });
+    expect(lift.meaningful).toBe(true);
+    expect(lift.delta).toBe(19);
+    expect(lift.displayScores).toBe(true);
+  });
+
+  it('treats exactly the floor as meaningful', () => {
+    const lift = assessLift({ original: 40, optimized: 40 + MIN_MEANINGFUL_LIFT });
+    expect(lift.meaningful).toBe(true);
+  });
+
+  it('does not invent a score, clamp the delta, or apply a floor', () => {
+    // The honest failure mode is to withhold the number, never to improve it.
+    const lift = assessLift({ original: 60, optimized: 55 });
+    expect(lift.optimized).toBe(55);
+    expect(lift.original).toBe(60);
+    expect(lift.delta).toBeLessThan(0);
+  });
+
+  it('names the weakest component so the failure is diagnosable', () => {
+    const lift = assessLift({
+      original: 42,
+      optimized: 44,
+      subscoresOriginal: { keyword_exact: 20, semantic_relevance: 70 },
+      subscores: { keyword_exact: 21, semantic_relevance: 70 },
+    });
+    expect(lift.meaningful).toBe(false);
+    // keyword_exact moved 1 point; semantic did not move at all. The component
+    // that failed to move is what an operator needs to see.
+    expect(lift.stalledComponents).toContain('semantic_relevance');
+  });
+
+  it('reports a privacy-safe payload only', () => {
+    const lift = assessLift({ original: 42, optimized: 44 });
+    const serialised = JSON.stringify(lift.analyticsProperties);
+    expect(serialised).not.toContain('Jane');
+    expect(serialised).not.toContain('@');
+    // Buckets, not raw scores, so the event carries no resume-identifying value.
+    expect(lift.analyticsProperties.delta_bucket).toBe('0_to_4');
+  });
+
+  it('buckets deltas without leaking exact values', () => {
+    expect(assessLift({ original: 50, optimized: 45 }).analyticsProperties.delta_bucket).toBe(
+      'negative'
+    );
+    expect(assessLift({ original: 40, optimized: 46 }).analyticsProperties.delta_bucket).toBe(
+      '5_to_9'
+    );
+    expect(assessLift({ original: 30, optimized: 55 }).analyticsProperties.delta_bucket).toBe(
+      '10_plus'
+    );
+  });
+});

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -65,19 +65,34 @@ export async function scoreResume(
     // format_parseability and recency_fit are measured the same way on both
     // sides of the comparison (WP-45 D3/D4). Sharing them made 22% of the
     // weighting either frozen or asymmetric across the before/after pair.
+    // Both sides must be measured by the same function, so the comparison
+    // reflects the resume rather than which representation happened to be
+    // available. section_completeness, title_alignment, metrics_presence and
+    // semantic_relevance all branch on `resume_json`, and in the shipping path
+    // only the optimized side has it — production shows section_completeness
+    // reading 99.7 optimized against 66.5 original, with 58 of 59 rows at 100,
+    // because one side was measured by field presence and the other by a
+    // header regex over messy extracted text (WP-45 S2).
+    //
+    // So: use the structured path only when BOTH sides are structured.
+    // Recency is exempt — it takes `recency_json`, which is reconstructed for
+    // the original side precisely so it stays comparable.
+    const useStructured = Boolean(input.resume_original_json && input.resume_optimized_json);
+
     const [originalResults, optimizedResults] = await Promise.all([
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: input.resume_original_json,
+        resume_json: useStructured ? input.resume_original_json : undefined,
         recency_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_optimized,
         resume_text: input.resume_optimized_text,
-        resume_json: input.resume_optimized_json,
+        resume_json: useStructured ? input.resume_optimized_json : undefined,
+        recency_json: input.resume_optimized_json,
       }),
     ]);
 
@@ -213,19 +228,26 @@ async function prepareInput(input: ATSScoreInput) {
         issues: [],
       };
 
-  // Resolve a report per side. Callers that supply only the shared
-  // `format_report` keep today's behavior; callers that supply per-side
-  // reports get an honest format comparison (WP-45 D3).
+  // Resolve a report per side (WP-45 D3). An explicit per-side report always
+  // wins — callers are responsible for deriving both from the same function.
+  //
+  // The analyzeFormatWithTemplate fallback only applies when BOTH sides are
+  // structured. Applying it to whichever side happens to have JSON would score
+  // one side with the JSON heuristic (base 100) and the other with whatever
+  // the shared report holds, which is the same two-different-functions
+  // comparison this field exists to eliminate (WP-45 S2).
+  const bothStructured = Boolean(input.resume_original_json && input.resume_optimized_json);
+
   const format_report_original =
     input.format_report_original ??
-    (input.resume_original_json
-      ? analyzeFormatWithTemplate(input.resume_original_json, null)
+    (bothStructured
+      ? analyzeFormatWithTemplate(input.resume_original_json!, null)
       : format_report);
 
   const format_report_optimized =
     input.format_report_optimized ??
-    (input.resume_optimized_json
-      ? analyzeFormatWithTemplate(input.resume_optimized_json, null)
+    (bothStructured
+      ? analyzeFormatWithTemplate(input.resume_optimized_json!, null)
       : format_report);
 
   return {

--- a/src/lib/ats/index.ts
+++ b/src/lib/ats/index.ts
@@ -66,19 +66,34 @@ export async function scoreResume(
     // format_parseability and recency_fit are measured the same way on both
     // sides of the comparison (WP-45 D3/D4). Sharing them made 22% of the
     // weighting either frozen or asymmetric across the before/after pair.
+    // Both sides must be measured by the same function, so the comparison
+    // reflects the resume rather than which representation happened to be
+    // available. section_completeness, title_alignment, metrics_presence and
+    // semantic_relevance all branch on `resume_json`, and in the shipping path
+    // only the optimized side has it — production shows section_completeness
+    // reading 99.7 optimized against 66.5 original, with 58 of 59 rows at 100,
+    // because one side was measured by field presence and the other by a
+    // header regex over messy extracted text (WP-45 S2).
+    //
+    // So: use the structured path only when BOTH sides are structured.
+    // Recency is exempt — it takes `recency_json`, which is reconstructed for
+    // the original side precisely so it stays comparable.
+    const useStructured = Boolean(input.resume_original_json && input.resume_optimized_json);
+
     const [originalResults, optimizedResults] = await Promise.all([
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
-        resume_json: input.resume_original_json,
+        resume_json: useStructured ? input.resume_original_json : undefined,
         recency_json: resolveOriginalResumeJson(input),
       }),
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_optimized,
         resume_text: input.resume_optimized_text,
-        resume_json: input.resume_optimized_json,
+        resume_json: useStructured ? input.resume_optimized_json : undefined,
+        recency_json: input.resume_optimized_json,
       }),
     ]);
 
@@ -237,19 +252,26 @@ async function prepareInput(input: ATSScoreInput) {
         issues: [],
       };
 
-  // Resolve a report per side. Callers that supply only the shared
-  // `format_report` keep today's behavior; callers that supply per-side
-  // reports get an honest format comparison (WP-45 D3).
+  // Resolve a report per side (WP-45 D3). An explicit per-side report always
+  // wins — callers are responsible for deriving both from the same function.
+  //
+  // The analyzeFormatWithTemplate fallback only applies when BOTH sides are
+  // structured. Applying it to whichever side happens to have JSON would score
+  // one side with the JSON heuristic (base 100) and the other with whatever
+  // the shared report holds, which is the same two-different-functions
+  // comparison this field exists to eliminate (WP-45 S2).
+  const bothStructured = Boolean(input.resume_original_json && input.resume_optimized_json);
+
   const format_report_original =
     input.format_report_original ??
-    (input.resume_original_json
-      ? analyzeFormatWithTemplate(input.resume_original_json, null)
+    (bothStructured
+      ? analyzeFormatWithTemplate(input.resume_original_json!, null)
       : format_report);
 
   const format_report_optimized =
     input.format_report_optimized ??
-    (input.resume_optimized_json
-      ? analyzeFormatWithTemplate(input.resume_optimized_json, null)
+    (bothStructured
+      ? analyzeFormatWithTemplate(input.resume_optimized_json!, null)
       : format_report);
 
   return {

--- a/src/lib/ats/lift.ts
+++ b/src/lib/ats/lift.ts
@@ -1,0 +1,105 @@
+/**
+ * Lift assessment (WP-45 S2)
+ *
+ * A moderated user session on 2026-07-24 showed a resume scoring 42 before
+ * optimization and 44 after. Over 60 days, 24 of 59 optimizations (41%) ended
+ * at +4 or worse and 6 of them ended lower than they started.
+ *
+ * A result that does not meaningfully improve on where the user began is a
+ * pipeline failure. This module decides that, and nothing else: it never
+ * changes a score, never clamps a delta positive, and never applies a floor.
+ * The honest response to a failed optimization is to withhold the number and
+ * say what is still missing — not to make the number look better.
+ */
+
+import type { SubScores } from './types';
+
+/**
+ * Minimum improvement, in composite points, that counts as a real result.
+ *
+ * Provisional. WP-45 S5 selects the final value from the labelled benchmark;
+ * this is a conservative placeholder chosen so that the observed failure cases
+ * (+2, +1, 0, negative) are caught while the genuine improvements in the same
+ * 60-day sample (median +9.4 among those that moved) are not.
+ *
+ * Deliberately a named constant and not a tunable: nudging this number is how
+ * a "no lift" problem gets redefined out of existence instead of fixed.
+ */
+export const MIN_MEANINGFUL_LIFT = 5;
+
+export type DeltaBucket = 'negative' | '0_to_4' | '5_to_9' | '10_plus';
+
+export interface LiftAssessment {
+  /** The original composite, unmodified. */
+  original: number;
+  /** The optimized composite, unmodified. */
+  optimized: number;
+  /** optimized - original. Negative values are preserved, never clamped. */
+  delta: number;
+  /** True when the delta clears MIN_MEANINGFUL_LIFT. */
+  meaningful: boolean;
+  /**
+   * Whether the caller should show the user a before/after number pair.
+   *
+   * False does not mean "hide the result" — it means show what changed and
+   * what is still missing, without a numeric pair that reads as a promise the
+   * optimization did not keep.
+   */
+  displayScores: boolean;
+  /** Components that did not move, for diagnosis. Never user-facing text. */
+  stalledComponents: string[];
+  /** Privacy-safe payload for the optimization_no_lift event. */
+  analyticsProperties: Record<string, string | number | boolean>;
+}
+
+export function bucketDelta(delta: number): DeltaBucket {
+  if (delta < 0) return 'negative';
+  if (delta < 5) return '0_to_4';
+  if (delta < 10) return '5_to_9';
+  return '10_plus';
+}
+
+export function assessLift(params: {
+  original: number;
+  optimized: number;
+  subscoresOriginal?: Partial<SubScores>;
+  subscores?: Partial<SubScores>;
+  passesUsed?: number;
+}): LiftAssessment {
+  const { original, optimized, subscoresOriginal, subscores, passesUsed } = params;
+
+  const delta = optimized - original;
+  const meaningful = delta >= MIN_MEANINGFUL_LIFT;
+
+  const stalledComponents =
+    subscoresOriginal && subscores
+      ? (Object.keys(subscores) as Array<keyof SubScores>)
+          .filter(key => {
+            const before = subscoresOriginal[key];
+            const after = subscores[key];
+            return typeof before === 'number' && typeof after === 'number' && after <= before;
+          })
+          .map(String)
+          .sort()
+      : [];
+
+  return {
+    original,
+    optimized,
+    delta,
+    meaningful,
+    displayScores: meaningful,
+    stalledComponents,
+    analyticsProperties: {
+      // Buckets rather than raw scores: this event exists to count failures,
+      // not to reconstruct anybody's resume quality from analytics.
+      delta_bucket: bucketDelta(delta),
+      meaningful_lift: meaningful,
+      stalled_component_count: stalledComponents.length,
+      ...(stalledComponents.length > 0
+        ? { top_stalled_component: stalledComponents[0] }
+        : {}),
+      ...(typeof passesUsed === 'number' ? { passes_used: passesUsed } : {}),
+    },
+  };
+}

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,19 @@
 # Project Progress
 
+## 2026-07-24 — WP-45 S2: symmetric comparison + no-regression invariant (PR #120, stacked on #119)
+
+**The invariant.** `optimize-pipeline.ts` chose between pass 1 and pass 2 by comparing them to each other and never to the resume the user started with, so a run that moved the score +2 — or moved it down — was returned as a result. That is the 42 -> 44 from the Meirav session, and it is not rare: 24 of 59 optimizations in 60 days ended at +4 or worse, 6 of them lower than they started. Pass 2 now also triggers when a run has not meaningfully beaten the original, and every result carries a `LiftAssessment` from the new `src/lib/ats/lift.ts`. That module never raises a score, never clamps a delta positive and never applies a floor — `lift.displayScores` tells the caller to show what changed and what is still missing instead of a number pair. Floor is a named constant at 5, provisional until S5 picks it from the labelled benchmark.
+
+**Fifth measurement defect found.** Four analyzers branch on `resume_json` — section_completeness, title_alignment, metrics_presence, semantic — and in the shipping path only the optimized side ever has it. section_completeness scores field presence via `hasRequiredSections()` with JSON and a header regex over messy extracted text without it. Production 60d: optimized mean 99.7 with 58 of 59 rows at or above 99 (min 85), against 66.5 original. Roughly +3 points of fake delta on every optimization. The structured path is now used only when both sides are structured; recency is exempt because it takes `recency_json`, reconstructed in S1 for exactly this reason.
+
+**S1 follow-on caught by the new tests:** `prepareInput`'s format fallback was still applying `analyzeFormatWithTemplate` to whichever side happened to have JSON, reintroducing the D3 two-different-functions comparison in a new place. Fixed.
+
+**Signal:** both routes running the pipeline emit `optimization_no_lift`, bucketed (negative / 0_to_4 / 5_to_9 / 10_plus) plus a stalled-component name. No resume or job content.
+
+**Validation:** 12 new deterministic tests. Both symmetry gates verified failing against the S1 head — the first needed a messy-extraction fixture, because a clean original with proper headers scores 100 on either path and hides the defect. A guard test confirms genuine improvements still register. Full suite 17 pre-existing suite failures before and after, passing 201 -> 213. eslint clean, tsc 26 before and after, `next build` passes on a clean checkout.
+
+**Not done:** no UI change — `lift.displayScores` is produced but nothing consumes it, that is S8, so users still see the raw pair for now. Absolute scores move for everyone as the optimized side loses an unearned advantage on four components, which makes historical rows even less comparable (S9). The floor of 5 is a placeholder for S5.
+
 ## 2026-07-24 — WP-45 S1: repair the three dead scoring components (PR #119)
 
 Backend-only scorer integrity pass. Triggered by a moderated user session (Meirav) that showed a fit score of 45, then 42 before / 44 after optimizing. The audit found the composite was structurally incapable of doing better.


### PR DESCRIPTION
Executes **S2** of WP-45 v2. **Stacks on [#119](https://github.com/nadavyigal/new-ResumeBuilder-ai-/pull/119)** — based on that branch, review/merge it first. Backend only.

## The invariant — this is Meirav's 42 → 44

`optimize-pipeline.ts` chose between pass 1 and pass 2 by comparing them **to each other**, never to the resume the user started with. A run that moved the score +2, or moved it *down*, was returned as a result. Not rare: **24 of 59** optimizations in 60 days ended at +4 or worse, **6 of them lower than they started**.

Now: pass 2 also triggers when a run hasn't meaningfully beaten the original, and every result carries a `LiftAssessment`. `src/lib/ats/lift.ts` decides that and nothing else — **it never raises a score, never clamps a delta positive, never applies a floor.** A failed optimization stays reported as failed; `lift.displayScores` tells the caller to show what changed and what's still missing instead of a number pair that reads as a promise the run didn't keep.

The floor is a named constant at 5, provisional until S5 picks it from the labelled benchmark, and deliberately not a tunable — nudging it is how a "no lift" problem gets defined out of existence instead of fixed.

Both routes running the pipeline emit `optimization_no_lift`, bucketed (`negative` / `0_to_4` / `5_to_9` / `10_plus`) plus a stalled-component name. No resume or job content.

## A fifth measurement defect

Four analyzers branch on `resume_json` — `section_completeness`, `title_alignment`, `metrics_presence`, `semantic`. In the shipping path **only the optimized side ever has it**, so each compared a JSON measurement against a text measurement.

`section_completeness` is the clearest: field presence via `hasRequiredSections()` when JSON exists, a header regex over messy extracted text when it doesn't. Production over 60 days:

| side | mean | rows ≥ 99 | min |
|---|---|---|---|
| optimized | **99.7** | **58 / 59** | 85 |
| original | 66.5 | 21 / 59 | — |

That is not the optimizer adding sections. It is one side graded by an easier function — roughly **+3 points of fake delta on every optimization**.

The structured path is now used only when **both** sides are structured. Recency is exempt because it takes `recency_json`, which S1 reconstructs for the original side precisely so it stays comparable.

**The same rule was missing from `prepareInput`'s format fallback**, which S1 left applying `analyzeFormatWithTemplate` to whichever side happened to have JSON — reintroducing the D3 two-different-functions comparison in a new place. The new symmetry test caught it.

## Verification

- 12 new deterministic tests, no network.
- Both symmetry gates verified to fail against the S1 head. The first needed a **messy-extraction fixture** — a clean original with proper headers scores 100 on either path and hides the defect entirely, which is worth knowing for future tests here.
- A guard test confirms genuine content improvements still register, so the symmetry fix doesn't flatten real gains.
- Full suite: **17 pre-existing suite failures before and after**; passing 201 → 213.
- `eslint` clean. `tsc` 26 before and after. `next build` passes on a clean checkout.

## Not done

- **No UI change.** `lift.displayScores` is produced and persisted but nothing consumes it yet — the copy and the suppressed-number state are **S8**. Until then users still see the raw pair; the signal is now measurable, which is the prerequisite.
- Absolute scores will move for everyone, since the optimized side loses an unearned advantage on four components. That is the intended correction, but it means **historical rows are now even less comparable** — S9.
- The floor of 5 is a placeholder. S5 sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)