### PR TITLE
WP-45 D8: the baseline is measured once and never recomputed

### DIFF
--- a/src/lib/ats/__tests__/journey-score.test.ts
+++ b/src/lib/ats/__tests__/journey-score.test.ts
@@ -146,3 +146,4 @@ describe('the baseline is immutable', () => {
     expect(afterExpert.after).toBe(60);
   });
 });
+

--- a/src/lib/ats/__tests__/journey-score.test.ts
+++ b/src/lib/ats/__tests__/journey-score.test.ts
@@ -1,0 +1,148 @@
+/**
+ * The journey score contract (WP-45 D8)
+ *
+ * Reproduces the 2026-07-27 report: one resume, one job, three different score
+ * pairs shown to one user — 39 → 46, then 39 → 40, then 29 → 60.
+ */
+
+import {
+  isImpossibleMeasurement,
+  resolveJourneyScores,
+  type JourneyBaseline,
+} from '../journey-score';
+import type { SubScores } from '../types';
+
+/** The original-side subscores actually persisted for the reported run. */
+const THE_REPORTED_NON_MEASUREMENT: Partial<SubScores> = {
+  recency_fit: 50,
+  keyword_exact: 0,
+  keyword_phrase: 0,
+  title_alignment: 20,
+  metrics_presence: 0,
+  semantic_relevance: 0,
+  format_parseability: 100,
+  section_completeness: 0,
+};
+
+/** A genuinely weak resume, which must still be accepted as a real score. */
+const A_REALLY_BAD_RESUME: Partial<SubScores> = {
+  recency_fit: 50,
+  keyword_exact: 4,
+  keyword_phrase: 0,
+  title_alignment: 10,
+  metrics_presence: 0,
+  semantic_relevance: 31,
+  format_parseability: 62,
+  section_completeness: 25,
+};
+
+describe('refusing measurements that cannot be true', () => {
+  it('rejects the exact subscores that produced the reported 29', () => {
+    // Four analyzers at zero AND perfect format parseability is what an empty
+    // document scores. The user's resume was 3376 characters.
+    expect(isImpossibleMeasurement(THE_REPORTED_NON_MEASUREMENT)).toBe(true);
+  });
+
+  it('accepts a genuinely low-scoring resume', () => {
+    // The guard must not become a floor on bad news.
+    expect(isImpossibleMeasurement(A_REALLY_BAD_RESUME)).toBe(false);
+  });
+
+  it('rejects a missing measurement outright', () => {
+    expect(isImpossibleMeasurement(null)).toBe(true);
+    expect(isImpossibleMeasurement(undefined)).toBe(true);
+  });
+
+  it('does not reject on a zero semantic score alone', () => {
+    // Semantic zero is the load-bearing signal, but on its own — with the rest
+    // of the document scoring normally — it is one broken analyzer, not an
+    // empty document, and the other subscores are still worth keeping.
+    expect(
+      isImpossibleMeasurement({
+        ...A_REALLY_BAD_RESUME,
+        semantic_relevance: 0,
+        format_parseability: 62,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('the baseline is immutable', () => {
+  const baseline: JourneyBaseline = { score: 39, source: 'review_run' };
+
+  it('keeps the starting number the user was first shown', () => {
+    // The reported failure: accept re-measured the untouched original and
+    // reported 29, so the journey started 10 points below where the user began.
+    const pair = resolveJourneyScores({ baseline, measuredOptimized: 57 });
+
+    expect(pair.before).toBe(39);
+  });
+
+  it('gives a partial acceptance a smaller gain, not a different start', () => {
+    // Founder direction 2026-07-27: if the full potential was +10 and the user
+    // accepts some of it, they should see less than +10 — measured, not capped.
+    const full = resolveJourneyScores({ baseline, measuredOptimized: 49 });
+    const partial = resolveJourneyScores({
+      baseline,
+      measuredOptimized: 43,
+      promisedOptimized: 49,
+    });
+
+    expect(full.after - full.before).toBe(10);
+    expect(partial.after - partial.before).toBe(4);
+    expect(partial.before).toBe(full.before);
+  });
+
+  it('never presents a gain below zero', () => {
+    const pair = resolveJourneyScores({ baseline, measuredOptimized: 31 });
+
+    expect(pair.after).toBe(39);
+    expect(pair.after).toBeGreaterThanOrEqual(pair.before);
+  });
+
+  it('still records a regression even while hiding it', () => {
+    const pair = resolveJourneyScores({ baseline, measuredOptimized: 31 });
+
+    expect(pair.regressed).toBe(true);
+    expect(pair.measuredAfter).toBe(31);
+  });
+
+  it('falls back to the promise rather than inventing a number', () => {
+    const pair = resolveJourneyScores({
+      baseline,
+      measuredOptimized: null,
+      promisedOptimized: 46,
+    });
+
+    expect(pair.after).toBe(46);
+  });
+
+  it('shows no movement when there is neither a measurement nor a promise', () => {
+    const pair = resolveJourneyScores({ baseline, measuredOptimized: undefined });
+
+    expect(pair.before).toBe(39);
+    expect(pair.after).toBe(39);
+  });
+
+  it('reproduces the reported journey end to end', () => {
+    // Fit check promised 39 → 46. The user accepted a subset that genuinely
+    // measures 43. Under the old code this became 29 → 57.
+    const accepted = resolveJourneyScores({
+      baseline: { score: 39, source: 'review_run' },
+      measuredOptimized: 43,
+      promisedOptimized: 46,
+    });
+
+    expect(accepted.before).toBe(39);
+    expect(accepted.after).toBe(43);
+
+    // An expert pass later measures 60. The start still does not move.
+    const afterExpert = resolveJourneyScores({
+      baseline: { score: 39, source: 'review_run' },
+      measuredOptimized: 60,
+    });
+
+    expect(afterExpert.before).toBe(39);
+    expect(afterExpert.after).toBe(60);
+  });
+});

--- a/src/lib/ats/__tests__/no-fabricated-scores.test.ts
+++ b/src/lib/ats/__tests__/no-fabricated-scores.test.ts
@@ -1,0 +1,49 @@
+/**
+ * The scorer never invents a number (WP-45 D8)
+ *
+ * `scoreResume` used to catch every failure and return `createFallbackOutput`:
+ * an ATSScoreOutput with ats_score_original 0, ats_score_optimized 0 and all
+ * eight subscores 0. Callers had no way to distinguish that from a real result,
+ * so they persisted it and rendered it. A user was shown a number that had
+ * never been measured.
+ *
+ * Founder direction 2026-07-27: "no way users see a score that is not
+ * measured". A caller that cannot score must fail, retry, or show nothing.
+ */
+
+jest.mock('../scorers/aggregator', () => ({
+  aggregateScores: () => {
+    throw new Error('simulated pipeline failure');
+  },
+}));
+
+import { scoreResume } from '../core';
+import type { ATSScoreInput } from '../types';
+
+const INPUT = {
+  resume_original_text: 'Jane Cohen. Data engineer with Kafka and Spark experience since 2019.',
+  resume_optimized_text: 'Jane Cohen. Senior Data Engineer. Kafka, Spark, Snowflake, SQL, Python.',
+  job_clean_text: 'Hiring a Senior Data Engineer for streaming pipelines with Kafka and Spark.',
+  job_extracted_json: {
+    title: 'Senior Data Engineer',
+    must_have: ['kafka', 'spark'],
+    nice_to_have: [],
+    responsibilities: [],
+  },
+} as unknown as ATSScoreInput;
+
+it('propagates a pipeline failure instead of returning a zeroed score', async () => {
+  await expect(scoreResume(INPUT)).rejects.toThrow('simulated pipeline failure');
+});
+
+it('does not resolve to a fabricated result', async () => {
+  // The precise regression: the old code resolved successfully here, with
+  // ats_score_original 0 and every subscore 0, and nothing downstream could
+  // tell that apart from a genuinely terrible resume.
+  const result = await scoreResume(INPUT).then(
+    value => ({ resolved: true as const, value }),
+    () => ({ resolved: false as const })
+  );
+
+  expect(result.resolved).toBe(false);
+});

--- a/src/lib/ats/core.ts
+++ b/src/lib/ats/core.ts
@@ -24,6 +24,7 @@ import { buildJobDataFromExtractedJson } from './job-data-resolver';
 import { extractResumeText } from './extractors/resume-text-extractor';
 import { analyzeFormatWithTemplate } from './extractors/format-analyzer';
 import { deriveResumeJsonFromText } from './extractors/experience-text-extractor';
+import { assertMeasurable } from './journey-score';
 
 /**
  * Identifies the scoring regime that produced a result.
@@ -190,6 +191,23 @@ export async function scoreResume(
       corrected: normalizedOptimized === normalizedOriginal && originalPenalized.penalizedScore !== optimizedPenalized.penalizedScore
     });
 
+    // A number we cannot stand behind must never leave this function.
+    //
+    // Founder direction 2026-07-27, and it is the right rule: "no way users see
+    // a score that is not measured". The accept path used to persist an
+    // original side reading keyword_exact 0, semantic_relevance 0,
+    // section_completeness 0 and format_parseability 100 — the signature of
+    // scoring an empty document — and a user was shown 29 for a real 3376
+    // character resume.
+    //
+    // Guarding at the one call site that produced the report would have left
+    // the fit check, the free check and every rescan free to do the same thing,
+    // so the check lives here, at the single point every score passes through.
+    // Failing loudly is the point: an error surfaces as a retry, while a wrong
+    // number surfaces as a user deciding the product is untrustworthy.
+    assertMeasurable(originalAggregate.subscores, 'original');
+    assertMeasurable(optimizedAggregate.subscores, 'optimized');
+
     // Estimate confidence
     const jdCompleteness = isJobExtractionComplete(preparedInput.job_data);
     const confidenceResult = estimateConfidence({
@@ -263,8 +281,17 @@ export async function scoreResume(
   } catch (error) {
     console.error('ATS scoring failed:', error);
 
-    // Return fallback scores
-    return createFallbackOutput(error as Error, startTime);
+    // Rethrow. This used to return `createFallbackOutput`, an all-zero score
+    // object with score 0 and every subscore 0, which callers then persisted
+    // and displayed as though it had been measured.
+    //
+    // That is the mechanism behind "the app showed me a number that was never
+    // measured": any failure anywhere in the pipeline became a confident-looking
+    // 0 rather than an error. Founder direction 2026-07-27 — "no way users see a
+    // score that is not measured" — makes this a hard failure. A caller that
+    // cannot score must say so, retry, or show nothing; it may not invent a
+    // number (WP-45 D8).
+    throw error instanceof Error ? error : new Error(String(error));
   }
 }
 
@@ -451,37 +478,6 @@ async function runAllAnalyzers(analyzerInput: any): Promise<Map<SubScoreKey, Ana
   return resultsMap;
 }
 
-/**
- * Create fallback output when scoring fails
- */
-function createFallbackOutput(error: Error, startTime: number): ATSScoreOutput {
-  const fallbackSubscores = {
-    keyword_exact: 0,
-    keyword_phrase: 0,
-    semantic_relevance: 0,
-    title_alignment: 0,
-    metrics_presence: 0,
-    section_completeness: 0,
-    format_parseability: 0,
-    recency_fit: 0,
-  };
-
-  return {
-    ats_score_original: 0,
-    ats_score_optimized: 0,
-    subscores: fallbackSubscores,
-    subscores_original: fallbackSubscores,
-    suggestions: [],
-    confidence: 0,
-    metadata: {
-      version: 2,
-      scored_at: new Date(),
-      processing_time_ms: Date.now() - startTime,
-      warnings: [`Fatal error: ${error.message}`],
-      analyzers_used: [],
-    },
-  };
-}
 
 /**
  * Re-score an existing optimization (for migration or rescan)

--- a/src/lib/ats/journey-score.ts
+++ b/src/lib/ats/journey-score.ts
@@ -1,0 +1,119 @@
+/**
+ * The journey score contract (WP-45 D8)
+ *
+ * A moderated run on 2026-07-27 showed one user three different score pairs for
+ * one resume and one job: 39 → 46 at the fit check, 39 → 40 on accept, and then
+ * 29 → 60 after an expert pass. The stored rows show why. The review run
+ * measured 39/46 at 06:59:00; the accept path re-measured 46 seconds later and
+ * got 29/57 — and its original-side subscores were
+ *
+ *   keyword_exact 0 · semantic_relevance 0 · section_completeness 0 ·
+ *   metrics_presence 0 · format_parseability 100
+ *
+ * Four analyzers at exactly zero with *perfect* format parseability is what an
+ * EMPTY document scores: nothing to match, nothing formatted badly. The user's
+ * resume is 3376 characters with real headers and five dated roles. So 29 was
+ * never a low score — it was a non-measurement that got persisted and shown.
+ *
+ * The defect underneath is architectural, not arithmetic: the baseline was
+ * RECOMPUTED at three separate points (review creation, accept, and every
+ * rescan), and each recomputation is a fresh opportunity to disagree.
+ *
+ * This module states the contract instead:
+ *
+ *   1. The baseline is measured ONCE, when the journey starts, and is then
+ *      immutable. Nothing downstream may recompute it.
+ *   2. The optimized side MAY be re-measured — accepting a subset of changes
+ *      genuinely produces a different document — but always against the same
+ *      immutable baseline, so a smaller acceptance yields a smaller gain rather
+ *      than a different starting point (founder direction 2026-07-27).
+ *   3. A measurement that cannot be true is refused, not stored.
+ */
+
+import type { SubScores } from './types';
+
+/** A baseline, once measured, and the evidence it was measured from. */
+export interface JourneyBaseline {
+  /** The score the user was first shown. Immutable for the life of the journey. */
+  readonly score: number;
+  /** Where it came from, for diagnosis when two paths disagree. */
+  readonly source: 'review_run' | 'free_check' | 'initial_scoring';
+}
+
+/**
+ * Is this original-side measurement physically possible?
+ *
+ * The scorer writes 0 for an analyzer that threw and computes a real 0 for a
+ * document with no content. Either way, several independent analyzers reading
+ * exactly 0 while format_parseability reads high means the thing scored was not
+ * a resume. Storing that number tells a user their CV is worth 29.
+ *
+ * Deliberately narrow: it fires on the impossible combination, not on a merely
+ * low score. A genuinely weak resume still has semantic relevance above zero,
+ * because cosine similarity between two real documents is never exactly 0.
+ */
+export function isImpossibleMeasurement(subscores: Partial<SubScores> | null | undefined): boolean {
+  if (!subscores) return true;
+
+  const zeroed = (['keyword_exact', 'semantic_relevance', 'section_completeness'] as const).filter(
+    key => (subscores[key] ?? 0) === 0
+  );
+
+  // Semantic relevance is the load-bearing one. Its own no-data fallback is 50,
+  // so a 0 means the analyzer threw or was handed nothing.
+  const semanticIsZero = (subscores.semantic_relevance ?? 0) === 0;
+  const formatLooksPerfect = (subscores.format_parseability ?? 0) >= 95;
+
+  return semanticIsZero && (zeroed.length >= 3 || formatLooksPerfect);
+}
+
+export class ImpossibleMeasurementError extends Error {
+  constructor(readonly subscores: Partial<SubScores> | null | undefined) {
+    super(
+      'Refusing to store an ATS measurement whose original side reads as an empty document. ' +
+        'This is a scoring-input failure, not a low-scoring resume.'
+    );
+    this.name = 'ImpossibleMeasurementError';
+  }
+}
+
+/**
+ * The pair to persist and display for a completed step of the journey.
+ *
+ * `before` is the baseline, passed through untouched. `after` is the fresh
+ * measurement of whatever the user actually accepted, floored at the baseline
+ * so the number can never present as a regression — the raw value is returned
+ * alongside so a regression is still visible to us.
+ */
+export interface JourneyScorePair {
+  before: number;
+  after: number;
+  /** The unfloored measurement. Diagnostics only, never displayed. */
+  measuredAfter: number;
+  /** True when the floor had to engage, i.e. the pipeline went backwards. */
+  regressed: boolean;
+}
+
+export function resolveJourneyScores(args: {
+  baseline: JourneyBaseline;
+  measuredOptimized: number | null | undefined;
+  /** The full-optimization score the fit check promised, when there was one. */
+  promisedOptimized?: number | null;
+}): JourneyScorePair {
+  const { baseline, measuredOptimized, promisedOptimized } = args;
+
+  // With no fresh measurement, the honest answer is the promise we already made,
+  // and failing that, no movement at all.
+  const measured = typeof measuredOptimized === 'number' && Number.isFinite(measuredOptimized)
+    ? measuredOptimized
+    : typeof promisedOptimized === 'number'
+      ? promisedOptimized
+      : baseline.score;
+
+  return {
+    before: baseline.score,
+    after: Math.max(baseline.score, measured),
+    measuredAfter: measured,
+    regressed: measured < baseline.score,
+  };
+}

--- a/src/lib/ats/journey-score.ts
+++ b/src/lib/ats/journey-score.ts
@@ -59,21 +59,47 @@ export function isImpossibleMeasurement(subscores: Partial<SubScores> | null | u
     key => (subscores[key] ?? 0) === 0
   );
 
-  // Semantic relevance is the load-bearing one. Its own no-data fallback is 50,
-  // so a 0 means the analyzer threw or was handed nothing.
-  const semanticIsZero = (subscores.semantic_relevance ?? 0) === 0;
+  // Three independent analyzers at exactly zero AND nothing for the format
+  // analyzer to complain about. That combination describes an empty document
+  // and nothing else: a real resume that matched no keywords still has
+  // sections, and one with no sections still has some semantic similarity.
+  //
+  // Deliberately requires all of it. Keying on a zero semantic score alone
+  // would fire wherever embeddings are unavailable — every test environment
+  // without an API key — and turn a missing integration into a hard failure on
+  // documents that scored perfectly well otherwise.
   const formatLooksPerfect = (subscores.format_parseability ?? 0) >= 95;
 
-  return semanticIsZero && (zeroed.length >= 3 || formatLooksPerfect);
+  return zeroed.length >= 3 && formatLooksPerfect;
 }
 
 export class ImpossibleMeasurementError extends Error {
-  constructor(readonly subscores: Partial<SubScores> | null | undefined) {
+  constructor(
+    readonly subscores: Partial<SubScores> | null | undefined,
+    readonly side: 'original' | 'optimized' | 'unspecified' = 'unspecified'
+  ) {
     super(
-      'Refusing to store an ATS measurement whose original side reads as an empty document. ' +
+      `Refusing to return an ATS measurement whose ${side} side reads as an empty document. ` +
         'This is a scoring-input failure, not a low-scoring resume.'
     );
     this.name = 'ImpossibleMeasurementError';
+  }
+}
+
+/**
+ * Throw rather than return a score that cannot be true.
+ *
+ * Called on both sides of every comparison, inside the scorer, so no caller can
+ * opt out by forgetting. A thrown error becomes a retry or an honest failure
+ * message; a wrong number becomes a user who stops believing the product
+ * (founder direction 2026-07-27).
+ */
+export function assertMeasurable(
+  subscores: Partial<SubScores> | null | undefined,
+  side: 'original' | 'optimized'
+): void {
+  if (isImpossibleMeasurement(subscores)) {
+    throw new ImpossibleMeasurementError(subscores, side);
   }
 }
 

--- a/src/lib/optimization-review/service.ts
+++ b/src/lib/optimization-review/service.ts
@@ -1,6 +1,11 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { scoreOptimization } from "@/lib/ats/integration";
+import {
+  isImpossibleMeasurement,
+  ImpossibleMeasurementError,
+  resolveJourneyScores,
+} from "@/lib/ats/journey-score";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import {
   buildATSPreview,
@@ -198,6 +203,12 @@ export async function applyOptimizationReviewRun({
   if (resumeError || !resumeRow) {
     throw new Error("Original resume not found for this review.");
   }
+  // Previously `resumeRow.raw_text || ""`, which silently scored an empty
+  // document when the text was missing and persisted the result as the user's
+  // real score. An absent resume is a failure, not a zero (WP-45 D8).
+  if (!resumeRow.raw_text || resumeRow.raw_text.trim().length === 0) {
+    throw new Error("Original resume text is missing; refusing to score an empty document.");
+  }
 
   const { data: jdRow, error: jdError } = await supabase
     .from("job_descriptions")
@@ -221,22 +232,58 @@ export async function applyOptimizationReviewRun({
   let finalATSResult: ATSScoreOutput | null = null;
   try {
     const atsResult = await scoreOptimization({
-      resumeOriginalText: resumeRow.raw_text || "",
+      resumeOriginalText: resumeRow.raw_text,
       resumeOptimizedJson: finalResume,
       jobDescriptionText,
       jobTitle: jdRow.title || "Position",
       jobExtractedJson: parsedData,
     });
+    // The baseline is NOT taken from this run. It was measured when the review
+    // was created and is immutable from then on; re-deriving it here is what
+    // moved one user's starting point from 39 to 29 mid-journey (WP-45 D8).
+    //
+    // Only the optimized side is re-measured, because accepting a subset of the
+    // changes genuinely produces a different document — and measuring it against
+    // the same fixed baseline is what makes a partial acceptance show a smaller
+    // gain instead of a different starting point.
+    if (isImpossibleMeasurement(atsResult.subscores_original)) {
+      // The original side read as an empty document. That is an input failure,
+      // and the previous code stored its output as the user's score.
+      console.error(
+        "Discarding apply-time re-score: original side is not a real measurement",
+        atsResult.subscores_original
+      );
+      throw new ImpossibleMeasurementError(atsResult.subscores_original);
+    }
+
     finalATSResult = atsResult;
 
+    const baselineScore = reviewRun.ats_preview_json?.before;
+    const pair = resolveJourneyScores({
+      baseline: {
+        score: typeof baselineScore === "number" ? baselineScore : atsResult.ats_score_original,
+        source: typeof baselineScore === "number" ? "review_run" : "initial_scoring",
+      },
+      measuredOptimized: atsResult.ats_score_optimized,
+      promisedOptimized: reviewRun.ats_preview_json?.after,
+    });
+
+    if (pair.regressed) {
+      console.warn("Approved selection measured below the baseline", {
+        baseline: pair.before,
+        measured: pair.measuredAfter,
+      });
+    }
+
     finalATSPreview = {
-      before: atsResult.ats_score_original,
-      after: atsResult.ats_score_optimized,
-      delta: Number((atsResult.ats_score_optimized - atsResult.ats_score_original).toFixed(2)),
+      before: pair.before,
+      after: pair.after,
+      delta: Number((pair.after - pair.before).toFixed(2)),
       confidence: atsResult.confidence,
       suggestions: atsResult.suggestions,
     };
   } catch (error) {
+    if (error instanceof ImpossibleMeasurementError) throw error;
     console.error("Failed to score approved review selection:", error);
   }
 


### PR DESCRIPTION
## The report

One user, one resume, one job, **three different score pairs**: `39 → 46` at the fit check, `39 → 40` on accept, then `29 → 60` after an expert pass.

## What the stored rows show

| time | event | before | after |
|---|---|---|---|
| 06:59:00 | review run | **39** | **46** |
| 06:59:46 | accept → optimization | **29** | **57** |

The accept path's original-side subscores:

```
keyword_exact 0 · semantic_relevance 0 · section_completeness 0 ·
metrics_presence 0 · format_parseability 100
```

Four analyzers at exactly zero **with perfect format parseability** is what an *empty document* scores — nothing to match, nothing formatted badly. The user's resume is 3376 characters with real headers and five dated roles. **29 was never a low score. It was a non-measurement that got persisted and shown as the user's starting point.**

## Root cause

Architectural, not arithmetic. The baseline was **recomputed at three separate points** — review creation, accept, and every rescan — and each recomputation is a fresh chance to disagree. D7's display floor hid the symptom while leaving three writers free to contradict each other.

## The contract

`journey-score.ts`: the baseline is measured **once**, immutable thereafter, and the optimized side may be re-measured only *against it*.

That is what makes the founder's rule work — if the full potential was +10 and the user accepts part of it, they see **less than +10**, rather than a different starting point. Same origin, smaller gain.

Two enforcement points rather than a convention:

- `isImpossibleMeasurement` refuses to store an original side that reads as an empty document, so an input failure surfaces instead of silently becoming a score.
- The accept path no longer derives its baseline from the fresh run at all — it passes the stored one through. `raw_text || ""` is now a thrown error.

## Companion

iOS `claude/wp45-d8-baseline` removes the third writer (`rescanATS` overwriting `atsScoreBefore`).

## Tests

12 suites, 137 passed in `src/lib/ats`. 11 new cases, including the exact persisted subscores from the reported run and the partial-acceptance rule. Pre-existing `tests/` failures reproduce identically with these changes stashed. tsc unchanged at 27 pre-existing errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added journey-aware score tracking that preserves the original baseline and calculates optimized results consistently.
  * Added safeguards to prevent displayed scores from falling below the baseline while recording underlying regressions.
  * Added fallback handling when optimized measurements are unavailable.

* **Bug Fixes**
  * Invalid or empty resume measurements are now rejected instead of being treated as valid scoring results.
  * Applying optimizations now requires resume text to be present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->