### PR TITLE
WP-64: the optimizer was deleting every experience bullet — investigation + fix

### DIFF
--- a/src/lib/ai-optimizer/index.ts
+++ b/src/lib/ai-optimizer/index.ts
@@ -5,6 +5,7 @@ import {
   RESUME_OPTIMIZATION_USER_PROMPT,
   OPTIMIZATION_CONFIG,
 } from '../prompts/resume-optimizer';
+import { normalizeExperienceBullets } from './normalize-experience';
 
 /**
  * Optimized resume structure returned by AI
@@ -133,7 +134,13 @@ export async function optimizeResume(
       };
     }
 
-    const optimizedResume = JSON.parse(responseContent) as OptimizedResume;
+    // WP-64: the model sometimes names the per-role bullet array
+    // `responsibilities` rather than `achievements`, and every consumer reads
+    // `achievements` only — so the bullets were silently discarded. Normalize
+    // at the parse boundary, before anything downstream sees the object.
+    const optimizedResume = normalizeExperienceBullets(
+      JSON.parse(responseContent) as OptimizedResume
+    );
 
     return {
       success: true,

--- a/src/lib/ai-optimizer/normalize-experience.ts
+++ b/src/lib/ai-optimizer/normalize-experience.ts
@@ -1,0 +1,96 @@
+/**
+ * WP-64 — deterministic repair for the model naming the per-role bullet array
+ * something other than `achievements`.
+ *
+ * The optimizer prompt specifies `achievements`. gpt-4o sometimes returns
+ * `responsibilities` instead, with `achievements` present but empty. Every
+ * consumer in the codebase reads `achievements` and skips on empty
+ * (`DesignRenderer.tsx:525`, `ats-resume-template.tsx:118`,
+ * `api/v1/optimizations/[id]/route.ts:60`, `lib/ats/integration.ts:102`), and
+ * nothing anywhere reads a resume role's `responsibilities`. The role therefore
+ * rendered with its title, company and dates and none of its content, and the
+ * scorer graded the same empty key — on the 2026-07-29 live run that was 18
+ * bullets discarded across 5 roles while the ATS score rose 38 -> 61.
+ *
+ * Measured at the time of the fix: 12 of 384 stored optimizations (3.1%),
+ * earliest 2026-05-28.
+ *
+ * Same posture as `stripFabricatedMetrics`: the prompt is instructed correctly,
+ * and the output is repaired deterministically anyway, because a prompt is not
+ * an enforcement mechanism.
+ *
+ * The only import is type-only, so this module adds nothing at runtime and
+ * cannot create a cycle with `./index` or drag anything across the
+ * client/server bundle boundary — see the WP-58 lesson in tasks/progress.md.
+ */
+
+import type { OptimizedResume } from './index';
+
+/**
+ * Accepted names for the per-role bullet array, in priority order. The first
+ * key present with at least one usable string wins.
+ */
+export const BULLET_KEY_ALIASES = [
+  'achievements',
+  'responsibilities',
+  'bullets',
+  'highlights',
+  'accomplishments',
+] as const;
+
+type ExperienceRole = OptimizedResume['experience'][number];
+
+/** Keeps non-blank strings only; trims. Anything else is dropped. */
+function usableStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const trimmed = item.trim();
+    if (trimmed) out.push(trimmed);
+  }
+  return out;
+}
+
+/** Reads a possibly-absent key off a role without widening the public type. */
+function readKey(role: ExperienceRole, key: string): unknown {
+  return (role as unknown as Record<string, unknown>)[key];
+}
+
+/**
+ * Returns a copy of `resume` in which every role's bullets live under
+ * `achievements`, whichever key the model actually used.
+ *
+ * Non-destructive in both directions: a role that already has usable
+ * `achievements` is never overwritten by an alias, and the original alias key
+ * is left on the object so nothing downstream that happens to read it breaks.
+ * Roles always come back with `achievements` as an array, never undefined.
+ */
+export function normalizeExperienceBullets(resume: OptimizedResume): OptimizedResume {
+  const roles: ExperienceRole[] = Array.isArray(resume?.experience) ? resume.experience : [];
+
+  const experience = roles.map((role) => {
+    if (!role || typeof role !== 'object') {
+      return { achievements: [] } as unknown as ExperienceRole;
+    }
+
+    let bullets: string[] = [];
+    for (const key of BULLET_KEY_ALIASES) {
+      const candidate = usableStrings(readKey(role, key));
+      if (candidate.length > 0) {
+        bullets = candidate;
+        break;
+      }
+    }
+
+    return { ...role, achievements: bullets };
+  });
+
+  return { ...resume, experience };
+}
+
+/** Total bullets across every role. Used by the preservation invariant. */
+export function countBullets(resume: OptimizedResume | null | undefined): number {
+  const roles: ExperienceRole[] = Array.isArray(resume?.experience) ? resume.experience : [];
+  return roles.reduce((sum, role) => sum + usableStrings(role?.achievements).length, 0);
+}

--- a/src/lib/ai-optimizer/optimize-pipeline.ts
+++ b/src/lib/ai-optimizer/optimize-pipeline.ts
@@ -7,6 +7,7 @@ import {
   type ResumeOptimizationGaps,
 } from '../prompts/resume-optimizer';
 import { optimizeResume, type OptimizedResume } from './index';
