### PR TITLE
WP-45: Hebrew scoring fix, calibrated bands, lift exposed

### DIFF
--- a/src/app/api/v1/optimizations/[id]/route.ts
+++ b/src/app/api/v1/optimizations/[id]/route.ts
@@ -12,6 +12,7 @@ import { createRouteHandlerClient } from "@/lib/supabase-server";
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { scoreOptimization } from "@/lib/ats/integration";
+import { assessLift } from "@/lib/ats/lift";
 import { mapSuggestionsToBlockers } from "@/lib/ats/blocker-mapper";
 import type { Suggestion } from "@/lib/ats/types";
 
@@ -182,6 +183,20 @@ export async function GET(
 
   const blockers = mapSuggestionsToBlockers(row.ats_suggestions as Suggestion[] | null);
 
+  const before = toIntPercent(row.ats_score_original);
+  const after = toIntPercent(row.ats_score_optimized);
+  const lift =
+    typeof before === 'number' && typeof after === 'number'
+      ? (() => {
+          const assessment = assessLift({ original: before, optimized: after });
+          return {
+            delta: assessment.delta,
+            meaningful: assessment.meaningful,
+            displayScores: assessment.displayScores,
+          };
+        })()
+      : null;
+
   return NextResponse.json({
     sections,
     contact,
@@ -194,6 +209,12 @@ export async function GET(
     ats_score_after: toIntPercent(row.ats_score_optimized),
     atsBlockers: blockers,
     ats_blockers: blockers,
+    // WP-45 S2/S8. The scores above stay honest; `lift` tells the client
+    // whether they are worth SHOWING. A run that moved the score by +2, or
+    // moved it down, is a pipeline failure, and a before/after pair reads as a
+    // promise the run did not keep. Clients must consult `displayScores`
+    // before rendering the pair.
+    lift,
   });
 }
 

--- a/src/lib/ats/__tests__/calibration-benchmark.test.ts
+++ b/src/lib/ats/__tests__/calibration-benchmark.test.ts
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 /**
  * WP-45 S5 — Calibration benchmark, weights and bands
  *
@@ -24,11 +25,26 @@ import {
   deriveThresholds,
   bandFor,
   scoreCase,
+  degradedCount,
   PUBLISHED_BANDS,
 } from '../benchmark/runner';
 import { CALIBRATION_CASES, HOLDOUT_CASES, BENCHMARK_CASES } from '../benchmark/cases';
 
-jest.setTimeout(120000);
+jest.setTimeout(300000);
+
+/**
+ * Band accuracy can only be judged against production-representative scoring.
+ *
+ * semantic_relevance is 18% of the weighting and falls back to a constant 50
+ * without an API key, which is what makes the rest of this file deterministic
+ * — and also what makes any threshold measured under it non-production-valid.
+ * The shipped bands were derived from a live run, so the assertions that check
+ * them are gated the same way this repo gates its optimizer eval.
+ *
+ * Run with:  set -a && . ./.env.local && set +a && npx jest calibration
+ */
+const LIVE = Boolean(process.env.OPENAI_API_KEY) || process.env.RUN_LIVE_EVAL === '1';
+const describeLive = LIVE ? describe : describe.skip;
 
 describe('WP-45 S5: the benchmark itself', () => {
   it('covers the spread of cases the packet asks for', () => {
@@ -42,6 +58,9 @@ describe('WP-45 S5: the benchmark itself', () => {
     expect(BENCHMARK_CASES.some(c => c.label === 'stretch')).toBe(true);
     expect(BENCHMARK_CASES.some(c => c.label === 'weak')).toBe(true);
     expect(HOLDOUT_CASES.length).toBeGreaterThan(0);
+    // The packet asks for 30-50 pairs. This set is smaller; every case is
+    // hand-written, and the count is stated rather than implied.
+    expect(BENCHMARK_CASES.length).toBeGreaterThanOrEqual(25);
   });
 
   it('is deterministic', async () => {
@@ -66,6 +85,9 @@ describe('WP-45 S5 G1: strong is reachable', () => {
     const results = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
     const strongScores = results.filter(r => r.label === 'strong').map(r => r.score);
 
+    // 75 was the old strong threshold and the number nobody could reach before
+    // S1. Asserting against it rather than the current band keeps the original
+    // finding pinned even though the band has since moved down to 57.
     expect(Math.max(...strongScores)).toBeGreaterThanOrEqual(75);
     expect(summarise(results).strongReached).toBe(true);
   });
@@ -108,64 +130,109 @@ describe('WP-45 S5: monotonicity and component isolation', () => {
   });
 });
 
-describe('WP-45 S5: calibration and holdout, reported separately', () => {
-  it('records how the published bands perform on the labelled set', async () => {
-    const results = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
-    const summary = summarise(results);
+describeLive('WP-45 S5: calibration and holdout, reported separately (live)', () => {
+  // Scored ONCE and shared. Each assertion used to re-run the whole benchmark,
+  // which fired well over a hundred embedding calls in a few seconds; under
+  // that load some fail, the semantic analyzer falls back to a neutral 50, and
+  // scores drift by several points. Sharing one run removes the self-inflicted
+  // rate pressure and makes the numbers reproducible.
+  let calibration: Awaited<ReturnType<typeof runBenchmark>>;
+  let holdout: Awaited<ReturnType<typeof runBenchmark>>;
 
-    // Documented state as of 2026-07-24, not an aspiration. The published
-    // 75/50 bands were set for the pre-2026-06-18 scale and misband roughly
-    // two in five labelled pairs on the current one.
-    expect(summary.accuracy).toBeLessThan(0.8);
-    expect(summary.falseWeakCount).toBeGreaterThan(0);
+  beforeAll(async () => {
+    calibration = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
+    holdout = await runBenchmark(PUBLISHED_BANDS, HOLDOUT_CASES);
+  }, 600000);
+
+  /**
+   * Refuse to judge bands on a degraded run.
+   *
+   * When embeddings fail the semantic analyzer returns a neutral 50 and the
+   * composite drops several points with no error anywhere. Asserting through
+   * that produces phantom red builds and, worse, would let someone "recalibrate"
+   * against numbers the scorer never really produced.
+   */
+  function requireCleanRun(results: typeof calibration) {
+    const degraded = degradedCount(results);
+    if (degraded > 0) {
+      throw new Error(
+        `${degraded}/${results.length} cases scored with a degraded semantic analyzer ` +
+          `(embedding calls failing). Re-run when the API is healthy; do not ` +
+          `recalibrate against these numbers.`
+      );
+    }
+  }
+
+  it('the shipped bands separate the labelled set well', async () => {
+    requireCleanRun(calibration);
+    const summary = summarise(calibration);
+
+    // Reference run 2026-07-26: accuracy 0.947 (18/19), false-Weak 1 (6.7%).
+    // Before adoption the 75/50 pair scored 0.79 with 4 false-Weaks (26.7%).
+    //
+    // The floor is deliberately below the reference. Embedding calls can fail
+    // transiently under load and the semantic analyzer falls back to a neutral
+    // 50 when they do, which moves individual scores a few points. The gate
+    // that must hold regardless is the false-Weak rate, asserted separately.
+    expect(summary.accuracy).toBeGreaterThanOrEqual(0.8);
+    expect(summary.strongReached).toBe(true);
   });
 
-  it('derives better-separating thresholds from the labelled evidence', async () => {
-    const results = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
-    const derived = deriveThresholds(results);
+  it('re-derives the thresholds the product actually ships', async () => {
+    // The shipped bands came from this sweep, so running it again should land
+    // back on them. That is the property worth pinning: if a scorer change
+    // moves the scale, the sweep drifts away from the shipped values and this
+    // fails — which is the signal to recalibrate deliberately rather than
+    // discover it from users.
+    requireCleanRun(calibration);
+    const derived = deriveThresholds(calibration);
 
-    // The sweep reads thresholds off the labels; it never adjusts a score.
-    expect(derived.strong).toBeLessThan(PUBLISHED_BANDS.strong);
     expect(derived.strong).toBeGreaterThan(derived.stretch);
-
-    const rebanded = await runBenchmark(derived, CALIBRATION_CASES);
-    expect(summarise(rebanded).accuracy).toBeGreaterThan(
-      summarise(results).accuracy
-    );
+    expect(Math.abs(derived.strong - PUBLISHED_BANDS.strong)).toBeLessThanOrEqual(5);
+    expect(Math.abs(derived.stretch - PUBLISHED_BANDS.stretch)).toBeLessThanOrEqual(5);
   });
 
-  it('does NOT yet clear the false-weak gate, so the bands must not ship', async () => {
-    // The packet requires a false-Weak rate below 10% before numeric bands are
-    // enabled. The best thresholds this set can produce sit above that, and the
-    // labels are not independent anyway. This test exists to keep that fact
-    // visible; when the gate is genuinely met, invert it.
-    const results = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
-    const derived = deriveThresholds(results);
-    const rebanded = summarise(await runBenchmark(derived, CALIBRATION_CASES));
+  it('clears the false-weak gate the packet requires', async () => {
+    // The gate: fewer than 10% of pairs a human called Strong or Stretch may
+    // be classified Weak. Telling a qualified candidate to skip a job they
+    // could get is the error that actually costs them something.
+    //
+    // This failed before the Hebrew scoring fixes and before the benchmark was
+    // expanded to the packet's stated size — it sat at 13% on 10 cases, where
+    // a single borderline pair moved the rate by 12 points.
+    requireCleanRun(calibration);
+    expect(summarise(calibration).falseWeakRate).toBeLessThan(0.1);
+  });
 
-    expect(rebanded.falseWeakRate).toBeGreaterThan(0.1);
+  it('does not misband a Hebrew pair relative to its English equivalent', async () => {
+    // heb-strong scored 52 against 74-92 for English equivalents until three
+    // Latin-script assumptions were fixed. A language penalty in the scorer is
+    // a language penalty for real users; no band may be chosen while one holds.
+    const hebrew = calibration.filter(r => r.id.startsWith('heb-'));
+    expect(hebrew.length).toBeGreaterThan(0);
+    for (const r of hebrew) {
+      expect(r.predicted).toBe(r.label);
+    }
   });
 
   it('reports holdout separately from calibration', async () => {
-    const calibration = await runBenchmark(PUBLISHED_BANDS, CALIBRATION_CASES);
-    const derived = deriveThresholds(calibration);
-    const holdout = summarise(await runBenchmark(derived, HOLDOUT_CASES));
-
     // Held-out cases never inform the threshold sweep.
-    expect(holdout.total).toBe(HOLDOUT_CASES.length);
-    expect(holdout.accuracy).toBeGreaterThan(0.5);
+    const summary = summarise(holdout);
+    expect(summary.total).toBe(HOLDOUT_CASES.length);
+    expect(summary.falseWeakRate).toBeLessThan(0.1);
   });
 
-  it('under-scores a strong Hebrew match — a real gap, recorded not hidden', async () => {
-    // heb-strong is a genuine top match by its own label and scores in the
-    // fifties, well below its English equivalents. Hebrew keyword matching is
-    // the likely cause. Filed rather than papered over: no threshold should be
-    // chosen while one language scores systematically lower.
+  it('scores a strong Hebrew match in line with its English equivalent', async () => {
+    // Was the reverse assertion: heb-strong scored 52 against 74 for the
+    // English case. section_completeness could not read Hebrew headings,
+    // title extraction required Latin capitalisation, and title normalisation
+    // stripped Hebrew entirely — which also made every Hebrew title compare
+    // EQUAL to every other. All three are fixed.
     const hebStrong = BENCHMARK_CASES.find(c => c.id === 'heb-strong')!;
     const enStrong = BENCHMARK_CASES.find(c => c.id === 'de-senior-strong')!;
 
     const [heb, en] = await Promise.all([scoreCase(hebStrong), scoreCase(enStrong)]);
-    expect(heb).toBeLessThan(en);
+    expect(Math.abs(heb - en)).toBeLessThanOrEqual(10);
   });
 });
 

--- a/src/lib/ats/__tests__/hebrew-scoring.test.ts
+++ b/src/lib/ats/__tests__/hebrew-scoring.test.ts
@@ -1,0 +1,134 @@
+/**
+ * WP-45 — Hebrew must not score lower for being Hebrew
+ *
+ * The calibration benchmark surfaced this: `heb-strong` is a top match by its
+ * own label and scored 52, while its English equivalents scored 74-92. The gap
+ * was not semantics. Two analyzers assumed Latin script:
+ *
+ *   - section_completeness searched for English header words with `\b`, which
+ *     never matches a Hebrew word boundary, so a complete Hebrew resume scored
+ *     0 for having no sections at all.
+ *   - title_alignment extracted resume titles with /[A-Z][a-z]+/, which cannot
+ *     match a script with no case, so it reported "no job titles found" and
+ *     returned its 20-point floor.
+ *
+ * Together that is roughly 18 points off every Hebrew resume — the whole gap.
+ * The product ships in Hebrew, so this was a real scoring penalty applied to
+ * real users for their language.
+ */
+
+import { SectionCompletenessAnalyzer } from '../analyzers/section-completeness';
+import { TitleAlignmentAnalyzer } from '../analyzers/title-alignment';
+import type { AnalyzerInput } from '../types';
+
+const HEBREW_RESUME = `מועמד לדוגמה
+candidate@example.com
+
+תקציר מקצועי
+מהנדס תוכנה עם חמש שנות ניסיון בפיתוח בקאנד.
+
+כישורים
+Node.js, SQL, Docker, עבודת צוות
+
+ניסיון תעסוקתי
+
+מהנדס תוכנה at Example Ltd
+2021 - Present
+• פיתוח שירותים ב-Node.js
+
+השכלה
+תואר ראשון במדעי המחשב
+`;
+
+const ENGLISH_RESUME = `Jane Cohen
+jane@example.com
+
+PROFESSIONAL SUMMARY
+Backend engineer with five years of experience.
+
+SKILLS
+Node.js, SQL, Docker, teamwork
+
+EXPERIENCE
+
+Software Engineer at Example Ltd
+2021 - Present
+• Built services in Node.js
+
+EDUCATION
+BSc Computer Science
+`;
+
+function inputFor(resumeText: string, jobTitle: string): AnalyzerInput {
+  return {
+    resume_text: resumeText,
+    job_text: 'Backend engineer role requiring Node.js, SQL and Docker.',
+    job_data: {
+      title: jobTitle,
+      must_have: ['Node.js', 'SQL', 'Docker'],
+      nice_to_have: [],
+      responsibilities: [],
+    },
+  } as unknown as AnalyzerInput;
+}
+
+describe('WP-45: section_completeness reads Hebrew headings', () => {
+  it('recognises a complete Hebrew resume as complete', async () => {
+    const result = await new SectionCompletenessAnalyzer().analyze(
+      inputFor(HEBREW_RESUME, 'מהנדס תוכנה')
+    );
+    // Was 0: none of summary/skills/experience/education matched, so a fully
+    // structured resume was scored as having no sections whatsoever.
+    expect(result.score).toBeGreaterThanOrEqual(100);
+  });
+
+  it('scores the Hebrew and English versions of the same resume the same', async () => {
+    const analyzer = new SectionCompletenessAnalyzer();
+    const [he, en] = await Promise.all([
+      analyzer.analyze(inputFor(HEBREW_RESUME, 'מהנדס תוכנה')),
+      analyzer.analyze(inputFor(ENGLISH_RESUME, 'Software Engineer')),
+    ]);
+    expect(he.score).toBe(en.score);
+  });
+
+  it('still scores a resume with no headings low', async () => {
+    const result = await new SectionCompletenessAnalyzer().analyze(
+      inputFor('מועמד לדוגמה\ncandidate@example.com\nטקסט חופשי ללא כותרות.\n', 'מהנדס תוכנה')
+    );
+    expect(result.score).toBeLessThan(50);
+  });
+
+  it('does not match a heading word buried inside another word', async () => {
+    // The English path relied on \b for this. The Unicode-aware boundary has
+    // to keep that property or "skillset" starts counting as a Skills section.
+    const result = await new SectionCompletenessAnalyzer().analyze(
+      inputFor('Jane Cohen\nMy skillsets and experiences are varied.\n', 'Engineer')
+    );
+    expect(result.score).toBeLessThan(100);
+  });
+});
+
+describe('WP-45: title_alignment reads Hebrew titles', () => {
+  it('finds the Hebrew job title in the resume', async () => {
+    const result = await new TitleAlignmentAnalyzer().analyze(
+      inputFor(HEBREW_RESUME, 'מהנדס תוכנה')
+    );
+    // Was 20 — the "no job titles found in resume" floor, for a resume whose
+    // title is an exact match for the role.
+    expect(result.score).toBeGreaterThan(70);
+  });
+
+  it('does not award a high score for an unrelated Hebrew title', async () => {
+    const result = await new TitleAlignmentAnalyzer().analyze(
+      inputFor(HEBREW_RESUME, 'מעצב גרפי')
+    );
+    expect(result.score).toBeLessThan(70);
+  });
+
+  it('leaves English title extraction working', async () => {
+    const result = await new TitleAlignmentAnalyzer().analyze(
+      inputFor(ENGLISH_RESUME, 'Software Engineer')
+    );
+    expect(result.score).toBeGreaterThan(70);
+  });
+});

--- a/src/lib/ats/__tests__/lift-contract.test.ts
+++ b/src/lib/ats/__tests__/lift-contract.test.ts
@@ -1,0 +1,42 @@
+/**
+ * WP-45 S8 — the client must be able to tell a real improvement from a fake one
+ *
+ * The backend has known since S2 whether a run improved on the resume the user
+ * started with. Until now nothing returned that to the client, so the app had
+ * no way to avoid rendering "42 before, 44 after" — the exact pair the
+ * moderated session hit. This pins the contract the UI depends on.
+ */
+
+import { assessLift, MIN_MEANINGFUL_LIFT } from '../lift';
+
+describe('WP-45 S8: the lift contract a client can act on', () => {
+  it('tells the client to withhold the pair for the case that started this', () => {
+    const lift = assessLift({ original: 42, optimized: 44 });
+    expect(lift.displayScores).toBe(false);
+    expect(lift.delta).toBe(2);
+  });
+
+  it('tells the client to show the pair for a real improvement', () => {
+    const lift = assessLift({ original: 33, optimized: 52 });
+    expect(lift.displayScores).toBe(true);
+  });
+
+  it('reports the honest numbers even when withholding them', () => {
+    // Withholding is a display decision. The scores themselves are never
+    // rewritten, clamped or floored — a client that wants the raw values for
+    // diagnostics still gets the truth.
+    const lift = assessLift({ original: 60, optimized: 55 });
+    expect(lift.original).toBe(60);
+    expect(lift.optimized).toBe(55);
+    expect(lift.delta).toBe(-5);
+    expect(lift.displayScores).toBe(false);
+  });
+
+  it('exposes a stable floor rather than a per-call threshold', () => {
+    // The floor is a named constant so it cannot be nudged per surface until
+    // an embarrassing result becomes a passing one.
+    expect(MIN_MEANINGFUL_LIFT).toBeGreaterThan(0);
+    expect(assessLift({ original: 40, optimized: 40 + MIN_MEANINGFUL_LIFT }).displayScores).toBe(true);
+    expect(assessLift({ original: 40, optimized: 39 + MIN_MEANINGFUL_LIFT }).displayScores).toBe(false);
+  });
+});

--- a/src/lib/ats/analyzers/section-completeness.ts
+++ b/src/lib/ats/analyzers/section-completeness.ts
@@ -56,20 +56,46 @@ export class SectionCompletenessAnalyzer extends BaseAnalyzer {
    * Analyze sections in plain text (fallback)
    */
   private analyzeTextSections(text: string): AnalyzerResult {
-    const sectionHeaders = [
-      'summary', 'profile', 'objective',
-      'skills', 'technical skills', 'competencies',
-      'experience', 'work experience', 'employment',
-      'education', 'academic background',
-    ];
+    // Grouped by the section each heading denotes, so a resume is credited once
+    // per section rather than once per synonym it happens to use.
+    //
+    // Hebrew is here because the product ships in Hebrew. Without it a fully
+    // structured Hebrew resume matched nothing and scored 0 for "no sections",
+    // which cost roughly 9 points of composite to every Hebrew user (WP-45).
+    const sectionHeaders: Record<string, string[]> = {
+      summary: [
+        'summary', 'profile', 'objective',
+        'תקציר', 'תקציר מקצועי', 'פרופיל', 'אודות',
+      ],
+      skills: [
+        'skills', 'technical skills', 'competencies',
+        'כישורים', 'מיומנויות', 'כישורים טכניים', 'תחומי מומחיות',
+      ],
+      experience: [
+        'experience', 'work experience', 'employment',
+        'ניסיון', 'ניסיון תעסוקתי', 'ניסיון מקצועי', 'תעסוקה',
+      ],
+      education: [
+        'education', 'academic background',
+        'השכלה', 'לימודים', 'רקע אקדמי',
+      ],
+    };
 
     const foundSections: string[] = [];
 
-    for (const header of sectionHeaders) {
-      const pattern = new RegExp(`\\b${header}\\b`, 'i');
-      if (pattern.test(text)) {
-        foundSections.push(header);
-      }
+    for (const [section, headers] of Object.entries(sectionHeaders)) {
+      const matched = headers.some(header => {
+        // \b is an ASCII word boundary: between a space and a Hebrew letter it
+        // does not match, so \bתקציר\b can never fire. This Unicode-aware
+        // boundary keeps the "not inside another word" property that \b gave
+        // the English headings — "skillset" still must not count as Skills.
+        const pattern = new RegExp(
+          `(?<![\\p{L}\\p{N}])${escapeRegExp(header)}(?![\\p{L}\\p{N}])`,
+          'iu'
+        );
+        return pattern.test(text);
+      });
+      if (matched) foundSections.push(section);
     }
 
     const score = (foundSections.length / 4) * 100; // Expect at least 4 sections
@@ -128,4 +154,9 @@ export class SectionCompletenessAnalyzer extends BaseAnalyzer {
 
     return bonus;
   }
+}
+
+/** Escape a literal heading before embedding it in a RegExp. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/src/lib/ats/analyzers/title-alignment.ts
+++ b/src/lib/ats/analyzers/title-alignment.ts
@@ -114,7 +114,11 @@ export class TitleAlignmentAnalyzer extends BaseAnalyzer {
       .toLowerCase()
       .replace(/\b(jr|sr|senior|junior|lead|staff|principal)\b/g, '') // Remove seniority markers
       .replace(/\b(i|ii|iii|iv|v|1|2|3|4|5)\b/g, '') // Remove level numbers
-      .replace(/[^\w\s]/g, ' ')
+      // Unicode-aware. \w is ASCII-only, so [^\w\s] deleted every Hebrew
+      // character and normalised every Hebrew title to the empty string —
+      // which then compared EQUAL to every other Hebrew title and returned a
+      // perfect 1.0 similarity for completely unrelated roles (WP-45).
+      .replace(/[^\p{L}\p{N}\s]/gu, ' ')
       .replace(/\s+/g, ' ')
       .trim();
   }
@@ -164,10 +168,23 @@ export class TitleAlignmentAnalyzer extends BaseAnalyzer {
   private extractTitlesFromText(text: string): string[] {
     const titles: string[] = [];
 
-    // Common title patterns
+    // Common title patterns.
+    //
+    // The first pattern relies on capitalisation to tell a job title from
+    // ordinary prose. Hebrew has no case, so it matched nothing and the
+    // analyzer fell through to its "no job titles found" floor of 20 for every
+    // Hebrew resume — including ones whose title was an exact match for the
+    // role. The third pattern covers caseless scripts by anchoring on the same
+    // "<title> at <company>" shape instead of on capitalisation (WP-45).
     const patterns = [
       /(?:^|\n)([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,4})\s*(?:at|@|\||,)/gm,
       /(?:position|role|title):\s*([^\n]+)/gi,
+      // Caseless scripts, currently Hebrew. Add further ranges here rather
+      // than loosening the Latin pattern, which would start matching prose.
+      // Space and tab only, never \n: a plain \s here lets the lazy quantifier
+      // run across lines and swallow the section heading above the role
+      // ("ניסיון תעסוקתי\n\nמהנדס תוכנה" came back as a single title).
+      /(?:^|\n)([\u0590-\u05FF][\u0590-\u05FF \t'"-]{1,58}?)[ \t]*(?:at|@|\|)/gmu,
     ];
 
     for (const pattern of patterns) {

--- a/src/lib/ats/benchmark/cases.ts
+++ b/src/lib/ats/benchmark/cases.ts
@@ -486,6 +486,245 @@ Photoshop, Illustrator, InDesign, עיצוב מותג
 תואר ראשון בעיצוב
 `,
   },
+
+  // --- Additional coverage (WP-45 S5 expansion to the packet's 30-50 range) --
+
+  {
+    id: 'de-senior-strong-2',
+    label: 'strong',
+    rationale: 'Platform engineer with the full streaming stack and mentoring, different wording to the JD.',
+    jobTitle: 'Senior Data Engineer',
+    jobText: SENIOR_DE_JOB,
+    requirements: SENIOR_DE_REQS,
+    resumeText: resume({
+      title: 'Staff Data Engineer',
+      summary: 'Staff engineer owning event streaming and warehouse modelling for a retail platform.',
+      skills: 'Kafka, Spark, Snowflake, Airflow, SQL, Python, AWS, data modelling, mentoring engineers',
+      roles: [
+        { title: 'Staff Data Engineer', company: 'Orchard Retail', dates: 'Feb 2020 - Present',
+          bullets: ['Run the Kafka event backbone and the Spark jobs on top of it',
+                    'Own Snowflake modelling and the Airflow schedule on AWS',
+                    'Mentor engineers across two squads and set data quality standards'] },
+      ],
+    }),
+  },
+  {
+    id: 'de-mid-stretch',
+    label: 'stretch',
+    rationale: 'Has Kafka and SQL but no warehouse, no orchestration, and one seniority level short.',
+    jobTitle: 'Senior Data Engineer',
+    jobText: SENIOR_DE_JOB,
+    requirements: SENIOR_DE_REQS,
+    resumeText: resume({
+      title: 'Data Engineer',
+      summary: 'Data engineer with four years on ingestion services.',
+      skills: 'Kafka, Python, SQL, Docker, Postgres',
+      roles: [
+        { title: 'Data Engineer', company: 'Signal Systems', dates: 'Jan 2022 - Present',
+          bullets: ['Maintain Kafka consumers feeding the operational store', 'Write Python and SQL for ad hoc analysis'] },
+      ],
+    }),
+  },
+  {
+    id: 'de-devops-weak',
+    holdout: true,
+    label: 'weak',
+    rationale: 'Infrastructure engineer, adjacent tooling but no data engineering.',
+    jobTitle: 'Senior Data Engineer',
+    jobText: SENIOR_DE_JOB,
+    requirements: SENIOR_DE_REQS,
+    resumeText: resume({
+      title: 'DevOps Engineer',
+      summary: 'DevOps engineer focused on Kubernetes and CI pipelines.',
+      skills: 'Kubernetes, Terraform, Jenkins, Bash, AWS',
+      roles: [
+        { title: 'DevOps Engineer', company: 'Cloudworks', dates: '2021 - Present',
+          bullets: ['Run the Kubernetes platform and CI pipelines'] },
+      ],
+    }),
+  },
+  {
+    id: 'ae-strong-2',
+    label: 'strong',
+    rationale: 'Enterprise closer with quota, forecasting, negotiation and exec relationships.',
+    jobTitle: 'Account Executive',
+    jobText: AE_JOB,
+    requirements: AE_REQS,
+    resumeText: resume({
+      title: 'Senior Account Executive',
+      summary: 'Senior AE closing SaaS deals into operations and supply chain teams.',
+      skills: 'B2B sales, quota ownership, CRM, pipeline management, contract negotiation, quarterly forecasting, SaaS, stakeholder management',
+      roles: [
+        { title: 'Senior Account Executive', company: 'Northwind Software', dates: 'Mar 2019 - Present',
+          bullets: ['Carry and consistently retire a mid-market quota',
+                    'Forecast quarterly and manage the pipeline end to end in the CRM',
+                    'Negotiate terms directly with senior executives'] },
+      ],
+    }),
+  },
+  {
+    id: 'ae-cs-stretch',
+    label: 'stretch',
+    rationale: 'Customer success manager: commercial exposure and renewals, but never carried new-business quota.',
+    jobTitle: 'Account Executive',
+    jobText: AE_JOB,
+    requirements: AE_REQS,
+    resumeText: resume({
+      title: 'Customer Success Manager',
+      summary: 'CSM owning renewals and expansion for mid-market accounts.',
+      skills: 'renewals, account management, CRM, stakeholder management, upselling',
+      roles: [
+        { title: 'Customer Success Manager', company: 'Vector Software', dates: '2021 - Present',
+          bullets: ['Own renewals and expansion across forty mid-market accounts', 'Work the CRM daily and coordinate with the AE team'] },
+      ],
+    }),
+  },
+  {
+    id: 'ae-marketing-weak',
+    label: 'weak',
+    rationale: 'Marketing specialist with no selling, no quota and no pipeline ownership.',
+    jobTitle: 'Account Executive',
+    jobText: AE_JOB,
+    requirements: AE_REQS,
+    resumeText: resume({
+      title: 'Marketing Specialist',
+      summary: 'Marketing specialist running email campaigns and events.',
+      skills: 'email marketing, campaign management, copywriting, event logistics',
+      roles: [
+        { title: 'Marketing Specialist', company: 'Brightline', dates: '2022 - Present',
+          bullets: ['Plan and run demand generation campaigns'] },
+      ],
+    }),
+  },
+  {
+    id: 'ops-strong-2',
+    label: 'strong',
+    rationale: 'Site manager covering planning, inventory, lean, suppliers, safety and WMS reporting.',
+    jobTitle: 'Operations Manager',
+    jobText: OPS_JOB,
+    requirements: OPS_REQS,
+    resumeText: resume({
+      title: 'Site Operations Manager',
+      summary: 'Site operations manager for a regional distribution centre.',
+      skills: 'shift planning, inventory management, team leadership, lean, supplier management, health and safety compliance, WMS, SQL',
+      roles: [
+        { title: 'Site Operations Manager', company: 'Meridian Logistics', dates: '2018 - Present',
+          bullets: ['Plan shifts for twenty-five staff and own inventory accuracy',
+                    'Lead lean continuous improvement and manage supplier schedules',
+                    'Report throughput and cost per unit from the WMS using SQL'] },
+      ],
+    }),
+  },
+  {
+    id: 'ops-admin-weak',
+    label: 'weak',
+    rationale: 'Office administrator with no operations, inventory or team leadership.',
+    jobTitle: 'Operations Manager',
+    jobText: OPS_JOB,
+    requirements: OPS_REQS,
+    resumeText: resume({
+      title: 'Office Administrator',
+      summary: 'Office administrator handling scheduling and correspondence.',
+      skills: 'diary management, correspondence, filing, reception',
+      roles: [
+        { title: 'Office Administrator', company: 'Grey & Co', dates: '2023 - Present',
+          bullets: ['Manage diaries and office correspondence'] },
+      ],
+    }),
+  },
+  {
+    id: 'ops-junior-stretch',
+    holdout: true,
+    label: 'stretch',
+    rationale: 'Team leader with genuine warehouse operations but no budget or supplier ownership.',
+    jobTitle: 'Operations Manager',
+    jobText: OPS_JOB,
+    requirements: OPS_REQS,
+    resumeText: resume({
+      title: 'Warehouse Team Leader',
+      summary: 'Team leader running a picking team in a distribution centre.',
+      skills: 'shift planning, team leadership, inventory management, health and safety, WMS',
+      roles: [
+        { title: 'Warehouse Team Leader', company: 'Meridian Logistics', dates: '2021 - Present',
+          bullets: ['Lead a picking team of ten and run daily shift plans', 'Maintain inventory accuracy in the WMS'] },
+      ],
+    }),
+  },
+  {
+    id: 'heb-stretch',
+    label: 'stretch',
+    rationale: 'Hebrew frontend engineer moving to backend: some overlap, missing the core stack.',
+    jobTitle: 'מהנדס תוכנה',
+    jobText: HEB_JOB,
+    requirements: HEB_REQS,
+    resumeText: `מועמד לדוגמה
+candidate@example.com
+
+תקציר מקצועי
+מפתח פרונטאנד עם שלוש שנות ניסיון.
+
+כישורים
+React, TypeScript, SQL, עבודת צוות, אנגלית ברמה גבוהה
+
+ניסיון תעסוקתי
+
+מפתח פרונטאנד at Example Ltd
+2023 - Present
+• פיתוח ממשקי משתמש ב-React
+• עבודה בצוות אג'ייל
+
+השכלה
+תואר ראשון במדעי המחשב
+`,
+  },
+  {
+    id: 'heb-strong-2',
+    label: 'strong',
+    rationale: 'Hebrew backend engineer matching the stack with more depth than the minimum.',
+    jobTitle: 'מהנדס תוכנה',
+    jobText: HEB_JOB,
+    requirements: HEB_REQS,
+    resumeText: `מועמד לדוגמה
+candidate@example.com
+
+תקציר מקצועי
+מהנדס תוכנה בכיר עם שבע שנות ניסיון בפיתוח בקאנד ומערכות בקנה מידה גדול.
+
+כישורים
+Node.js, SQL, Docker, Kubernetes, ניסיון בפיתוח, עבודת צוות, אנגלית ברמה גבוהה
+
+ניסיון תעסוקתי
+
+מהנדס תוכנה at Scale Systems
+2019 - Present
+• פיתוח שירותים ב-Node.js מול בסיסי נתונים
+• עבודה בסביבת ענן עם Docker ו-Kubernetes
+• כתיבת בדיקות ועבודה בצוות אג'ייל
+
+השכלה
+תואר ראשון במדעי המחשב
+`,
+  },
+  {
+    id: 'switch-strong',
+    holdout: true,
+    label: 'strong',
+    rationale: 'Analytics engineer who genuinely made the move: owns the full pipeline stack now.',
+    jobTitle: 'Senior Data Engineer',
+    jobText: SENIOR_DE_JOB,
+    requirements: SENIOR_DE_REQS,
+    resumeText: resume({
+      title: 'Analytics Engineer',
+      summary: 'Analytics engineer who moved into platform work and now owns ingestion end to end.',
+      skills: 'Kafka, Spark, Snowflake, Airflow, SQL, Python, AWS, dbt, data modelling',
+      roles: [
+        { title: 'Analytics Engineer', company: 'Lumen Data', dates: 'Apr 2021 - Present',
+          bullets: ['Own Snowflake modelling and the Airflow orchestration',
+                    'Built the Kafka and Spark ingestion path with the platform team',
+                    'Mentor two analysts moving into engineering'] },
+      ],
+    }),
+  },
 ];
 
 export const CALIBRATION_CASES = BENCHMARK_CASES.filter(c => !c.holdout);

--- a/src/lib/ats/benchmark/runner.ts
+++ b/src/lib/ats/benchmark/runner.ts
@@ -10,6 +10,7 @@ import { scoreResume } from '../core';
 import { generateFormatReport } from '../integration';
 import { BENCHMARK_CASES, type BandLabel, type BenchmarkCase } from './cases';
 import type { ATSScoreInput } from '../types';
+import { FIT_BANDS } from '../config/bands';
 
 export interface BandThresholds {
   /** At or above this is 'strong'. */
@@ -19,12 +20,13 @@ export interface BandThresholds {
 }
 
 /**
- * Current published bands, mirroring FitVerdict.swift on iOS.
+ * The bands the product actually ships, mirroring FitVerdict.swift on iOS.
  *
- * These were set when the scoring scale was materially different. They are the
- * subject of this benchmark, not an input to it.
+ * Adopted 2026-07-26 from this benchmark. The previous 75/50 belonged to the
+ * pre-2026-06-18 scale and produced a 26.7% false-Weak rate on the labelled
+ * set. See config/bands.ts for the full evidence.
  */
-export const PUBLISHED_BANDS: BandThresholds = { strong: 75, stretch: 50 };
+export const PUBLISHED_BANDS: BandThresholds = { strong: FIT_BANDS.strong, stretch: FIT_BANDS.stretch };
 
 export function bandFor(score: number, thresholds: BandThresholds): BandLabel {
   if (score >= thresholds.strong) return 'strong';
@@ -41,9 +43,28 @@ export interface CaseResult {
   /** A Strong or Stretch pair predicted Weak — the costliest error. */
   falseWeak: boolean;
   holdout: boolean;
+  /** True when the semantic analyzer fell back, so this score is not trustworthy. */
+  semanticDegraded: boolean;
 }
 
+/** How many cases in a run were scored with a degraded semantic analyzer. */
+export function degradedCount(results: CaseResult[]): number {
+  return results.filter(r => r.semanticDegraded).length;
+}
+
+/**
+ * The semantic analyzer returns exactly this when an embedding call fails.
+ * A run where cases hit it is measuring a degraded scorer, not the scorer.
+ */
+const SEMANTIC_FALLBACK = 50;
+
 export async function scoreCase(testCase: BenchmarkCase): Promise<number> {
+  return (await scoreCaseDetailed(testCase)).score;
+}
+
+export async function scoreCaseDetailed(
+  testCase: BenchmarkCase
+): Promise<{ score: number; semanticDegraded: boolean }> {
   const input: ATSScoreInput = {
     resume_original_text: testCase.resumeText,
     resume_optimized_text: testCase.resumeText,
@@ -60,17 +81,24 @@ export async function scoreCase(testCase: BenchmarkCase): Promise<number> {
   };
 
   const result = await scoreResume(input);
-  return result.ats_score_optimized;
+  return {
+    score: result.ats_score_optimized,
+    semanticDegraded: result.subscores.semantic_relevance === SEMANTIC_FALLBACK,
+  };
 }
 
 export async function runBenchmark(
   thresholds: BandThresholds = PUBLISHED_BANDS,
   cases: BenchmarkCase[] = BENCHMARK_CASES
 ): Promise<CaseResult[]> {
-  const scores = await Promise.all(cases.map(scoreCase));
+  // Parallel, matching the run the shipped bands were derived from. Sequential
+  // scoring was tried and did not improve stability, so the extra wall-clock
+  // bought nothing. `semanticDegraded` is the real safeguard: it reports when
+  // an embedding failure has made a run unfit to calibrate against.
+  const scores = await Promise.all(cases.map(scoreCaseDetailed));
 
   return cases.map((testCase, i) => {
-    const score = scores[i];
+    const { score, semanticDegraded } = scores[i];
     const predicted = bandFor(score, thresholds);
     return {
       id: testCase.id,
@@ -80,6 +108,7 @@ export async function runBenchmark(
       correct: predicted === testCase.label,
       falseWeak: predicted === 'weak' && testCase.label !== 'weak',
       holdout: Boolean(testCase.holdout),
+      semanticDegraded,
     };
   });
 }

--- a/src/lib/ats/config/bands.ts
+++ b/src/lib/ats/config/bands.ts
@@ -1,0 +1,47 @@
+/**
+ * Fit band thresholds (WP-45 S5)
+ *
+ * One definition, shared by the web response builder and mirrored by iOS.
+ *
+ * These replace the previous strong >= 75 / stretch >= 50, which were set for
+ * the scoring scale that existed before 2026-06-18. On the current scale those
+ * thresholds classified 4 of 19 labelled pairs as Weak when a human called them
+ * Strong or Stretch — a 26.7% false-Weak rate — and told roughly three in four
+ * free-checker users to skip the job.
+ *
+ * Selected by sweeping integer cut points over the labelled benchmark in
+ * `src/lib/ats/benchmark/`, maximising accuracy with ties broken toward fewer
+ * false-Weak calls. Run with real embeddings on 2026-07-26:
+ *
+ *   published 75/50 : accuracy 0.79, false-Weak 4 of 15 (26.7%)
+ *   derived   57/42 : accuracy 0.95, false-Weak 1 of 15 (6.7%), Strong reached
+ *   holdout (n=6)   : accuracy 0.67, false-Weak 0 (0.0%)
+ *
+ * The packet's gates are met: Strong is reachable and actually reached (8 of 8
+ * labelled Strong pairs score 76-90), the false-Weak rate is under 10%, no
+ * threshold rescues a labelled Weak pair into Strong, and calibration and
+ * holdout are reported separately.
+ *
+ * CARRIED CAVEAT: the benchmark labels were written by the same author as the
+ * fixtures. The packet asks for independent labels, and that is still owed.
+ * Treat these thresholds as evidence-based but not externally validated, and
+ * re-run the sweep if the labels are ever revised.
+ *
+ * Anything that changes what the scorer counts changes this scale. Re-run the
+ * benchmark in the same change and move these deliberately, with the date.
+ */
+export const FIT_BANDS = {
+  /** At or above this is a strong match. */
+  strong: 57,
+  /** At or above this (and below strong) is a stretch. Below it is weak. */
+  stretch: 42,
+} as const;
+
+export type FitBandName = 'strong' | 'stretch' | 'weak';
+
+export function fitBandFor(score: number): FitBandName {
+  if (!Number.isFinite(score)) return 'weak';
+  if (score >= FIT_BANDS.strong) return 'strong';
+  if (score >= FIT_BANDS.stretch) return 'stretch';
+  return 'weak';
+}

--- a/src/lib/ats/public-ats-check-response.ts
+++ b/src/lib/ats/public-ats-check-response.ts
@@ -2,6 +2,7 @@ import type { JobExtraction } from '@/lib/ats/types';
 import { buildJobDataFromExtractedJson } from '@/lib/ats/job-data-resolver';
 import { scoreSkillCoverage } from '@/lib/ats/skill-match';
 import { assessExtractionQuality } from '@/lib/ats/extraction-quality';
+import { fitBandFor } from '@/lib/ats/config/bands';
 
 type FitVerdict = 'Strong' | 'Stretch' | 'Skip';
 
@@ -14,9 +15,12 @@ export interface FitSource {
 const FIT_SCORE_NOTE = 'Estimated fit vs this job, not a hiring guarantee.';
 
 function getFitVerdict(overallScore: unknown): FitVerdict {
-  const score = Number(overallScore);
-  if (Number.isFinite(score) && score >= 75) return 'Strong';
-  if (Number.isFinite(score) && score >= 50) return 'Stretch';
+  // Thresholds live in config/bands.ts, chosen from the labelled benchmark.
+  // They were 75/50, set for a scale that stopped existing on 2026-06-18
+  // (WP-45 S5).
+  const band = fitBandFor(Number(overallScore));
+  if (band === 'strong') return 'Strong';
+  if (band === 'stretch') return 'Stretch';
   return 'Skip';
 }
 

--- a/tests/api/ats-check-format-response.test.ts
+++ b/tests/api/ats-check-format-response.test.ts
@@ -51,7 +51,7 @@ describe('formatResponse', () => {
       available: true,
       extractionQuality: 'low',
       requirementCount: 4,
-      verdict: 'Stretch',
+      verdict: 'Strong',
       recoveryReason: null,
       scoreNote: 'Estimated fit vs this job, not a hiring guarantee.',
       topGaps: ['strategic partnerships', 'payment platforms', 'senior executives'],
@@ -106,9 +106,14 @@ describe('formatResponse', () => {
   });
 
   it.each([
-    [75, 'Strong'],
-    [50, 'Stretch'],
-    [49, 'Skip'],
+    // Bands recalibrated 2026-07-26 from the labelled benchmark: strong >= 57,
+    // stretch >= 42. The old 75/50 belonged to the pre-2026-06-18 scale and
+    // classified 4 of 19 labelled pairs as Weak that a human called Strong or
+    // Stretch. See src/lib/ats/config/bands.ts.
+    [57, 'Strong'],
+    [56, 'Stretch'],
+    [42, 'Stretch'],
+    [41, 'Skip'],
   ])('maps score %i to the locked %s fit verdict', (atsScore, verdict) => {
     const response = buildPublicAtsCheckResponse({ ...scoreRow, ats_score: atsScore }, 'session-1', 3);
 


### PR DESCRIPTION
Closes the three items WP-45 was still carrying. Pairs with iOS [PR #124](https://github.com/nadavyigal/ResumeBuilder-IOS-APP/pull/124).

## Hebrew was being penalised for being Hebrew

The benchmark flagged `heb-strong` scoring **52** against 74–92 for equivalent English pairs. Not semantics — **three Latin-script assumptions**, in a product that ships in Hebrew:

| bug | effect |
|---|---|
| `section_completeness` matched English headings with `\b` | ASCII word boundary never fires between a space and a Hebrew letter, so a fully structured Hebrew resume scored **0** for having no sections |
| `title_alignment` extracted with `/[A-Z][a-z]+/` | cannot match a caseless script → returned its 20-point "no titles found" floor |
| `normalizeTitle` stripped with `[^\w\s]` | deleted every Hebrew character, so **every Hebrew title compared EQUAL to every other** and scored a perfect 1.0 for unrelated roles |

That third one was *inflating*, not deflating, and only surfaced because a test asserted the negative case. `heb-strong` now scores **78** and bands correctly.

This is the **third** instance of the ASCII-`\w` bug in this codebase.

## Bands adopted: 57/42

Measured on the labelled benchmark with **real embeddings**, 2026-07-26:

| bands | accuracy | false-Weak |
|---|---|---|
| published 75/50 | 0.79 | 4 of 15 (**26.7%**) |
| **adopted 57/42** | **0.947** (18/19) | 1 (**6.7%**) |
| holdout (n=6) | — | 0 (**0.0%**) |

The packet's gate is <10% and it now passes. It failed at 13% before the Hebrew fixes and before the benchmark grew 13 → 25 cases — at ten cases a single borderline pair moved the rate twelve points, so the metric had no resolution.

The sweep **re-derives 57/42** from the same data, and a test pins that: if a future scorer change moves the scale, the sweep drifts and the test fails.

## Why the band numbers kept moving

The live calibration file ran under **jsdom**. Its fetch shim was corrupting embedding calls, semantic fell back to a neutral 50, and accuracy read 0.79 instead of 0.947 — *reproducibly*, so it looked like a real result. The file now declares `@jest-environment node`, and the runner reports `semanticDegraded` per case so a degraded run **refuses to be calibrated against**.

## S8 backend

The optimization response now carries `lift` — `delta`, `meaningful`, `displayScores`. The backend has known since S2 whether a run beat the starting resume; nothing returned it, so a client had no way to avoid rendering "42 before, 44 after". Scores stay honest and unclamped; `lift` only says whether they're worth showing.

## Verification

11 new tests. Full suite at the **17 pre-existing** suite failures; passing 277 → 284. `eslint` clean. `tsc` 26 tracked errors, **0** in `src/lib/ats`. Clean-checkout `next build` passes.

## Note

An earlier commit here accidentally tracked two stray `" 2.ts"` duplicates via `git add src/app/api`. Removed from the commit, preserved on disk.

## Still open

The benchmark labels are mine, not independent — the packet asks for a second pass from someone who didn't write the fixtures. Recorded in `config/bands.ts` and `cases.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ATS results now include a lift summary showing score change and whether the improvement is meaningful.
  * Fit verdicts use updated score bands for Strong, Stretch, and Skip recommendations.
  * Hebrew resume headings and job titles are now recognized more accurately.
  * Expanded calibration coverage includes additional technical, commercial, operational, Hebrew, and career-switch scenarios.

* **Bug Fixes**
  * Improved section detection to avoid matching keywords embedded within other words.
  * Prevented misleading “improvement” displays when score changes are too small.

* **Tests**
  * Added and strengthened coverage for lift calculations, Hebrew scoring, calibration accuracy, and fit-band thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->