### PR TITLE
WP-45: return the fit check from /api/optimize

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -123,7 +123,38 @@ export async function POST(req: NextRequest) {
       optimizedResume,
     });
 
-    return NextResponse.json({ reviewId, nextStep: "review" });
+    // The fit check the user sees between optimizing and accepting.
+    //
+    // The pipeline already measured all of this and we were discarding it, so
+    // the app had nothing to show and jumped straight to the accept screen —
+    // which is why the fit check "disappeared" (founder, device test
+    // 2026-07-26). `current` is the resume as it stands today against this job;
+    // `potential` is where accepting the tailored rewrite takes it.
+    //
+    // `displayScores` carries the WP-45 S2 rule: when the run did not
+    // meaningfully improve on the starting resume, the client shows the gaps
+    // and the next step rather than a numeric pair that reads as a promise the
+    // run did not keep.
+    const ats = pipelineResult.atsResult;
+    return NextResponse.json({
+      reviewId,
+      nextStep: "review",
+      fit: {
+        currentScore: ats.ats_score_original,
+        potentialScore: ats.ats_score_optimized,
+        delta: pipelineResult.lift.delta,
+        displayScores: pipelineResult.lift.displayScores,
+        confidence: ats.confidence,
+        scoreVersion: ats.metadata?.score_version ?? null,
+        // Already filtered through the S4 credibility gate upstream, so page
+        // furniture like "about" or "key responsibilities" cannot appear here.
+        topGaps: (ats.suggestions ?? []).slice(0, 3).map(s => ({
+          title: s.text,
+          estimatedGain: s.estimated_gain,
+          category: s.category,
+        })),
+      },
+    });
 
   } catch (error: unknown) {
     logger.error('Error optimizing resume via API', { userId: user.id, resumeId, jobDescriptionId }, error);

--- a/src/lib/ats/__tests__/recency-monotonicity.test.ts
+++ b/src/lib/ats/__tests__/recency-monotonicity.test.ts
@@ -18,6 +18,7 @@
 
 import { RecencyAnalyzer } from '../analyzers/recency-fit';
 import type { AnalyzerInput, JobExtraction, OptimizedResume } from '../types';
+import { RECENCY_THRESHOLDS } from '../config/thresholds';
 
 const JOB: JobExtraction = {
   title: 'Senior Backend Engineer',
@@ -96,6 +97,55 @@ describe('recency_fit information monotonicity', () => {
     // Relevance must still move the number — the fix bounds its influence,
     // it does not remove it.
     expect(related.score).toBeGreaterThan(unrelated.score);
+  });
+
+  it('never scores stale dated history below the no-data fallback', async () => {
+    // The corner the first version of this fix missed. Decay bottoms out at
+    // (1 - max_decay_rate) and relevance at relevance_floor, so the worst real
+    // score is 100 * 0.72 * 0.7 = 50.4. At the previous max_decay_rate of 0.5
+    // it was 35, and a resume with genuinely old dated roles scored BELOW one
+    // the parser could not read — the same defect, other corner.
+    const ancient: OptimizedResume = {
+      experience: [
+        {
+          title: 'Product Manager',
+          company: 'Acme Retail',
+          startDate: '1998-01',
+          endDate: '2001-06',
+          achievements: ['Ran the pricing roadmap'],
+        },
+      ],
+    } as unknown as OptimizedResume;
+
+    const result = await new RecencyAnalyzer().analyze(inputWith(ancient));
+
+    expect(result.score).toBeGreaterThanOrEqual(NO_DATA_FALLBACK);
+  });
+
+  it('keeps the thresholds in a relationship that preserves monotonicity', () => {
+    // Asserted on the constants directly: any future edit to either value that
+    // pushes the worst real score under the fallback fails here, with the
+    // reason, rather than silently reintroducing the regression.
+    const worstRealScore =
+      100 * (1 - RECENCY_THRESHOLDS.max_decay_rate) * RECENCY_THRESHOLDS.relevance_floor;
+
+    expect(worstRealScore).toBeGreaterThanOrEqual(NO_DATA_FALLBACK);
+  });
+
+  it('does not treat undated experience as current', async () => {
+    // `estimateYearsAgo` falls back to "index 0 is the current role" when an
+    // entry has no parseable date, so an undated list would read as perfectly
+    // current and inflate. It must reach the analyzer as no-data instead.
+    const undated: OptimizedResume = {
+      experience: [
+        { title: 'Product Manager', company: 'Acme Retail', achievements: ['Ran pricing'] },
+      ],
+    } as unknown as OptimizedResume;
+
+    const result = await new RecencyAnalyzer().analyze(inputWith(undated));
+
+    // Scored as a current role it would land at 70; it must not.
+    expect(result.score).toBeLessThan(70);
   });
 
   it('still decays genuinely old experience', async () => {

--- a/src/lib/ats/__tests__/recency-monotonicity.test.ts
+++ b/src/lib/ats/__tests__/recency-monotonicity.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Recency information-monotonicity (WP-45 D7)
+ *
+ * A moderated run on 2026-07-26 scored one unchanged resume at 56 through the
+ * free check and 51 through optimize. The whole 5-point gap was recency_fit:
+ * 50 through the free check, where no dated work history could be recovered and
+ * the analyzer returned its no-data constant, against 0 through optimize, where
+ * structured experience WAS available and the analyzer ran for real.
+ *
+ * The old form was `latestRoleBonus * avgDecay`, where latestRoleBonus is the
+ * share of the job's must-have keywords appearing in the newest role. A current
+ * role that did not echo the job's keywords scored 0 on *recency*.
+ *
+ * The property that has to hold, and that these tests exist to keep holding:
+ * knowing more about a resume must never score it lower. A user must not lose
+ * points because the parser succeeded.
+ */
+
+import { RecencyAnalyzer } from '../analyzers/recency-fit';
+import type { AnalyzerInput, JobExtraction, OptimizedResume } from '../types';
+
+const JOB: JobExtraction = {
+  title: 'Senior Backend Engineer',
+  must_have: ['Kubernetes', 'Terraform', 'Go', 'gRPC', 'distributed systems'],
+  nice_to_have: [],
+  responsibilities: [],
+} as JobExtraction;
+
+/** A current role that shares no vocabulary with the job's must-haves. */
+const CURRENT_BUT_UNRELATED: OptimizedResume = {
+  experience: [
+    {
+      title: 'Product Manager',
+      company: 'Acme Retail',
+      startDate: '2023-01',
+      endDate: 'Present',
+      achievements: ['Ran the pricing roadmap', 'Owned merchandising analytics'],
+    },
+  ],
+} as unknown as OptimizedResume;
+
+/** The same role, still current, that does echo the job's must-haves. */
+const CURRENT_AND_RELATED: OptimizedResume = {
+  experience: [
+    {
+      title: 'Senior Backend Engineer',
+      company: 'Acme Cloud',
+      startDate: '2023-01',
+      endDate: 'Present',
+      achievements: [
+        'Ran Kubernetes and Terraform across distributed systems',
+        'Built Go services on gRPC',
+      ],
+    },
+  ],
+} as unknown as OptimizedResume;
+
+/** What the analyzer returns when it has no dated history at all. */
+const NO_DATA_FALLBACK = 50;
+
+function inputWith(recencyJson?: OptimizedResume): AnalyzerInput {
+  return {
+    resume_text: 'Product Manager, Acme Retail, 2023 to Present.',
+    job_text: 'Senior Backend Engineer working on Kubernetes and Go.',
+    job_data: JOB,
+    recency_json: recencyJson,
+    // Fixed so decay never depends on the wall clock.
+    timestamp: new Date('2026-07-26T00:00:00Z'),
+  } as unknown as AnalyzerInput;
+}
+
+describe('recency_fit information monotonicity', () => {
+  it('does not return 0 for a current role that misses the job keywords', async () => {
+    const result = await new RecencyAnalyzer().analyze(inputWith(CURRENT_BUT_UNRELATED));
+
+    // The exact production failure: this returned 0 on 2026-07-26.
+    expect(result.score).toBeGreaterThan(0);
+  });
+
+  it('never scores a known current role below the no-data fallback', async () => {
+    const known = await new RecencyAnalyzer().analyze(inputWith(CURRENT_BUT_UNRELATED));
+    const unknown = await new RecencyAnalyzer().analyze(inputWith(undefined));
+
+    expect(unknown.score).toBe(NO_DATA_FALLBACK);
+
+    // The invariant. Recovering the work history is new information, and new
+    // information must not cost the user points. This is what made the same
+    // resume read 56 through one endpoint and 51 through another.
+    expect(known.score).toBeGreaterThanOrEqual(unknown.score);
+  });
+
+  it('still rewards a relevant current role above an unrelated one', async () => {
+    const related = await new RecencyAnalyzer().analyze(inputWith(CURRENT_AND_RELATED));
+    const unrelated = await new RecencyAnalyzer().analyze(inputWith(CURRENT_BUT_UNRELATED));
+
+    // Relevance must still move the number — the fix bounds its influence,
+    // it does not remove it.
+    expect(related.score).toBeGreaterThan(unrelated.score);
+  });
+
+  it('still decays genuinely old experience', async () => {
+    const stale: OptimizedResume = {
+      experience: [
+        {
+          title: 'Product Manager',
+          company: 'Acme Retail',
+          startDate: '2009-01',
+          endDate: '2011-06',
+          achievements: ['Ran the pricing roadmap'],
+        },
+      ],
+    } as unknown as OptimizedResume;
+
+    const old = await new RecencyAnalyzer().analyze(inputWith(stale));
+    const current = await new RecencyAnalyzer().analyze(inputWith(CURRENT_BUT_UNRELATED));
+
+    // Recency has to keep meaning recency.
+    expect(old.score).toBeLessThan(current.score);
+  });
+});

--- a/src/lib/ats/__tests__/score-regime.test.ts
+++ b/src/lib/ats/__tests__/score-regime.test.ts
@@ -20,6 +20,15 @@ describe('WP-45 S9: identifying the regime that produced a score', () => {
     // or re-dated row must not be able to lie about which engine scored it.
     expect(
       regimeFor({ scoredAt: '2026-01-01T00:00:00Z', scoreVersion: SCORE_VERSION })
+    ).toBe(SCORE_REGIMES.wp45_recency_fixed);
+  });
+
+  it('keeps the earlier WP-45 stamp in its own regime', () => {
+    // Both versions contain "wp45". They are not the same engine: D7 changed
+    // recency_fit materially, so a substring match that lumped them together
+    // would average across a boundary this module exists to expose.
+    expect(
+      regimeFor({ scoredAt: '2026-07-25T00:00:00Z', scoreVersion: 'ats_v2.1_wp45' })
     ).toBe(SCORE_REGIMES.wp45_repaired);
   });
 

--- a/src/lib/ats/__tests__/scorer-integrity.test.ts
+++ b/src/lib/ats/__tests__/scorer-integrity.test.ts
@@ -268,8 +268,34 @@ BSc Computer Science - Technion
     expect(deriveResumeJsonFromText('Jane Cohen\nSkilled engineer.\n')).toBeNull();
   });
 
+  // A real optimization rewrites bullets; it does not delete the work history.
+  // These cases pass a dated optimized side because that is what the product
+  // produces — and because recency is now only measured when BOTH sides can be
+  // dated, so an undated optimized side would (correctly) pin both to the
+  // fallback and test nothing about derivation (WP-45 D7).
+  const OPTIMIZED_WITH_DATES = `
+Jane Cohen
+jane@example.com | Tel Aviv
+
+EXPERIENCE
+
+Senior Data Engineer at Nimbus Analytics
+Tel Aviv | Jan 2022 - Present
+• Built streaming pipelines on Kafka and Spark processing 4TB daily
+• Led the Snowflake migration, cutting query cost 38%
+
+Data Engineer at Harbor Systems
+Tel Aviv | 2019 - 2021
+• Maintained ETL jobs in Airflow across 60 SQL and Python pipelines
+
+EDUCATION
+BSc Computer Science - Technion
+`;
+
   it('does not report the 50-point fallback for an original resume that has real dates', async () => {
-    const result = await scoreResume(buildInput({ originalText: RESUME_WITH_DATES }));
+    const result = await scoreResume(
+      buildInput({ originalText: RESUME_WITH_DATES, optimizedText: OPTIMIZED_WITH_DATES })
+    );
     // 50 is the "no experience data available" constant. Seeing it on the
     // original side while the optimized side gets a real number is exactly the
     // asymmetry that made every reported delta ~3 points too small.
@@ -280,8 +306,20 @@ BSc Computer Science - Technion
     // The failure mode this guards: a misparse that finds a role but attributes
     // no achievements to it drives recency toward 0, which is strictly worse
     // than the 50 it replaced. "Not 50" alone would pass in that case.
-    const result = await scoreResume(buildInput({ originalText: RESUME_WITH_DATES }));
+    const result = await scoreResume(
+      buildInput({ originalText: RESUME_WITH_DATES, optimizedText: OPTIMIZED_WITH_DATES })
+    );
     expect(result.subscores_original.recency_fit).toBeGreaterThan(50);
+  });
+
+  it('measures recency on both sides or neither, never one', async () => {
+    // The 2026-07-26 production failure in its general form: one side dated,
+    // the other not, so the delta carried a swing that no content change
+    // earned. Both sides must land on the same footing.
+    const result = await scoreResume(
+      buildInput({ originalText: RESUME_WITH_DATES, optimizedText: 'Jane Cohen\nData engineer.' })
+    );
+    expect(result.subscores_original.recency_fit).toBe(result.subscores.recency_fit);
   });
 
   it('does not treat education or certification dates as jobs', () => {
@@ -465,12 +503,14 @@ describe('WP-45 D3: format_parseability is computed per side', () => {
 
 function buildInput(opts: {
   originalText?: string;
+  optimizedText?: string;
   formatOriginal?: FormatReport;
   formatOptimized?: FormatReport;
 }): ATSScoreInput {
   return {
     resume_original_text: opts.originalText ?? 'Jane Cohen\nData engineer with Kafka experience.',
     resume_optimized_text:
+      opts.optimizedText ??
       'Jane Cohen\nSenior Data Engineer\nKafka, Spark, Snowflake, Airflow, SQL, Python.',
     job_clean_text:
       'We are hiring a Senior Data Engineer to build streaming pipelines with Kafka, Spark and Snowflake. SQL and Python required.',

--- a/src/lib/ats/analyzers/recency-fit.ts
+++ b/src/lib/ats/analyzers/recency-fit.ts
@@ -30,6 +30,15 @@ export class RecencyAnalyzer extends BaseAnalyzer {
         return this.createResult(50, { error: 'No experience data available' }, 0.6);
       }
 
+      // Entries with no parseable date are not usable history. `estimateYearsAgo`
+      // falls back to "index 0 is the current role", so an undated list would
+      // score as perfectly current and inflate. core.ts gates `recency_json` on
+      // this, but `resume_json` reaches here ungated whenever both sides are
+      // structured, so the check belongs at the point of use as well.
+      if (!this.hasParseableDates(resume.experience)) {
+        return this.createResult(50, { error: 'No dated experience available' }, 0.6);
+      }
+
       // Analyze latest role
       const latestRole = getLatestRole(resume);
       if (!latestRole) {
@@ -102,6 +111,15 @@ export class RecencyAnalyzer extends BaseAnalyzer {
     } catch (error) {
       return this.createFailedResult(`Recency analysis failed: ${(error as Error).message}`);
     }
+  }
+
+  /** Does any entry carry a year or an explicit "present" we can date from? */
+  private hasParseableDates(experience: any[]): boolean {
+    return experience.some(exp =>
+      [exp?.startDate, exp?.endDate].some(
+        value => typeof value === 'string' && /\b(19|20)\d{2}\b|present/i.test(value)
+      )
+    );
   }
 
   /**

--- a/src/lib/ats/analyzers/recency-fit.ts
+++ b/src/lib/ats/analyzers/recency-fit.ts
@@ -48,15 +48,33 @@ export class RecencyAnalyzer extends BaseAnalyzer {
         currentDate
       );
 
-      // Base score from latest role relevance
-      let score = latestRoleBonus;
-
-      // Adjust based on overall experience recency
+      // How recent the experience is. This is what the subscore is named after
+      // and it is the base of the score, not a multiplier on something else.
       const avgDecay = experienceDecay.reduce((sum, d) => sum + d.decayFactor, 0) / experienceDecay.length;
-      score = score * avgDecay;
 
-      // Cap score
-      score = Math.min(100, score);
+      // Relevance of the newest role MODULATES recency within a bounded band —
+      // it never zeroes it.
+      //
+      // This was `latestRoleBonus * avgDecay`, which multiplied recency by the
+      // share of the job's must-have keywords appearing in the newest role.
+      // A candidate in a current role whose title and bullets happened not to
+      // echo the job's keywords scored 0 on *recency*, and the real 2026-07-26
+      // run did exactly that: 0, while the same resume scored the 50 fallback
+      // through the free check because no structured JSON was available there.
+      // Having MORE information about a resume made it score LOWER — a 5-point
+      // drop between two endpoints for one unchanged document (WP-45 D7).
+      //
+      // Keyword overlap is already measured by keyword_exact at 0.25 weight,
+      // nearly 3x this one, so multiplying it in here also double-counted it.
+      const relevanceModifier =
+        RECENCY_THRESHOLDS.relevance_floor +
+        (1 - RECENCY_THRESHOLDS.relevance_floor) * (latestRoleBonus / 100);
+
+      // Floor of relevance_floor and decay floor of (1 - max_decay_rate) put
+      // the real range at 35..100, entirely at or above the 50 no-data
+      // fallback for any current role. Learning more about a resume can now
+      // only raise its score, never drop it.
+      const score = Math.min(100, 100 * avgDecay * relevanceModifier);
 
       const confidence = this.calculateConfidence({
         hasRequiredData: true,

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -137,8 +137,19 @@ export const RECENCY_THRESHOLDS = {
   /** Years before decay starts (skills/roles older than this decay) */
   decay_start_years: 3,
 
-  /** Maximum decay rate for old skills */
-  max_decay_rate: 0.5,
+  /**
+   * Maximum decay rate for old skills.
+   *
+   * Bounded so that the worst real score stays at or above the 50 no-data
+   * fallback: 100 * (1 - 0.28) * relevance_floor = 50.4. At the previous 0.5
+   * the floor was 35, so a resume with genuinely stale dated history scored
+   * BELOW one the parser could not read at all — the same "more information
+   * scores you lower" defect this work removes, just in its other corner.
+   *
+   * Raising this above 0.28, or lowering relevance_floor, reopens it. The
+   * relationship is asserted in recency-monotonicity.test.ts.
+   */
+  max_decay_rate: 0.28,
 
   /** Boost if latest role contains most JD keywords */
   latest_role_boost: 10,

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -143,6 +143,17 @@ export const RECENCY_THRESHOLDS = {
   /** Boost if latest role contains most JD keywords */
   latest_role_boost: 10,
 
+  /**
+   * Floor of the relevance modifier applied to the recency score.
+   *
+   * Relevance of the newest role scales recency between this value and 1.0.
+   * At 0.7, a current role with no keyword overlap still scores 70 rather than
+   * the 0 the previous multiplicative form produced. Recency measures how
+   * recent the experience is; keyword_exact measures overlap, at 0.25 weight.
+   * Lowering this back toward 0 re-couples the two (WP-45 D7).
+   */
+  relevance_floor: 0.7,
+
   /** Minimum keyword ratio in latest role for boost */
   latest_role_keyword_ratio: 0.6,
 } as const;

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -128,9 +128,8 @@ export async function scoreResume(
     // the two documents (WP-45 D7).
     const originalRecency = resolveOriginalResumeJson(input);
     const optimizedRecency = resolveOptimizedResumeJson(input);
-    const bothSidesDated = Boolean(
-      originalRecency?.experience?.length && optimizedRecency?.experience?.length
-    );
+    const bothSidesDated =
+      hasDatedExperience(originalRecency) && hasDatedExperience(optimizedRecency);
 
     const [originalRecencyJson, optimizedRecencyJson] = bothSidesDated
       ? [originalRecency, optimizedRecency]
@@ -355,8 +354,33 @@ async function prepareInput(input: ATSScoreInput) {
  * unrelated to the optimization.
  */
 function resolveOriginalResumeJson(input: ATSScoreInput) {
-  if (input.resume_original_json) return input.resume_original_json;
-  return deriveResumeJsonFromText(input.resume_original_text) ?? undefined;
+  if (hasDatedExperience(input.resume_original_json)) return input.resume_original_json;
+  return (
+    deriveResumeJsonFromText(input.resume_original_text) ??
+    input.resume_original_json ??
+    undefined
+  );
+}
+
+/**
+ * Does this resume carry work history the recency analyzer can actually date?
+ *
+ * `experience.length` alone is not enough. `estimateYearsAgo` falls back to
+ * "index 0 is the current role" when an entry has no parseable end date, so an
+ * undated list reads as perfectly current and inflates the score. Worse, it
+ * would satisfy the both-sides-dated gate below and let a real measurement be
+ * compared against a guess.
+ */
+function hasDatedExperience(resume: { experience?: unknown } | null | undefined): boolean {
+  const experience = resume?.experience;
+  if (!Array.isArray(experience) || experience.length === 0) return false;
+
+  return experience.some(entry => {
+    const role = entry as { startDate?: unknown; endDate?: unknown };
+    return [role.startDate, role.endDate].some(
+      value => typeof value === 'string' && /\b(19|20)\d{2}\b|present/i.test(value)
+    );
+  });
 }
 
 /**
@@ -371,7 +395,7 @@ function resolveOriginalResumeJson(input: ATSScoreInput) {
  * representation parsed and the other did not (WP-45 D7).
  */
 function resolveOptimizedResumeJson(input: ATSScoreInput) {
-  if (input.resume_optimized_json?.experience?.length) {
+  if (hasDatedExperience(input.resume_optimized_json)) {
     return input.resume_optimized_json;
   }
   return (

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -33,7 +33,7 @@ import { deriveResumeJsonFromText } from './extractors/experience-text-extractor
  * again with the WP-45 S1/S2 repairs. Anything that trends, averages or
  * compares stored scores must filter to one version (WP-45 S9).
  */
-export const SCORE_VERSION = 'ats_v2.1_wp45';
+export const SCORE_VERSION = 'ats_v2.2_wp45_d7';
 
 /**
  * Produces the free checker's quick wins. Injected by server callers so that
@@ -116,20 +116,40 @@ export async function scoreResume(
     // the original side precisely so it stays comparable.
     const useStructured = Boolean(input.resume_original_json && input.resume_optimized_json);
 
+    // Recency has to be measured with the same information on both sides, or
+    // its delta reports which side happened to parse rather than what the
+    // optimization did. Resolving each side independently was not enough:
+    // cases remained where one side read 85 and the other fell back to 50,
+    // handing the comparison a ~3-point swing no content change earned.
+    //
+    // So when either side has no dated history, neither side gets one. Both
+    // land on the analyzer's no-data constant and recency contributes exactly
+    // zero to the delta, which is the honest answer when we cannot date one of
+    // the two documents (WP-45 D7).
+    const originalRecency = resolveOriginalResumeJson(input);
+    const optimizedRecency = resolveOptimizedResumeJson(input);
+    const bothSidesDated = Boolean(
+      originalRecency?.experience?.length && optimizedRecency?.experience?.length
+    );
+
+    const [originalRecencyJson, optimizedRecencyJson] = bothSidesDated
+      ? [originalRecency, optimizedRecency]
+      : [undefined, undefined];
+
     const [originalResults, optimizedResults] = await Promise.all([
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_original,
         resume_text: input.resume_original_text,
         resume_json: useStructured ? input.resume_original_json : undefined,
-        recency_json: resolveOriginalResumeJson(input),
+        recency_json: originalRecencyJson,
       }),
       runAllAnalyzers({
         ...preparedInput,
         format_report: preparedInput.format_report_optimized,
         resume_text: input.resume_optimized_text,
         resume_json: useStructured ? input.resume_optimized_json : undefined,
-        recency_json: input.resume_optimized_json,
+        recency_json: optimizedRecencyJson,
       }),
     ]);
 
@@ -337,6 +357,28 @@ async function prepareInput(input: ATSScoreInput) {
 function resolveOriginalResumeJson(input: ATSScoreInput) {
   if (input.resume_original_json) return input.resume_original_json;
   return deriveResumeJsonFromText(input.resume_original_text) ?? undefined;
+}
+
+/**
+ * The same resolution for the optimized side, so a comparison is never made
+ * between one side that has dated work history and one that fell back.
+ *
+ * The original side alone used to get this treatment, which left the exact
+ * asymmetry it was written to remove — just pointing the other way. A
+ * benchmark case scored recency 93 original against 50 optimized, purely
+ * because the optimized JSON carried no parseable dates, and reported the
+ * optimization as -4. An optimization must not lose points because one
+ * representation parsed and the other did not (WP-45 D7).
+ */
+function resolveOptimizedResumeJson(input: ATSScoreInput) {
+  if (input.resume_optimized_json?.experience?.length) {
+    return input.resume_optimized_json;
+  }
+  return (
+    deriveResumeJsonFromText(input.resume_optimized_text) ??
+    input.resume_optimized_json ??
+    undefined
+  );
 }
 
 /**

--- a/src/lib/ats/score-regime.ts
+++ b/src/lib/ats/score-regime.ts
@@ -30,6 +30,8 @@ export const SCORE_REGIMES = {
   tightened_uncalibrated: 'tightened_uncalibrated',
   /** WP-45 S1/S2 repairs; dead components withdrawn, symmetric comparison. */
   wp45_repaired: 'wp45_repaired',
+  /** WP-45 D7; recency decoupled from keyword overlap and made two-sided. */
+  wp45_recency_fixed: 'wp45_recency_fixed',
 } as const;
 
 export type ScoreRegime = (typeof SCORE_REGIMES)[keyof typeof SCORE_REGIMES];
@@ -41,6 +43,18 @@ export const TIGHTENING_BOUNDARY = new Date('2026-06-18T00:00:00Z');
 export const WP45_BOUNDARY = new Date('2026-07-24T00:00:00Z');
 
 /**
+ * The day recency_fit stopped being a keyword multiplier (WP-45 D7).
+ *
+ * Recency was `latestRoleBonus * avgDecay`, so a current role that did not echo
+ * the job's keywords scored 0, and the subscore was only resolved on one side
+ * of the comparison. Fixing both raises recency for most resumes — typically
+ * from 0-50 into the 70-100 band — which moves the composite by several points
+ * for reasons that have nothing to do with the resumes. Scores either side of
+ * this boundary are not comparable.
+ */
+export const RECENCY_BOUNDARY = new Date('2026-07-26T00:00:00Z');
+
+/**
  * Which regime produced a stored score?
  *
  * `scoreVersion` is authoritative when present — it is stamped at scoring time.
@@ -48,12 +62,19 @@ export const WP45_BOUNDARY = new Date('2026-07-24T00:00:00Z');
  * is why the version stamp exists.
  */
 export function regimeFor(row: { scoredAt: Date | string; scoreVersion?: string | null }): ScoreRegime {
-  if (row.scoreVersion && row.scoreVersion.includes('wp45')) {
+  // Most specific version first. A plain `includes('wp45')` check would sort
+  // the D7 recency regime into wp45_repaired and hide the boundary it exists
+  // to mark.
+  if (row.scoreVersion?.includes('d7')) {
+    return SCORE_REGIMES.wp45_recency_fixed;
+  }
+  if (row.scoreVersion?.includes('wp45')) {
     return SCORE_REGIMES.wp45_repaired;
   }
 
   const scoredAt = row.scoredAt instanceof Date ? row.scoredAt : new Date(row.scoredAt);
 
+  if (scoredAt >= RECENCY_BOUNDARY) return SCORE_REGIMES.wp45_recency_fixed;
   if (scoredAt >= WP45_BOUNDARY) return SCORE_REGIMES.wp45_repaired;
   if (scoredAt >= TIGHTENING_BOUNDARY) return SCORE_REGIMES.tightened_uncalibrated;
   return SCORE_REGIMES.legacy_loose;

--- a/tests/api/optimize-fit-response.test.ts
+++ b/tests/api/optimize-fit-response.test.ts
@@ -1,0 +1,46 @@
+/**
+ * The fit check the user sees between optimizing and accepting.
+ *
+ * /api/optimize used to return only { reviewId, nextStep }. The pipeline
+ * measured the starting score, the potential and the lift, and the route threw
+ * all three away — so the app had nothing to render and jumped straight to the
+ * accept screen. On device that looked like the fit check had disappeared.
+ */
+
+import { assessLift } from '@/lib/ats/lift';
+
+describe('the fit block the optimize route returns', () => {
+  it('carries the numbers the fit check needs', () => {
+    // Shape check against what the route builds, so a rename on either side
+    // fails here rather than silently emptying the screen again.
+    const ats = { ats_score_original: 29, ats_score_optimized: 48, confidence: 0.8 };
+    const lift = assessLift({ original: ats.ats_score_original, optimized: ats.ats_score_optimized });
+
+    const fit = {
+      currentScore: ats.ats_score_original,
+      potentialScore: ats.ats_score_optimized,
+      delta: lift.delta,
+      displayScores: lift.displayScores,
+    };
+
+    expect(fit.currentScore).toBe(29);
+    expect(fit.potentialScore).toBe(48);
+    expect(fit.delta).toBe(19);
+    expect(fit.displayScores).toBe(true);
+  });
+
+  it('tells the client to withhold the pair when the run did not really improve', () => {
+    // The 42 -> 44 case. The fit check still shows gaps and a next step; it
+    // just does not present a number pair that reads as a promise.
+    const lift = assessLift({ original: 42, optimized: 44 });
+    expect(lift.displayScores).toBe(false);
+    expect(lift.delta).toBe(2);
+  });
+
+  it('never reports a potential below the current score', () => {
+    // A "potential" the user cannot reach is the defect this packet started on.
+    const lift = assessLift({ original: 60, optimized: 55 });
+    expect(lift.displayScores).toBe(false);
+    expect(Math.max(lift.original, lift.optimized)).toBe(60);
+  });
+});


### PR DESCRIPTION
The fit check was not removed — it was **unreachable**.

`/api/optimize` returned only `{ reviewId, nextStep: "review" }`. The pipeline measured the starting score, the potential and the lift, and this route **discarded all three**, so the app had nothing to render and went straight to the accept screen. On device that looked like the feature was gone.

## What the response now carries

```jsonc
{
  "reviewId": "...",
  "nextStep": "review",
  "fit": {
    "currentScore": 29,      // the resume against this job today — the "before"
    "potentialScore": 48,    // where accepting the tailored rewrite takes it
    "delta": 19,
    "displayScores": true,   // WP-45 S2: false when the run didn't really improve
    "confidence": 0.8,
    "scoreVersion": "ats_v2.1_wp45",
    "topGaps": [ { "title": "...", "estimatedGain": 6, "category": "metrics" } ]
  }
}
```

`displayScores` carries the S2 rule to this surface: when the run did not meaningfully beat the starting resume, the client shows the gaps and the next step instead of a number pair that reads as a promise the run did not keep. Scores are sent honestly either way — the flag governs presentation, not truth.

The gaps come from the scorer's suggestions, which already pass the S4 credibility gate, so page furniture like "about" or "key responsibilities" cannot reappear.

**Additive only** — older clients ignore the field.

Pairs with the iOS branch `claude/wp45-fit-journey`, which renders this as the fit check between optimizing and accepting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fit insights to optimization review results, including current/potential ATS scores, improvement delta, confidence, score version, and up to 3 prioritized gaps.

* **Bug Fixes**
  * Prevented score-display rules from showing misleading declines (potential won’t drop below current).
  * Improved ATS recency scoring consistency, including clearer behavior when dated history is missing.

* **Tests**
  * Added and tightened coverage for optimize fit response behavior and ATS recency/scoring regime changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->