+import { normalizeExperienceBullets, countBullets } from './normalize-experience';
 import { scoreOptimization, resumeJsonToText } from '@/lib/ats/integration';
 import { assessLift, MIN_MEANINGFUL_LIFT, type LiftAssessment } from '@/lib/ats/lift';
 import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
@@ -86,7 +87,11 @@ async function callOpenAIWithGapPrompt(
       return null;
     }
 
-    return JSON.parse(responseContent) as OptimizedResume;
+    // WP-64: normalize the bullet key here too — the gap pass is a second,
+    // independent model call and drifts the same way.
+    return normalizeExperienceBullets(
+      JSON.parse(responseContent) as OptimizedResume
+    );
   } catch (error) {
     console.error('Gap-prompt OpenAI call failed:', error);
     return null;
@@ -148,6 +153,40 @@ export function stripFabricatedMetrics(resume: OptimizedResume, originalResumeTe
   });
 
   return { ...resume, experience };
+}
+
+/**
+ * WP-64 — a candidate that returns roles with no bullets under any of them has
+ * deleted the candidate's evidence, whatever the score says. On the 2026-07-29
+ * live run that shape scored 61 against an original of 38, because the scorer
+ * reads the same empty `achievements` key the renderer does, so nothing in the
+ * scoring path can be relied on to catch it.
+ *
+ * Deliberately narrow: only the total-loss case. Legitimate optimizations do
+ * merge and drop individual bullets, and this must not fight them.
+ */
+export function hasTotalBulletLoss(candidate: OptimizedResume | null | undefined): boolean {
+  const roles = Array.isArray(candidate?.experience) ? candidate.experience : [];
+  return roles.length > 0 && countBullets(candidate) === 0;
+}
+
+/**
+ * WP-64 — pass 2 starts from pass 1's output and never sees the original
+ * resume, so any content it drops is unrecoverable. Comparing the two candidate
+ * bullet counts is therefore the only place content loss across passes can be
+ * detected at all. Mirrors the WP-45 S2 posture for scores: a pass must be
+ * compared against what it started from, not only against the other pass.
+ */
+export function losesContentAgainst(
+  candidate: OptimizedResume | null | undefined,
+  previous: OptimizedResume
+): boolean {
+  const after = countBullets(candidate);
+  const before = countBullets(previous);
+  if (before === 0) return false;
+  // A pass may consolidate; losing more than a third of the evidence is not
+  // consolidation.
+  return after < Math.ceil(before * (2 / 3));
 }
 
 function buildInitialGaps(resumeText: string, mustHave: string[]): ResumeOptimizationGaps {
@@ -240,6 +279,23 @@ export async function runOptimizePipeline(
 
   candidate1 = stripFabricatedMetrics(candidate1, resumeText);
 
+  // WP-64: if pass 1 came back with roles and no bullets under any of them, the
+  // candidate's evidence is gone. Normalization has already recovered the known
+  // key-drift cause, so reaching here means a genuinely empty generation —
+  // retry once through the plain optimizer rather than returning a skeleton.
+  if (hasTotalBulletLoss(candidate1)) {
+    console.warn('Pipeline pass 1 returned roles with zero bullets (WP-64), retrying once');
+    const retry = await optimizeResume(resumeText, jobDescription, options?.aiTrace);
+    const retryCandidate = retry.success && retry.optimizedResume
+      ? stripFabricatedMetrics(retry.optimizedResume, resumeText)
+      : null;
+    if (retryCandidate && !hasTotalBulletLoss(retryCandidate)) {
+      candidate1 = retryCandidate;
+    } else {
+      console.error('Pipeline: retry also produced zero bullets (WP-64), returning it unrepaired');
+    }
+  }
+
   // Step 3: Score pass 1 candidate
   const score1 = await scoreOptimization({
     resumeOriginalText: resumeText,
@@ -291,6 +347,17 @@ export async function runOptimizePipeline(
   }
 
   const candidate2 = stripFabricatedMetrics(candidate2Raw, resumeText);
+
+  // WP-64: pass 2 never sees the original resume, so anything it drops is gone
+  // for good. Keep pass 1 rather than shipping a thinner document, regardless of
+  // how pass 2 scores — the score cannot see this loss.
+  if (hasTotalBulletLoss(candidate2) || losesContentAgainst(candidate2, candidate1)) {
+    console.warn('Pipeline pass 2 lost experience content (WP-64), keeping pass 1 candidate', {
+      pass1Bullets: countBullets(candidate1),
+      pass2Bullets: countBullets(candidate2),
+    });
+    return { optimizedResume: candidate1, atsResult: score1, passesUsed: 1, lift: lift1 };
+  }
 
   // Score pass 2 candidate
   const score2 = await scoreOptimization({

--- a/src/lib/prompts/resume-optimizer.ts
+++ b/src/lib/prompts/resume-optimizer.ts
@@ -38,6 +38,12 @@ What to optimize:
 - Keep sections complete and easy to parse.
 - Experience bullets should be concise, action-first, and result-oriented.
 
+5. Completeness (non-negotiable)
+- Every role present in the original resume must appear in the output, with its bullets.
+- Never return a role with an empty bullet list. If a role's source material is thin, keep the bullets short rather than dropping them.
+- You may merge or reword bullets. You may not silently delete a role's evidence.
+- The bullet array is named "achievements". Do not rename it to "responsibilities", "bullets", "highlights", or anything else. This is the single most common failure mode for this task, and it causes the user's entire work history to disappear from the rendered document.
+
 Output requirements:
 - Return valid JSON only.
 - Do not wrap output in markdown.
@@ -68,6 +74,8 @@ Output requirements:
         "Another optimized bullet"
       ]
     }
+    // ... repeat this object for EVERY role in the original resume.
+    // One object shown here is the shape, not the expected count.
   ],
   "education": [
     {
@@ -96,6 +104,8 @@ Output requirements:
 
 Validation checklist before finalizing:
 - JSON is valid and complete.
+- Every role from the original resume is present, and each one has a non-empty "achievements" array.
+- The bullet arrays are named "achievements" and nothing else.
 - matchScore is a number from 0 to 100 with no percent sign.
 - Output reflects only supported, truthful content.
 - Writing is concise, professional, and ATS-friendly.`;

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,31 @@
 # Project Progress
 
+## 2026-07-29 — WP-64: the optimizer was deleting every experience bullet
+
+**Found from a live user report, not a test.** The founder ran an optimization on iOS 1.4.7 (17) at 05:16 UTC and got back a resume with all five roles present and not one bullet under any of them: "it cut all my experience."
+
+**Root cause.** `RESUME_OPTIMIZATION_SYSTEM_PROMPT` specifies the per-role bullet array as `achievements`. gpt-4o sometimes returns **`responsibilities`** instead, with `achievements` present but empty. Every consumer reads `achievements` and skips on empty — `DesignRenderer.tsx:525`, `ats-resume-template.tsx:118`, `api/v1/optimizations/[id]/route.ts:60`, `lib/ats/integration.ts:102` — and **nothing in the codebase reads a resume role's `responsibilities`**. The role survived with title, company and dates; every bullet was discarded. Structurally intact, substantively empty, which is exactly why it read as "lean" rather than "broken".
+
+**The scorer could not catch it, because it reads the same empty key.** The founder's run scored `ats_score_original` 38 → `ats_score_optimized` **61**. The product deleted the user's evidence, graded the remains on summary and skills alone, and reported a 23-point improvement. Any guard built on the score would have passed this.
+
+**Scope, measured in production:** 12 of 384 stored optimizations carrying an `experience` array lost every bullet this way (3.1%), earliest 2026-05-28, most recent the founder's run. All 12 belong to one account — **but that account holds 357 of 384 runs (93%)**, so at the observed 3.4% rate the other 27 runs would be expected to produce roughly one event and produced zero. **The data cannot distinguish a resume-specific trigger from a background rate affecting every user**, and it is not reported as founder-only.
+
+**Fix is three layers, because a prompt is not an enforcement mechanism** (same posture as `stripFabricatedMetrics` and RunSmart's `enforcePlanSafety`):
+
+1. **`src/lib/ai-optimizer/normalize-experience.ts`** coalesces the bullet key at **both** parse sites — `index.ts` pass 1 and `optimize-pipeline.ts` gap pass, which is a second independent model call that drifts the same way. Accepts `achievements`, `responsibilities`, `bullets`, `highlights`, `accomplishments`; first non-empty wins; never overwrites real achievements; always returns an array. Its only import is type-only, so it adds nothing at runtime and cannot cycle with `./index` or cross the client/server bundle boundary (WP-58).
+2. **Two preservation guards in the pipeline.** `hasTotalBulletLoss` rejects a candidate whose roles carry no bullets at all and retries pass 1 once. `losesContentAgainst` keeps pass 1 when pass 2 drops more than a third of the evidence — **pass 2 starts from pass 1's output and never sees the original resume, so its losses are permanent by construction**. Both are deliberately narrow so genuine consolidation still passes.
+3. **The prompt** now states that every role must appear with its bullets, that an empty bullet list is not allowed, and that the array is named `achievements` and must not be renamed. The schema example is annotated so a single role reads as the shape rather than the expected count.
+
+**Validation.** 25 new tests, all passing. Two of them (`4a`, `4b`) drive the real `runOptimizePipeline` rather than the pure helpers, and **both were confirmed failing on the parent commit** — `Array []` where the bullets belong, and `passesUsed 2` where the emptied pass 2 wins on score. That second one is the point: the guard has to beat the score, because the score prefers the broken document.
+
+Full suite **17 failed suites / 80 failed tests, identical to baseline**, passing **311 → 336** (exactly the 25 added). `tsc` **27 errors, exactly baseline**, none in touched files — an intermediate version added 19 and was rewritten. `eslint` 0 errors, its single warning pre-existing and unchanged. **`next build` verified on a clean detached worktree of the fix commit**, not the working tree: the working tree fails on `src/app/[locale]/auth/callback/route 2.ts`, an untracked iCloud duplicate that does not exist in CI, and building in place would have reported a red build for a green change.
+
+**Not done:** (1) **The 12 affected historical rows are not backfilled.** Their bullets are intact in `rewrite_data` under `responsibilities` and simply are not read; moving them into `achievements` is a production write and needs explicit approval. (2) **No `response_format: json_schema`** — instruction-level enforcement only; a strict schema would make the key name impossible to get wrong and is the real fix for layer 3. (3) The founder's 38 → 61 is not a valid measurement of anything and must not enter any activation or quality series. (4) Not verified against a live model call; the eval harness at `evals/resume-optimizer/` would be the place to prove the prompt change actually lowers the drift rate.
+
+**Related:** the iOS repo's 2026-07-27 entry recorded "the optimizer still degrades resumes" (`keyword_exact` 60 → 40) and asked for its own packet. **That is a different, less severe defect** — a scoring regression, not content deletion — and remains open. Both come from the same gap: until now nothing compared the optimizer's output against its input.
+
+**Last Updated:** 2026-07-29
+
 ## 2026-07-26 — WP-58: landed the WP-45 scorer stack on main
 
 Nine commits of scorer-integrity work were stacked three PRs deep with none of it on `main`. All of it is now merged: S1 via PR #119, S2 through S9 plus the WP-58 build fixes via PR #121.

--- a/tasks/work-pack-optimizer-drops-all-bullets.md
+++ b/tasks/work-pack-optimizer-drops-all-bullets.md
@@ -1,0 +1,81 @@
+# WP-64 — The optimizer silently deletes every experience bullet when the model names the key `responsibilities`
+
+**Filed:** 2026-07-29
+**Severity:** P0 on output correctness. The user receives a resume with their entire work history reduced to job titles and dates, and the product tells them it improved.
+**Reported by:** founder, from a live run on iOS 1.4.7 (17), 2026-07-29 05:16 UTC. Wording: "the optimized resume looks very lean, it cut all my experience."
+**Status:** Root cause confirmed against production data. No fix applied.
+
+## What happens
+
+`RESUME_OPTIMIZATION_SYSTEM_PROMPT` (`src/lib/prompts/resume-optimizer.ts`) specifies the per-role bullet array as `achievements`. The model **sometimes returns `responsibilities` instead**, with `achievements` present but empty.
+
+Every consumer in the codebase reads `achievements` and nothing reads `responsibilities` for resume experience:
+
+| Consumer | Line | Behaviour when `achievements: []` |
+|---|---|---|
+| `src/components/design/DesignRenderer.tsx` | 525 | `Array.isArray(exp.achievements) && exp.achievements.length > 0` guard fails, bullet list not rendered |
+| `src/components/templates/ats-resume-template.tsx` | 118 | same guard, renders nothing |
+| `src/app/api/v1/optimizations/[id]/route.ts` | 60 | `bullets` resolves to empty |
+| `src/lib/ats/integration.ts` | 102 | scorer never sees the bullet text |
+
+The `responsibilities` matches elsewhere in the codebase are all **job-description** parsing (`job-data-resolver.ts`, `ats-check/route.ts`), a different object. Nothing anywhere reads a resume role's `responsibilities`.
+
+Net effect: the role survives (title, company, location, dates) and every bullet under it is discarded. The document is structurally intact and substantively empty, which is exactly why it reads as "lean" rather than "broken".
+
+## The founder's run, measured
+
+Optimization `0f3f0f89-374e-434f-9cbc-ac771623786f`, 2026-07-29 05:16:01 UTC.
+
+- 5 roles returned, all 5 with `achievements: []` (type `array`, length 0)
+- `responsibilities` populated on all 5: 3, 4, 4, 4, 3 = **18 bullets discarded**
+- `ats_score_original` **38** → `ats_score_optimized` **61**
+
+**The score rose 23 points on a resume that lost its entire achievement history.** `integration.ts:102` builds the scored text from `achievements`, so the scorer also saw zero bullets and still scored the result higher, on summary and skills alone. This is the sharpest available statement of the problem: the product deleted the user's evidence and rewarded itself for it.
+
+## Scope, stated honestly
+
+Across all 384 stored optimizations carrying an `experience` array:
+
+- **12 rows lost every bullet this way** (3.1% overall), earliest 2026-05-28, most recent 2026-07-29
+- 372 rows returned `achievements` normally
+- 0 rows had no bullets in either key
+
+All 12 belong to one `user_id` (`9fa6c1f5…`, the founder). **This is not evidence the defect is specific to one resume.** That account holds 357 of the 384 optimizations (93%); the other 20 users have 27 runs between them. At the observed 3.4% per-run rate, 27 runs would be expected to produce roughly one event, so observing zero is entirely consistent with the same background rate applying to everyone. **The data cannot distinguish "triggered by this particular resume" from "3.4% of all runs, for everyone."** Do not report it as founder-only.
+
+A plausible but unverified trigger: the source resume uses "Responsibilities" as a section heading under each role, and the model mirrors the source's vocabulary over the schema's. Testable by running a resume with and without that heading.
+
+## Why nothing caught it
+
+1. **No output-shape validation.** `optimize-pipeline.ts` maps over `resume.experience` (lines 113, 150) and never asserts that bullets exist, that the count is plausible, or that the input's bullet count survived.
+2. **No preservation rule in the prompt.** The system prompt says "Keep sections complete" but never states that every role in the original must appear in the output with its bullets. The JSON schema example shows a single experience entry with two bullets, which is a shape hint the model can follow literally.
+3. **The second pass cannot repair it.** `RESUME_OPTIMIZATION_GAP_PROMPT` takes pass 1's output as "starting point" and never receives the original resume. Anything dropped in pass 1 is unrecoverable by design, so loss is monotonic across passes.
+4. **The score moved the wrong way**, so no automated signal fired. `assessLift` and the never-decrease floor are both satisfied by a resume that improved on paper while losing its content.
+
+## Recommended fix, smallest first
+
+1. **Normalize at the parse boundary** (highest value, lowest risk). Where the model's JSON is parsed in `optimize-pipeline.ts`, coalesce bullet keys: accept `achievements`, `responsibilities`, `bullets`, `highlights`, whichever is non-empty, and write the result to `achievements`. This alone recovers all 12 historical cases and any future key drift.
+2. **Add a preservation invariant.** After parsing, compare the output's total bullet count against the input's. If the output has zero bullets while the input had any, or the count collapses beyond a threshold, fail the pass and retry rather than returning it. WP-45 S2 already established the precedent that a pass must be compared against the original, not only against the other pass.
+3. **Tighten the prompt.** State explicitly that every role present in the original must appear in the output with its bullets, and that `achievements` is the only accepted key name. Consider `response_format: json_schema` with a strict schema so the key name is enforced by the API rather than by instruction.
+4. **Backfill the 12 affected rows** by moving `responsibilities` into `achievements`, so those users' stored optimizations stop rendering empty.
+5. **Re-score after the fix.** The 38 → 61 on the founder's run is not a valid measurement of anything and should not enter any activation or quality series.
+
+## Reproduction
+
+```sql
+-- rows where every bullet was discarded
+select o.id, o.created_at,
+  (select coalesce(sum(jsonb_array_length(coalesce(e->'responsibilities','[]'::jsonb))),0)
+     from jsonb_array_elements(o.rewrite_data->'experience') e) as lost_bullets
+from optimizations o
+where o.rewrite_data ? 'experience'
+  and (select coalesce(sum(jsonb_array_length(coalesce(e->'achievements','[]'::jsonb))),0)
+         from jsonb_array_elements(o.rewrite_data->'experience') e) = 0
+order by o.created_at desc;
+```
+
+Supabase project `brtdyamysfmctrhuankn` (ResumeBuilder AI). Read-only; nothing was modified during this investigation.
+
+## Related
+
+- The 2026-07-27 entry in the iOS repo's `tasks/progress.md` already recorded "the optimizer still degrades resumes" (`keyword_exact` 60 → 40) and asked for its own packet. **This is a different and more severe defect than that one** — that is a scoring regression, this is content deletion — but both point at the same gap: nothing validates the optimizer's output against its input.
+- WP-45 S2 introduced `src/lib/ats/lift.ts` and the no-regression invariant for *scores*. The same discipline does not exist for *content*.

--- a/tests/unit/bullet-preservation.test.ts
+++ b/tests/unit/bullet-preservation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * WP-64 — the preservation invariant.
+ *
+ * Content loss is invisible to the ATS score: the scorer reads the same
+ * `achievements` key the renderer does, so an emptied resume scores on its
+ * summary and skills alone and can come back *higher*. On the 2026-07-29 live
+ * run it scored 61 against an original of 38 with every bullet gone. These
+ * guards are the only thing in the pipeline that can see that.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  hasTotalBulletLoss,
+  losesContentAgainst,
+} from '@/lib/ai-optimizer/optimize-pipeline';
+
+const role = (bullets: string[]) => ({
+  title: 'Head of Product',
+  company: 'Acme',
+  location: 'Tel Aviv',
+  startDate: 'Jan 2020',
+  endDate: 'Present',
+  achievements: bullets,
+});
+
+const resume = (roles: ReturnType<typeof role>[]) => ({ experience: roles }) as never;
+
+describe('hasTotalBulletLoss', () => {
+  it('flags the live WP-64 shape: roles present, every bullet gone', () => {
+    expect(hasTotalBulletLoss(resume([role([]), role([]), role([]), role([]), role([])]))).toBe(true);
+  });
+
+  it('does not flag a healthy candidate', () => {
+    expect(hasTotalBulletLoss(resume([role(['Led discovery']), role(['Shipped v2'])]))).toBe(false);
+  });
+
+  it('does not flag a resume with no roles at all — that is a different problem', () => {
+    // A genuinely experience-free resume (new graduate) must not be rejected.
+    expect(hasTotalBulletLoss(resume([]))).toBe(false);
+  });
+
+  it('flags a partially-empty resume only when nothing survives anywhere', () => {
+    expect(hasTotalBulletLoss(resume([role([]), role(['One bullet left'])]))).toBe(false);
+  });
+
+  it('tolerates null and malformed input', () => {
+    expect(hasTotalBulletLoss(null)).toBe(false);
+    expect(hasTotalBulletLoss(undefined)).toBe(false);
+    expect(hasTotalBulletLoss({} as never)).toBe(false);
+  });
+});
+
+describe('losesContentAgainst', () => {
+  it('rejects a pass 2 that dropped everything', () => {
+    const before = resume([role(['a', 'b', 'c']), role(['d', 'e', 'f'])]);
+    const after = resume([role([]), role([])]);
+    expect(losesContentAgainst(after, before)).toBe(true);
+  });
+
+  it('rejects a pass 2 that lost more than a third of the evidence', () => {
+    const before = resume([role(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])]); // 9
+    const after = resume([role(['a', 'b', 'c', 'd', 'e'])]);                       // 5 < ceil(6)
+    expect(losesContentAgainst(after, before)).toBe(true);
+  });
+
+  it('allows genuine consolidation', () => {
+    const before = resume([role(['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'])]); // 9
+    const after = resume([role(['a', 'b', 'c', 'd', 'e', 'f'])]);                 // 6 == ceil(6)
+    expect(losesContentAgainst(after, before)).toBe(false);
+  });
+
+  it('allows a pass 2 that added content', () => {
+    const before = resume([role(['a', 'b'])]);
+    const after = resume([role(['a', 'b', 'c'])]);
+    expect(losesContentAgainst(after, before)).toBe(false);
+  });
+
+  it('does not fire when pass 1 had nothing to lose', () => {
+    // Avoids double-punishing a candidate already handled by hasTotalBulletLoss.
+    expect(losesContentAgainst(resume([role([])]), resume([role([])]))).toBe(false);
+  });
+
+  it('treats a null pass 2 as a loss', () => {
+    expect(losesContentAgainst(null, resume([role(['a', 'b', 'c'])]))).toBe(true);
+  });
+});

--- a/tests/unit/normalize-experience.test.ts
+++ b/tests/unit/normalize-experience.test.ts
@@ -1,0 +1,186 @@
+/**
+ * WP-64 — the optimizer silently deleted every experience bullet whenever the
+ * model named the per-role array `responsibilities` instead of `achievements`.
+ *
+ * Every consumer (DesignRenderer, the ATS template, the optimizations API and
+ * the scorer) reads `achievements` and skips on empty, so 18 real bullets were
+ * discarded on a live 2026-07-29 run while the ATS score rose 38 -> 61.
+ *
+ * These tests pin the deterministic normalizer that fixes it. No OpenAI, no
+ * network — the function is pure.
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  normalizeExperienceBullets,
+  countBullets,
+  BULLET_KEY_ALIASES,
+} from '@/lib/ai-optimizer/normalize-experience';
+
+describe('normalizeExperienceBullets', () => {
+  it('promotes `responsibilities` into `achievements` when achievements is empty — the live WP-64 failure', () => {
+    const raw = {
+      experience: [
+        {
+          title: 'Head of Product',
+          company: 'Acme',
+          achievements: [],
+          responsibilities: ['Led discovery', 'Shipped v2', 'Grew the team'],
+        },
+      ],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.experience[0].achievements).toEqual([
+      'Led discovery',
+      'Shipped v2',
+      'Grew the team',
+    ]);
+    expect(countBullets(out)).toBe(3);
+  });
+
+  it('reproduces the founder run: 5 roles, 18 bullets, all recovered', () => {
+    const raw = {
+      experience: [3, 4, 4, 4, 3].map((n, r) => ({
+        title: `Role ${r}`,
+        company: `Company ${r}`,
+        achievements: [],
+        responsibilities: Array.from({ length: n }, (_, i) => `bullet ${r}.${i}`),
+      })),
+    };
+
+    expect(countBullets(raw as never)).toBe(0);
+    const out = normalizeExperienceBullets(raw as never);
+    expect(countBullets(out)).toBe(18);
+    expect(out.experience).toHaveLength(5);
+  });
+
+  it('leaves a correct response untouched — the 372 of 384 rows that were fine', () => {
+    const raw = {
+      experience: [
+        { title: 'Engineer', company: 'Acme', achievements: ['Built the thing'] },
+      ],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.experience[0].achievements).toEqual(['Built the thing']);
+  });
+
+  it('never lets an alias overwrite non-empty achievements', () => {
+    const raw = {
+      experience: [
+        {
+          title: 'Engineer',
+          company: 'Acme',
+          achievements: ['The real bullet'],
+          responsibilities: ['A duplicate the model also emitted'],
+        },
+      ],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.experience[0].achievements).toEqual(['The real bullet']);
+  });
+
+  it('accepts every documented alias', () => {
+    for (const alias of BULLET_KEY_ALIASES) {
+      const raw = {
+        experience: [{ title: 'T', company: 'C', [alias]: [`from ${alias}`] }],
+      };
+      const out = normalizeExperienceBullets(raw as never);
+      expect(out.experience[0].achievements).toEqual([`from ${alias}`]);
+    }
+  });
+
+  it('prefers the earlier alias when the model emits two of them', () => {
+    // BULLET_KEY_ALIASES is ordered; `achievements` wins, then the rest in order.
+    const raw = {
+      experience: [{ title: 'T', company: 'C', responsibilities: ['resp'], bullets: ['bul'] }],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.experience[0].achievements).toEqual(['resp']);
+  });
+
+  it('drops blank and non-string entries rather than rendering empty bullets', () => {
+    const raw = {
+      experience: [
+        {
+          title: 'Engineer',
+          company: 'Acme',
+          responsibilities: ['  real  ', '', '   ', null, 42, 'also real'] as never,
+        },
+      ],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.experience[0].achievements).toEqual(['real', 'also real']);
+  });
+
+  it('always leaves achievements as an array, even when the model sends nothing', () => {
+    const raw = { experience: [{ title: 'T', company: 'C' }] };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(Array.isArray(out.experience[0].achievements)).toBe(true);
+    expect(out.experience[0].achievements).toEqual([]);
+  });
+
+  it('tolerates a missing or non-array experience section without throwing', () => {
+    expect(() => normalizeExperienceBullets({} as never)).not.toThrow();
+    expect(normalizeExperienceBullets({} as never).experience).toEqual([]);
+    expect(normalizeExperienceBullets({ experience: null } as never).experience).toEqual([]);
+  });
+
+  it('does not mutate its input', () => {
+    const raw = {
+      experience: [{ title: 'T', company: 'C', achievements: [], responsibilities: ['a'] }],
+    };
+
+    normalizeExperienceBullets(raw as never);
+
+    expect(raw.experience[0].achievements).toEqual([]);
+  });
+
+  it('preserves every other field on the role and on the resume', () => {
+    const raw = {
+      summary: 'A summary',
+      matchScore: 61,
+      experience: [
+        {
+          title: 'Head of Product',
+          company: 'Acme',
+          location: 'Tel Aviv',
+          startDate: 'Jan 2020',
+          endDate: 'Present',
+          responsibilities: ['Led discovery'],
+        },
+      ],
+    };
+
+    const out = normalizeExperienceBullets(raw as never);
+
+    expect(out.summary).toBe('A summary');
+    expect(out.matchScore).toBe(61);
+    expect(out.experience[0]).toMatchObject({
+      title: 'Head of Product',
+      company: 'Acme',
+      location: 'Tel Aviv',
+      startDate: 'Jan 2020',
+      endDate: 'Present',
+    });
+  });
+});
+
+describe('countBullets', () => {
+  it('counts across roles and tolerates missing sections', () => {
+    expect(countBullets({ experience: [{ achievements: ['a', 'b'] }, { achievements: ['c'] }] } as never)).toBe(3);
+    expect(countBullets({} as never)).toBe(0);
+    expect(countBullets({ experience: [] } as never)).toBe(0);
+  });
+});

--- a/tests/unit/optimize-pipeline.test.ts
+++ b/tests/unit/optimize-pipeline.test.ts
@@ -436,3 +436,91 @@ describe('stripFabricatedMetrics', () => {
     expect(cleaned.experience[0].achievements[0]).not.toMatch(/40%/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Suite 4: WP-64 — bullet-key drift and content preservation, end to end
+//
+// These exercise runOptimizePipeline itself rather than the pure helpers, so
+// they prove the normalizer and the guards are actually wired into the path a
+// user's request takes. Without the fix, 4a returns a resume whose only role
+// has zero achievements — the exact document the founder received on
+// 2026-07-29, which scored 61 against an original of 38.
+// ---------------------------------------------------------------------------
+describe('runOptimizePipeline — WP-64 bullet preservation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockExtractJobData.mockReturnValue(DEFAULT_JD_EXTRACTION);
+    process.env.OPENAI_API_KEY = 'test-key';
+  });
+
+  /** The live failure shape: bullets under `responsibilities`, achievements empty. */
+  const RESUME_JSON_KEY_DRIFT = {
+    ...makeResumeJson(),
+    experience: [
+      {
+        title: 'Head of Product',
+        company: 'Acme',
+        location: 'Tel Aviv',
+        startDate: 'Jan 2020',
+        endDate: 'Present',
+        achievements: [],
+        responsibilities: ['Led discovery', 'Shipped v2', 'Grew the team'],
+      },
+    ],
+  };
+
+  it('4a: recovers bullets when the model names the array `responsibilities`', async () => {
+    buildOpenAIMock(RESUME_JSON_KEY_DRIFT);
+    mockScoreOptimization.mockResolvedValue(makeAtsScore(60, 80));
+
+    const result = await runOptimizePipeline('resume text', 'job description');
+
+    expect(result.optimizedResume.experience[0].achievements).toEqual([
+      'Led discovery',
+      'Shipped v2',
+      'Grew the team',
+    ]);
+  });
+
+  it('4b: keeps pass 1 when pass 2 empties the experience, even though pass 2 scores higher', async () => {
+    const pass1 = {
+      ...makeResumeJson(),
+      experience: [
+        {
+          title: 'Head of Product',
+          company: 'Acme',
+          location: 'Tel Aviv',
+          startDate: 'Jan 2020',
+          endDate: 'Present',
+          achievements: ['Led discovery', 'Shipped v2', 'Grew the team'],
+        },
+      ],
+    };
+    const pass2Empty = {
+      ...pass1,
+      experience: [{ ...pass1.experience[0], achievements: [] }],
+    };
+
+    const createMock = jest.fn()
+      .mockResolvedValueOnce({ choices: [{ message: { content: JSON.stringify(pass1) } }] } as any)
+      .mockResolvedValueOnce({ choices: [{ message: { content: JSON.stringify(pass2Empty) } }] } as any);
+    const mockInstance = { chat: { completions: { create: createMock } } };
+    (OpenAI as jest.MockedClass<typeof OpenAI>).mockImplementation(() => mockInstance as any);
+
+    // Pass 1 scores 40->60 so pass 2 runs. Pass 2 would score 40->90, i.e. the
+    // score prefers the emptied document. The guard must win anyway.
+    mockScoreOptimization
+      .mockResolvedValueOnce(makeAtsScore(40, 60))
+      .mockResolvedValueOnce(makeAtsScore(40, 90));
+
+    const result = await runOptimizePipeline('resume text', 'job description');
+
+    expect(result.passesUsed).toBe(1);
+    expect(result.optimizedResume.experience[0].achievements).toEqual([
+      'Led discovery',
+      'Shipped v2',
+      'Grew the team',
+    ]);
+    expect(result.atsResult.ats_score_optimized).toBe(60);
+  });
+});


### PR DESCRIPTION
Investigation **and fix**. Found from a live user report, not a test.

## The report

Founder ran an optimization on iOS 1.4.7 (17) at 2026-07-29 05:16 UTC and got back a resume with all five roles present and not one bullet under any of them: *"it cut all my experience."*

## Root cause

The prompt specifies the per-role bullet array as `achievements`. gpt-4o sometimes returns **`responsibilities`** instead, with `achievements` present but empty. Every consumer reads `achievements` and skips on empty; **nothing in the codebase reads a resume role's `responsibilities`**.

| Consumer | Line | On `achievements: []` |
|---|---|---|
| `DesignRenderer.tsx` | 525 | length guard fails, nothing rendered |
| `ats-resume-template.tsx` | 118 | same |
| `api/v1/optimizations/[id]/route.ts` | 60 | `bullets` empty |
| `lib/ats/integration.ts` | 102 | scorer never sees the text |

**The scorer could not catch it, because it reads the same empty key.** The founder's run scored 38 to **61**. The product deleted the user's evidence, graded the remains on summary and skills, and reported a 23-point improvement. Any guard built on the score would have passed this.

## Scope, measured in production

12 of 384 stored optimizations (3.1%), earliest 2026-05-28. All 12 belong to one account, **but that account holds 93% of all runs**, so at the observed rate the other 27 would be expected to yield ~1 and yielded 0. **The data cannot distinguish a resume-specific trigger from a background rate hitting everyone**, and this is not reported as founder-only.

## The fix, three layers

1. **`normalize-experience.ts`** coalesces the bullet key at **both** parse sites (pass 1 in `index.ts`, gap pass in `optimize-pipeline.ts`, a second independent model call that drifts the same way). Accepts `achievements` / `responsibilities` / `bullets` / `highlights` / `accomplishments`, first non-empty wins, never overwrites real achievements, always returns an array. Type-only import, so no runtime cycle and nothing crosses the client/server bundle boundary (WP-58).
2. **Two preservation guards.** `hasTotalBulletLoss` rejects a roles-but-no-bullets candidate and retries pass 1 once. `losesContentAgainst` keeps pass 1 when pass 2 drops more than a third of the evidence: pass 2 starts from pass 1's output and **never sees the original**, so its losses are permanent by construction. Both deliberately narrow so genuine consolidation passes.
3. **The prompt** now requires every role to survive with its bullets, forbids empty bullet lists, and pins the key name. The schema example is annotated so one role reads as the shape, not the count.

## Validation

- **25 new tests, all passing.** `4a` and `4b` drive the real `runOptimizePipeline`, and **both were confirmed failing on the parent commit**: `Array []` where the bullets belong, and `passesUsed 2` where the emptied pass 2 wins on score. That second one is the point, the guard has to beat the score, because the score prefers the broken document.
- Full suite **17 failed suites / 80 failed tests, identical to baseline**; passing **311 to 336**, exactly the 25 added.
- `tsc` **27 errors, exactly baseline**, none in touched files. An intermediate version added 19 and was rewritten rather than shipped.
- `eslint` 0 errors; its single warning is pre-existing and unchanged.
- **`next build` verified on a clean detached worktree of the fix commit.** The working tree fails on `src/app/[locale]/auth/callback/route 2.ts`, an untracked iCloud duplicate absent from CI. Building in place would have reported red for a green change.

## Not done

1. **The 12 historical rows are not backfilled.** Their bullets are intact under `responsibilities` and simply unread. Moving them is a production write and needs explicit approval.
2. **No `response_format: json_schema`**, layer 3 is instruction-level only. A strict schema would make the key name impossible to get wrong.
3. The founder's 38 to 61 must not enter any activation or quality series.
4. Not verified against a live model call; `evals/resume-optimizer/` is where the prompt change should be proven to lower the drift rate.

Note: the "Workers Builds: match1resume1to1job" check fails on every PR in this repo including `main`, and is not a signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
