### PR TITLE
The baseline had two more writers on the server

### DIFF
--- a/src/app/api/ats/rescan/route.ts
+++ b/src/app/api/ats/rescan/route.ts
@@ -63,18 +63,44 @@ export async function POST(request: NextRequest) {
       job_data: jobData,
     });
 
-    // Update optimization with new scores
+    // The baseline is NOT updated here, and this is the whole point of the
+    // route's behaviour changing.
+    //
+    // This endpoint used to write `ats_score_original` on every rescan, which
+    // made it a fourth writer of the one number that must never move. The
+    // sequence in production on 2026-07-27: accept correctly stored the
+    // baseline the fit check had shown (51), the app rescanned moments later,
+    // and this update overwrote it with a fresh reading of the same untouched
+    // original (43). WP-45 D8 fixed the other three writers and this one kept
+    // moving the number underneath them, which is why the stored baseline still
+    // disagreed with the fit check after that deploy.
+    //
+    // A rescan re-measures what the CURRENT resume is worth. It has no claim on
+    // where the user started: nothing they did changed the original document,
+    // so nothing may change its score. The fresh original reading is returned
+    // for diagnostics but never persisted.
+    const existingBaseline = optimization.ats_score_original;
+    const baselineMoved =
+      typeof existingBaseline === 'number' &&
+      Math.round(existingBaseline) !== Math.round(result.ats_score_original);
+
+    if (baselineMoved) {
+      logger.warn('Rescan disagrees with the stored baseline; keeping the stored one', {
+        optimizationId: optimization_id,
+        stored: existingBaseline,
+        rescanned: result.ats_score_original,
+      });
+    }
+
     const { error: updateError } = await supabase
       .from('optimizations')
       .update({
         ats_version: 2,
-        ats_score_original: result.ats_score_original,
         ats_score_optimized: result.ats_score_optimized,
         ats_subscores: result.subscores,
-        ats_subscores_original: result.subscores_original,
         ats_suggestions: result.suggestions,
         ats_confidence: result.confidence,
-        match_score: result.ats_score_optimized, // Update match_score too
+        match_score: result.ats_score_optimized,
       })
       .eq('id', optimization_id)
       .eq('user_id', user.id);
@@ -83,13 +109,18 @@ export async function POST(request: NextRequest) {
       throw updateError;
     }
 
+    // Report the stored baseline, not the one just measured, so the client and
+    // the database cannot disagree about where the journey began.
+    const baseline =
+      typeof existingBaseline === 'number' ? existingBaseline : result.ats_score_original;
+
     return NextResponse.json({
       success: true,
       optimization_id,
       scores: {
-        original: result.ats_score_original,
+        original: baseline,
         optimized: result.ats_score_optimized,
-        improvement: result.ats_score_optimized - result.ats_score_original,
+        improvement: result.ats_score_optimized - baseline,
       },
       suggestions_count: result.suggestions.length,
       confidence: result.confidence,

--- a/src/lib/ats/__tests__/baseline-single-writer.test.ts
+++ b/src/lib/ats/__tests__/baseline-single-writer.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @jest-environment node
+ *
+ * The baseline has exactly one writer (WP-45 D8)
+ *
+ * `ats_score_original` is the number the user's whole journey is anchored to.
+ * It is measured once, when the review run is created, and must never be
+ * rewritten afterwards.
+ *
+ * WP-45 D8 fixed three writers — review creation, accept, and the iOS rescan
+ * display — and shipped believing the problem was solved. It was not: two more
+ * existed on the server, and production data after that deploy still showed the
+ * stored baseline disagreeing with the fit check on every run.
+ *
+ *   /api/ats/rescan          re-scored and wrote ats_score_original
+ *   expert-workflows/orchestrator  did the same after an expert apply
+ *
+ * Reading the code found the first three. Only the data found the other two.
+ * This test exists so the next one is found by CI instead: it fails the moment
+ * any new code path writes this column in an UPDATE.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SRC = path.join(process.cwd(), 'src');
+
+/** The one place a baseline is legitimately established. */
+const ALLOWED = ['src/lib/optimization-review/service.ts'];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Find Supabase `.update({...})` calls whose payload sets ats_score_original.
+ *
+ * Deliberately crude: it scans the text of each update payload rather than
+ * parsing. A false positive is a developer reading this comment; a false
+ * negative is another month of users watching their score move.
+ */
+function updatesWritingBaseline(source: string): string[] {
+  const hits: string[] = [];
+  const re = /\.update\(\s*\{/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = re.exec(source)) !== null) {
+    let depth = 0;
+    let i = m.index + m[0].length - 1;
+    const start = i;
+    for (; i < source.length; i++) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    const payload = source.slice(start, i + 1);
+    if (/(^|[^_\w])ats_score_original\s*:/.test(payload)) hits.push(payload.slice(0, 120));
+  }
+  return hits;
+}
+
+describe('ats_score_original has a single writer', () => {
+  it('is never written by an UPDATE outside the review service', () => {
+    const offenders: string[] = [];
+
+    for (const file of walk(SRC)) {
+      const rel = path.relative(process.cwd(), file);
+      if (ALLOWED.includes(rel)) continue;
+
+      const hits = updatesWritingBaseline(fs.readFileSync(file, 'utf8'));
+      if (hits.length) offenders.push(`${rel}: ${hits.join(' | ')}`);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('is not restored to the two routes that used to write it', () => {
+    // Named explicitly, because these are the two that survived a fix that was
+    // believed complete and shipped.
+    for (const rel of [
+      'src/app/api/ats/rescan/route.ts',
+      'src/lib/expert-workflows/orchestrator.ts',
+    ]) {
+      const source = fs.readFileSync(path.join(process.cwd(), rel), 'utf8');
+      expect(updatesWritingBaseline(source)).toEqual([]);
+    }
+  });
+});

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -747,13 +747,24 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
 
         newAtsScore = scoreResult.ats_score_optimized;
 
+        // `ats_score_original` is deliberately absent from this update.
+        //
+        // An expert pass rewrites the optimized resume, so re-measuring the
+        // optimized side is correct. It does not touch the ORIGINAL document,
+        // so that side has nothing new to say — and writing it here made this
+        // the sixth place in the codebase that could move the one number the
+        // user's whole journey is anchored to. It is what turned a real run on
+        // 2026-07-27 into "29 to 60" after an expert pass, when the user had
+        // started at 39 (WP-45 D8).
+        //
+        // `ats_subscores_original` goes with it: keeping a fresh original-side
+        // subscore vector against a baseline it did not produce is how the
+        // stored evidence stops matching the stored score.
         await params.supabase
           .from('optimizations')
           .update({
-            ats_score_original: scoreResult.ats_score_original,
             ats_score_optimized: scoreResult.ats_score_optimized,
             ats_subscores: scoreResult.subscores,
-            ats_subscores_original: scoreResult.subscores_original,
             ats_suggestions: scoreResult.suggestions,
             ats_confidence: scoreResult.confidence,
             match_score: scoreResult.ats_score_optimized,


### PR DESCRIPTION
WP-45 D8 fixed three writers of `ats_score_original` and shipped believing the problem was solved. **Production data after that deploy says otherwise.**

| run (UTC) | fit check said | stored as |
|---|---|---|
| 10:11 | 51 → 66 | **43** → 72 |
| 08:49 | 53 → 65 | **51** → 60 |

Both are *after* the D8 production deploy at 08:19 UTC. Two server routes were still rewriting the column after the accept path had correctly stored it.

## The two writers

**`/api/ats/rescan`** re-scored and wrote `ats_score_original` on every call. The app rescans moments after accepting — so the correct baseline was written, then immediately overwritten with a fresh reading of the same untouched original. That is the entire 51 → 43 gap.

**`expert-workflows/orchestrator`** did the same after an expert apply. That is what turned a real run into "29 → 60" when the user had started at 39.

## The change

Both now update only the optimized side. A rescan and an expert pass re-measure what the **current** resume is worth; neither touches the original document, so neither has anything new to say about where the user started.

The rescan route also returns the **stored** baseline rather than the one it just measured, so the client and the database cannot disagree, and logs a warning when they differ instead of silently adopting the new value.

## The guard

A test walks `src/` and fails on any `.update({...})` payload writing `ats_score_original` outside the review service — the one place a baseline is legitimately established.

**Verified to fail on the old code before committing.** That matters here: the three-writer fix looked complete by reading alone, and only the production data caught the rest. This makes the next one a CI failure instead of a month of users watching their score move.

## Tests

14 suites, 141 passed. tsc unchanged at 27 pre-existing errors, none in the changed files.

## After merge

This needs one real optimization run to confirm, then the integrity query should show `baseline_moved = false`. Do not ship the iOS build until that is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original ATS score baseline during rescoring and expert workflow updates.
  * Ensured score improvements and original-score values remain consistent between the database and client responses.
  * Prevented recalculated scores from overwriting previously stored original subscores.

* **Tests**
  * Added coverage to verify that only the approved process can write the original ATS baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->