### PR TITLE
chore: clear the working tree, land the stranded WP-64 progress notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ resume-builder-ai/nul
 
 # Eval run artifacts (regenerated each run)
 evals/**/report.json
+
+# iCloud sync duplicates ("route 2.ts", "en 2.json") — always stale copies of a
+# tracked file, and anything reading by glob picks up the wrong version.
+* [0-9].*

--- a/docs/superpowers/plans/2026-06-29-fit-match-web-reconciliation.md
+++ b/docs/superpowers/plans/2026-06-29-fit-match-web-reconciliation.md
@@ -1,0 +1,361 @@
+# Fit/Match Web Copy Reconciliation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring every public-facing web surface in this repo into alignment with the canonical Fit/Match positioning locked in the iOS repo (`ResumeBuilder IOS APP/.agents/product-marketing.md`, updated 2026-06-28), removing "pass ATS" / "official ATS score" framing wherever it appears in marketing copy, while leaving factual/process descriptions of ATS mechanics intact.
+
+**Architecture:** This is a copy-only reconciliation, not a feature build. No new components, no schema changes, no new dependencies. Every task edits existing i18n strings in `src/messages/en.json` (and the matching `src/messages/he.json` key when one exists) or existing markdown blog content. Each task is independently shippable — none depend on another's code changes, only on the canonical doc as the shared source of truth.
+
+**Tech Stack:** Next.js App Router, `next-intl` for i18n (`src/messages/en.json`, `src/messages/he.json`), Vercel deploy.
+
+## Global Constraints
+
+- Canonical source of truth for product facts: `/Users/nadavyigal/Documents/Projects /ResumeBuilder/ResumeBuilder IOS APP/.agents/product-marketing.md` (read it first, it may have changed since this plan was written).
+- Banned words (verbatim from the canonical doc's "Words to avoid"): "pass ATS", "guaranteed", "beat the bots", "official ATS score", "get interviews", "pass filters", "auto-apply".
+- Allowed words: "ATS-friendly" is fine in process-descriptive contexts (e.g. "ATS-friendly formatting"). Do not strip every mention of "ATS" — only the claim that the product makes a resume *pass* an ATS or reports an *official* ATS score.
+- Words to use instead, per the canonical doc: "job fit", "Match Score", "Resumely Match Score", "tailored resume", "missing keywords", "top gaps", "targeted edits", "ATS-friendly", "export PDF".
+- Hebrew copy must be authored, not auto-translated (repo convention, confirmed in `src/messages/he.json` history and CLAUDE.md project rules). If a task touches `he.json`, write natural Hebrew yourself — do not machine-translate the English string.
+- No new npm dependencies. Flag before installing anything.
+- Do not touch `docs/gtm/week-1-*` or `canonical-90-day-plan.md` — those are intentionally-preserved historical execution logs, not live copy (per `distribution-os/operating-principles.md` Principle 6 and the 2026-06-29 distribution-command-center decision).
+- Scope gate: if you find this touching more than the files listed below, stop and surface it before continuing.
+
+---
+
+### Task 1: Reconcile the `/ats-checker` page metadata and App Store CTA
+
+**Files:**
+- Modify: `src/messages/en.json` — keys `atsCheckerPage.meta.title`, `atsCheckerPage.meta.description`
+- Reference (no code change needed): `src/app/[locale]/ats-checker/page.tsx` — confirms these keys are consumed for `<title>`/`<meta description>` and OpenGraph tags
+
+**Current strings (verified 2026-06-29):**
+```json
+"atsCheckerPage": {
+  "meta": {
+    "title": "Free ATS Resume Checker — See If Your Resume Passes",
+    "description": "Paste your resume and job description. Get an instant Resumely Match Score and the top keyword gaps, based on how ATS systems parse resumes. Free, no sign-up required."
+  }
+}
+```
+
+The `title` violates "pass ATS." The `description` is already compliant (leads with "Resumely Match Score") — leave it.
+
+- [ ] **Step 1: Read the current file to confirm nothing changed since this plan was written**
+
+Run: `cat src/messages/en.json | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['atsCheckerPage']['meta'])"`
+Expected: matches the "Current strings" block above. If it doesn't, stop and re-read the canonical doc before proceeding.
+
+- [ ] **Step 2: Edit the title string**
+
+In `src/messages/en.json`, change:
+```json
+"title": "Free ATS Resume Checker — See If Your Resume Passes",
+```
+to:
+```json
+"title": "Free Resume Match Score Checker — See What's Missing",
+```
+
+- [ ] **Step 3: Verify the banned phrase is gone**
+
+Run: `grep -n "See If Your Resume Passes" src/messages/en.json`
+Expected: no output (zero matches).
+
+- [ ] **Step 4: Visually confirm in dev**
+
+Run: `npm run dev` (if not already running), then open `http://localhost:3000/ats-checker` and check the browser tab title matches the new string.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/messages/en.json
+git commit -m "copy: remove pass-ATS framing from /ats-checker page title"
+```
+
+---
+
+### Task 2: Reconcile the homepage hero copy
+
+**Files:**
+- Modify: `src/messages/en.json` — keys under `landing.hero`
+
+**Current strings (verified 2026-06-29):**
+```json
+"hero": {
+  "badge": "Used by Job Seekers Worldwide",
+  "titleLine1": "Turn Your Resume Into",
+  "titleLine2": "Interview Invitations",
+  "subtitle": "Your resume gets 6 seconds of attention. Make every second count. Our AI matches your experience to what recruiters actually search for.",
+  "benefits": ["Pass the 6-second scan test", "Match what recruiters search for", "See your score in 30 seconds"],
+  "ctaPrimary": "Get My Free Match Score",
+  "ctaSecondary": "See a Sample Report",
+  "socialProof": {
+    "atsApproved": "Built for ATS-safe formatting"
+  }
+}
+```
+
+`ctaPrimary` and `benefits[1]`/`benefits[2]` are already compliant. `benefits[0]` ("Pass the 6-second scan test") is about a *recruiter* skim, not an ATS claim — borderline but reads as ATS-adjacent given the page context; reword to remove ambiguity. `socialProof.atsApproved` implies a vendor approval that doesn't exist.
+
+- [ ] **Step 1: Edit `benefits[0]`**
+
+Change:
+```json
+"benefits": ["Pass the 6-second scan test", "Match what recruiters search for", "See your score in 30 seconds"],
+```
+to:
+```json
+"benefits": ["Built to survive the 6-second scan", "Match what recruiters search for", "See your score in 30 seconds"],
+```
+
+- [ ] **Step 2: Edit `socialProof.atsApproved`**
+
+Change:
+```json
+"atsApproved": "Built for ATS-safe formatting"
+```
+to:
+```json
+"atsApproved": "ATS-friendly formatting, built in"
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `grep -n "ATS-safe formatting\|Pass the 6-second" src/messages/en.json`
+Expected: no output.
+
+- [ ] **Step 4: Visually confirm in dev**
+
+Open `http://localhost:3000/` and check the hero benefits list and the social-proof badge under the fold render the new copy.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/messages/en.json
+git commit -m "copy: soften ATS-pass framing in homepage hero"
+```
+
+---
+
+### Task 3: Reconcile footer, newsletter, and blog index copy
+
+**Files:**
+- Modify: `src/messages/en.json` — keys `footer.newsletterDescription`, `newsletter.note`, `blog.index.subtitle`
+
+**Current strings (verified 2026-06-29):**
+```json
+"footer": {
+  "newsletterDescription": "Get proven, ATS-aware resume strategies and practical job-search tips every week."
+},
+"newsletter": {
+  "note": "Weekly resume tips and ATS insights. Unsubscribe anytime."
+},
+"blog": {
+  "index": {
+    "subtitle": "Expert advice on ATS optimization, resume writing, and landing your dream job."
+  }
+}
+```
+
+None of these use a literally banned phrase, but all three center the value prop on generic "ATS" framing instead of job-fit/tailoring, which is the new front-door story per the canonical doc ("Fit-First is the front-door story"). Low-risk, optional polish — do this task only after Tasks 1–2 land and only if you have remaining time in the session.
+
+- [ ] **Step 1: Edit `footer.newsletterDescription`**
+
+Change to:
+```json
+"newsletterDescription": "Get proven resume-tailoring strategies and practical job-search tips every week."
+```
+
+- [ ] **Step 2: Edit `newsletter.note`**
+
+Change to:
+```json
+"note": "Weekly resume tips and job-search insights. Unsubscribe anytime."
+```
+
+- [ ] **Step 3: Edit `blog.index.subtitle`**
+
+Change to:
+```json
+"subtitle": "Expert advice on resume tailoring, job fit, and landing your dream job."
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `grep -n "ATS-aware resume strategies\|ATS insights\|ATS optimization, resume writing" src/messages/en.json`
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/messages/en.json
+git commit -m "copy: lead footer/newsletter/blog-index copy with fit/tailoring, not generic ATS"
+```
+
+---
+
+### Task 4: Author matching Hebrew updates for Tasks 1–3
+
+**Files:**
+- Modify: `src/messages/he.json` — Hebrew counterparts of every key touched in Tasks 1–3
+
+**Why this is its own task:** the repo's Hebrew copy is authored, not machine-translated (confirmed by the existing `hebrew-program.md` convention and CLAUDE.md's project rule). This task cannot be done by literally translating the English strings above — write natural Hebrew that carries the same meaning and tone (calm, practical, non-alarmist, per the canonical doc's Brand Voice section).
+
+- [ ] **Step 1: Find the current Hebrew strings**
+
+Run:
+```bash
+python3 -c "
+import json
+d = json.load(open('src/messages/he.json'))
+for path in ['atsCheckerPage.meta.title', 'landing.hero.benefits', 'landing.hero.socialProof.atsApproved', 'footer.newsletterDescription', 'newsletter.note', 'blog.index.subtitle']:
+    cur = d
+    for k in path.split('.'):
+        cur = cur[k]
+    print(path, '=', cur)
+"
+```
+
+- [ ] **Step 2: Author Hebrew replacements**
+
+For each key, write a Hebrew string that matches the *meaning* of the new English string from Tasks 1–3 (not a literal translation), in the same calm/practical tone used elsewhere in `he.json`. Read 5-10 neighboring Hebrew strings in the file first to match register and terminology already in use (e.g. how "התאמה"/match, "התאמה למשרה"/job match are already phrased elsewhere in the file — search for them first with `grep -n "התאמה" src/messages/he.json` so the new copy is consistent with existing Hebrew terminology, not a new coinage).
+
+- [ ] **Step 3: Edit `src/messages/he.json` with the authored strings**
+
+- [ ] **Step 4: Verify JSON is valid**
+
+Run: `python3 -m json.tool src/messages/he.json > /dev/null && echo OK`
+Expected: `OK`
+
+- [ ] **Step 5: Visually confirm in dev**
+
+Open `http://localhost:3000/he/ats-checker` and `http://localhost:3000/he` and confirm the Hebrew renders correctly RTL with no layout breakage from string length changes.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/messages/he.json
+git commit -m "copy(he): author Hebrew counterparts for fit/match reconciliation"
+```
+
+---
+
+### Task 5: Retitle the two "pass ATS" blog posts
+
+**Files:**
+- Modify: `src/content/blog/en/how-to-beat-ats-systems-2025.md` (frontmatter `title`, `excerpt`, and the `# How to Pass ATS Screens in 2026` H1)
+- Modify: `src/content/blog/en/ats-baseline-mistakes-2026.md` (frontmatter `title` only — its H1 doesn't use "pass")
+- Check for Hebrew equivalents: `src/content/blog/he/` (verify whether matching Hebrew posts exist; if they do, repeat the title/H1 edit there with authored Hebrew per Task 4's approach, not translation)
+
+**Current state (verified 2026-06-29):**
+
+`how-to-beat-ats-systems-2025.md` frontmatter:
+```yaml
+title: "How to Pass ATS Screens in 2026: A Practical Resume Checklist"
+excerpt: "A practical, evidence-first checklist to make your resume easier for ATS systems and recruiters to read."
+```
+and body H1: `# How to Pass ATS Screens in 2026`
+
+`ats-baseline-mistakes-2026.md` frontmatter:
+```yaml
+title: "The 7 ATS Mistakes That Block Qualified Candidates (And How to Fix Them)"
+```
+This title doesn't use "pass" or "official score" — it's about avoiding mistakes, which is compliant. Leave its title as-is; only check its body for any "guaranteed"/"pass ATS" claims while you're in the file (see Step 3).
+
+**Scope note:** this task retitles the posts and their H1s only. A full body rewrite of both posts is out of scope for this plan — flag it as a follow-up if you want the body content audited line by line. The body text is process-descriptive ("ATS systems parse resumes") which is allowed; only the headline-level "pass ATS" promise needs to go.
+
+- [ ] **Step 1: Edit `how-to-beat-ats-systems-2025.md` frontmatter**
+
+Change:
+```yaml
+title: "How to Pass ATS Screens in 2026: A Practical Resume Checklist"
+```
+to:
+```yaml
+title: "How to Tailor Your Resume for ATS Systems in 2026: A Practical Checklist"
+```
+
+- [ ] **Step 2: Edit the H1 in the same file**
+
+Change:
+```markdown
+# How to Pass ATS Screens in 2026
+```
+to:
+```markdown
+# How to Tailor Your Resume for ATS Systems in 2026
+```
+
+- [ ] **Step 3: Scan both files for any other banned phrase**
+
+Run:
+```bash
+grep -in "guaranteed\|beat the bots\|official ats score\|pass filters\|auto-apply" src/content/blog/en/how-to-beat-ats-systems-2025.md src/content/blog/en/ats-baseline-mistakes-2026.md
+```
+Expected: no output. If something matches, reword that sentence in place (don't rewrite the whole post).
+
+- [ ] **Step 4: Check for and update Hebrew equivalents**
+
+Run: `ls src/content/blog/he/ | grep -i "ats"`
+If matching Hebrew posts exist, repeat Steps 1-3 with authored (not translated) Hebrew titles/H1s.
+
+- [ ] **Step 5: Verify the blog index and post still build**
+
+Run: `npm run build 2>&1 | tail -40`
+Expected: build succeeds with no errors related to `src/content/blog/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content/blog/en/how-to-beat-ats-systems-2025.md
+git commit -m "copy: retitle blog post away from pass-ATS framing"
+```
+
+---
+
+### Task 6: Leave the in-app dashboard "ATS support" copy as-is, document why
+
+**Files:**
+- No file edits in this task — it's a documentation/decision task.
+
+**Why this task exists:** The research pass for this plan found extensive "ATS support" / "ATS-friendly" / "ATS impact" copy throughout the authenticated dashboard (`dashboard.applications.detail.reports.atsImpact`, `dashboard.optimization.readiness.structureBadge`, `dashboard.ats.compact.title`, etc., all in `src/messages/en.json` under the `dashboard.*` namespace, rendered by `src/components/ats/ATSScoreCard.tsx`, `CompactATSScoreCard.tsx`, and `src/components/chat/ATSSuggestionsBanner.tsx`). None of it claims to "pass" an ATS or reports an "official" score — it consistently says "support," "impact," "friendly," "structure," which matches the canonical doc's allowed usage ("Keep 'ATS' for discoverability only in process-descriptive contexts"). This is intentionally out of scope for this plan.
+
+- [ ] **Step 1: Confirm no dashboard string crosses the line**
+
+Run:
+```bash
+python3 -c "
+import json
+d = json.load(open('src/messages/en.json'))
+def find(d, path=''):
+    if isinstance(d, dict):
+        for k,v in d.items():
+            find(v, path+'.'+k if path else k)
+    elif isinstance(d, str) and path.startswith('dashboard'):
+        low = d.lower()
+        if any(b in low for b in ['pass ats', 'guaranteed', 'beat the bots', 'official ats score', 'pass filters', 'auto-apply']):
+            print('VIOLATION:', path, '=', d)
+find(d)
+"
+```
+Expected: no output. If something prints, add a new sub-task to fix that specific string — do not bulk-edit the dashboard namespace.
+
+- [ ] **Step 2: Note the decision in the distribution OS lessons file**
+
+Append one row to `/Users/nadavyigal/Documents/Projects /Agentic OS/distribution-os/lessons.md` under "Cross-Product Patterns":
+```markdown
+| 2026-06-29 | Dashboard "ATS support/impact" copy is allowed under the canonical doc's process-descriptive carve-out; only public-marketing "pass ATS" claims needed reconciliation, not in-app labels | ResumeBuilder web dashboard | Verified via dashboard.* namespace scan, zero violations found |
+```
+
+- [ ] **Step 3: Commit (lessons file is in a different repo than the rest of this plan)**
+
+```bash
+cd "/Users/nadavyigal/Documents/Projects /Agentic OS" && git add distribution-os/lessons.md && git commit -m "lessons: confirm dashboard ATS copy is in-bounds, no edit needed"
+```
+
+---
+
+## Self-Review Notes (for whoever executes this)
+
+- **Spec coverage:** Task 1 covers the `/ats-checker` route's SEO metadata (the single most visible violation). Task 2 covers the homepage hero. Task 3 covers footer/newsletter/blog-index. Task 4 covers Hebrew parity. Task 5 covers the two blog post titles. Task 6 explicitly scopes OUT the dashboard copy with a verification step, so nothing gets silently missed.
+- **What this plan deliberately does not touch:** `docs/gtm/week-1-*`, `canonical-90-day-plan.md` (historical logs, see Global Constraints), the body content of the two blog posts beyond title/H1 (flag as separate follow-up if wanted), and all `dashboard.*` copy (verified compliant in Task 6).
+- **Before starting:** re-read `ResumeBuilder IOS APP/.agents/product-marketing.md` — if the founder has changed the canonical positioning since 2026-06-28, the target strings in this plan may be stale. Treat this plan's "current strings" snapshots as a diff base, not a guarantee.

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -30,6 +30,14 @@ With the founder included it reads 1 and 1, which is the sanity check confirming
 
 **The honest read:** the instrument is no longer the constraint and neither, now, is this defect. **Traffic is.** 95 launches in five months and zero since the current release is not a funnel problem that more engineering solves.
 
+**Post-deploy live verification, 2026-07-29 08:10 UTC.** Optimization `1cdce873-65e1-4ba3-a7be-72d7ccb6fa02` on iOS 1.4.7 (17) against the deployed backend: **5 roles, 14 bullets, every role populated** (3/3/3/3/2), bullets substantive at 110-134 characters. `optimized_preview_rendered` fired. Score 44 → 85. The document renders with content; the defect is gone from the live path.
+
+**But read what this run actually proves, because it is less than it looks.** Every role carries both keys — `achievements` populated and `responsibilities` present but **empty**. That means **the model named the key correctly on its own and the normalizer had nothing to rescue.** The fix path was never exercised. Since the model already complied on 372 of 384 runs (96.9%), one compliant run is exactly what the *pre-fix* baseline predicts, so **this is not evidence that the prompt change lowered the drift rate.** What it does prove: the deploy did not break anything, and the end-to-end path is healthy. The rescue path's evidence is the unit and integration tests (`4a`, `4b`), which were confirmed failing on the parent commit. Proving the prompt change needs `evals/resume-optimizer/` across many runs, not one.
+
+**A limitation the guards do not cover, now visible.** The source resume carries 18 bullets (recoverable from the backfilled rows); this run produced 14, a 22% reduction. `losesContentAgainst` compares **pass 2 against pass 1**, and pass 1's input is raw text with no structural bullet count, so **under-generation relative to the user's original document is undetectable by design**. Closing it means parsing the source resume into structure before optimizing, or counting source bullets heuristically and threading that through. Not attempted.
+
+**The event-duplication defect is unchanged and visible again in this trace**: `optimized_viewed` ×2, `export_cta_seen` ×2, `saved_resume_prompt_viewed` ×2, and `optimization_completed` emitted by both client (with version) and server (without).
+
 **Not done:** (1) `response_format: json_schema` — the key name is still enforced by instruction rather than by the API. (2) The fix is not yet verified against a live model call; `evals/resume-optimizer/` is where the prompt change should be proven to lower the drift rate, and the nightly eval ran at 05:36 UTC *before* this merge. (3) The event-duplication defect found in the same trace (several events firing 2-4x, `optimization_completed` emitted by both client and server) is recorded but has no packet. (4) The founder's 38 → 61 must not enter any activation or quality series.
 
 **Last Updated:** 2026-07-29

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,39 @@
 # Project Progress
 
+## 2026-07-29 (later) — WP-64 shipped to production, and the 12 rows are repaired
+
+**Merged and deployed.** PR #126 squash-merged to `main` as `3c1c58c` at 07:52 UTC. CI `build-test` success, Vercel production deploy success on the merge commit, `https://www.resumelybuilderai.com` responding 200. Checks that passed: build-test, Vercel, GitGuardian, CodeRabbit. The one failure was `Workers Builds: match1resume1to1job`, which fails on every PR in this repo including `main` and is not a signal.
+
+**This fixed the live iOS app without an App Store release.** The optimizer runs server-side and iOS 1.4.7 calls `resumelybuilderai.com`, so the deploy repaired the shipping binary's behaviour with no Apple review in the loop. Worth remembering as a general property: **defects in the optimize/score path are hot-fixable; only client-side defects need a build.**
+
+**Backfill applied to the 12 affected rows.** Each role's `responsibilities` was copied into `achievements`, only where `achievements` was empty and `responsibilities` was not.
+
+- Dry run first, as a pure SELECT: 12 rows, `roles_before` = `roles_after` = 5 on every row, and the company list byte-identical in the same order before and after. Role identity and ordering were the two things that could silently break, and both were checked before the write, not after.
+- `jsonb_agg(... ORDER BY ord)` is load-bearing. Without the explicit ordinality ordering, role order is not guaranteed and the resumes would have been silently reshuffled.
+- Applied: 12 rows updated, 0 → **214 bullets restored**.
+- Post-write verification across the whole table: **384 rows with an experience array, 0 still empty, 384 with bullets, 4,611 bullets total, 0 rows with unrepaired key drift.**
+
+**The backfill is reversible.** `responsibilities` was deliberately left in place rather than moved, so undoing it is setting the same roles' `achievements` back to `[]`. Nothing was destroyed; the repair is additive.
+
+**`updated_at` was bumped.** Deliberate: the row content genuinely changed, and any consumer caching on `updated_at` has to see it or it will keep serving the empty version, which is the entire point of the backfill. The cost is that these 12 rows now read as recently modified when the user did not modify them — noted here so nobody reads it as user activity.
+
+**Activation as of this write, and it is the real headline.** Pinned window from the 1.4.7 release (2026-07-28T19:30:45Z) to now, person-level internal exclusion, founder person `a6441489-...` excluded:
+
+| Step | People |
+|---|---|
+| `app_launched` | **0** |
+| `optimized_preview_rendered` | **0** |
+
+With the founder included it reads 1 and 1, which is the sanity check confirming the query resolves, not a result. **Lifetime (365d, same exclusions): 95 launched → 2 activated → 4 exported.** Against EXD-022's gate of >=20 clean activations that is **2 of 20**, and 1.4.7 has contributed nothing because nobody outside the founder has opened it.
+
+**4 exported against 2 activated is structurally impossible** — you cannot export a preview you never rendered. That is the pre-1.4.5 broken-milestone residue still showing through, and it means the lifetime 2 is itself not a clean figure. Any activation claim built on it needs that caveat attached.
+
+**The honest read:** the instrument is no longer the constraint and neither, now, is this defect. **Traffic is.** 95 launches in five months and zero since the current release is not a funnel problem that more engineering solves.
+
+**Not done:** (1) `response_format: json_schema` — the key name is still enforced by instruction rather than by the API. (2) The fix is not yet verified against a live model call; `evals/resume-optimizer/` is where the prompt change should be proven to lower the drift rate, and the nightly eval ran at 05:36 UTC *before* this merge. (3) The event-duplication defect found in the same trace (several events firing 2-4x, `optimization_completed` emitted by both client and server) is recorded but has no packet. (4) The founder's 38 → 61 must not enter any activation or quality series.
+
+**Last Updated:** 2026-07-29
+
 ## 2026-07-29 — WP-64: the optimizer was deleting every experience bullet
 
 **Found from a live user report, not a test.** The founder ran an optimization on iOS 1.4.7 (17) at 05:16 UTC and got back a resume with all five roles present and not one bullet under any of them: "it cut all my experience."

--- a/tasks/work-pack-grandfather-existing-free-users.md
+++ b/tasks/work-pack-grandfather-existing-free-users.md
@@ -1,0 +1,52 @@
+# Work Pack: Grandfather Existing Free Users Before Monetization
+
+> Open this in the ResumeBuilder web repo (Cursor).
+> Ungated — does not require EXD-009 Gate A (CFO price validation) to be open. This is entitlement bookkeeping, not pricing.
+> One story. Verify (lint + tests) before calling it done.
+
+**Repo:** `/Users/nadavyigal/Documents/Projects /ResumeBuilder/new-ResumeBuilder-ai-`
+
+**Context:** Red-team + advisor session (2026-07-02) on the Resumely monetization plan flagged the highest-leverage, zero-cost fix: existing users must never hit a surprise paywall mid-session. Plan 3 (StoreKit paywall, `docs/superpowers/plans/2026-06-07-resumely-plan-3-storekit-paywall.md`) is correctly gated behind CFO price validation and D7 activation data — that gate should stay closed while the founder builds traffic. This work pack is independent of that gate: it only needs a cutoff timestamp, not a final price.
+
+**Goal:** Every account created before the paywall ships keeps full free access forever. Only accounts created after the cutoff are subject to any future paywall/credit enforcement. Existing users get a heads-up announcement before anything changes for them (which, per this fix, is nothing).
+
+---
+
+## Phase 1: Add the grandfathering flag (30 min)
+
+- [ ] **Check existing schema for `profiles.credit_balance` / `credit_transactions`** (per `tasks/MEMORY.md` EXD-009 note) — confirm no grandfathering column already exists.
+  ```bash
+  grep -rn "credit_balance\|is_legacy_free\|grandfathered" src/ supabase/ --include="*.ts" --include="*.sql" -l
+  ```
+
+- [ ] **Write a migration** adding a boolean/timestamp to `profiles` (or wherever the canonical user table lives):
+  ```sql
+  alter table profiles
+    add column if not exists legacy_free_access boolean not null default false;
+  ```
+  Do not apply this migration to production without explicit founder go-ahead per global rule (no migrations without explicit "yes" in the message).
+
+- [ ] **Backfill script (one-time, run at ship time, not now):** set `legacy_free_access = true` for every row where `created_at < <cutoff_timestamp>`. Cutoff = the moment this backfill runs, decided at ship time, not today.
+
+## Phase 2: Entitlement check (30-45 min)
+
+- [ ] Find wherever export/paywall gating will eventually check credits or subscription status (likely near `src/components/paywall/upgrade-modal.tsx` or the export flow).
+- [ ] Add a guard: if `profiles.legacy_free_access = true`, skip all paywall/credit checks unconditionally, regardless of which pricing model (flat fee vs. credits) Plan 3 eventually ships with.
+- [ ] This guard must not depend on which pricing model is chosen — it's model-agnostic by design, so it doesn't get re-litigated when Gate A opens.
+
+## Phase 3: Comms draft (not code — write, don't send)
+
+- [ ] Draft a one-paragraph in-app + email announcement: "Resumely is introducing pricing for new users. If you signed up before [date], your account keeps full free access — nothing changes for you." Save as `docs/comms/legacy-user-grandfathering-announcement.md`.
+- [ ] Do not send. Sending is a separate, explicit founder decision at ship time.
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] Existing test suite passes: `npm test` (or project's test command)
+- [ ] Confirm migration is NOT applied to any live database as part of this work pack — schema change only, no deploy.
+
+## Explicitly out of scope
+
+- Final price or credit amount (blocked on Gate A / CFO validation).
+- Sending the comms email (separate decision).
+- Any StoreKit/IAP code (Plan 3, still gated).


### PR DESCRIPTION
WP-70 story 5, plus two doc commits that were stranded on this branch.

## What this is

Docs and `.gitignore` only. No source, no schema, no dependency change.

**Working tree cleanup.** Eight iCloud duplicate files (`route 2.ts`, `en 2.json`, and friends) were sitting untracked in the primary working tree. Each was compared byte-for-byte against `origin/claude/wp49-anonymous-carryover` (PR #117) before deletion — all eight matched exactly, so nothing unique was lost. A `.gitignore` rule now blocks them from returning; no tracked file in the repo matches the pattern, verified with `git ls-files`.

**Two planning docs** that had never been committed: the Fit/Match web copy reconciliation plan and the grandfather-free-users work pack.

**Two WP-64 progress notes** that were committed to this branch on 2026-07-29 but never landed on `main` — the live-verification record and what it does and does not prove.

## Why it matters

Anything reading source by glob would have picked the stale ` 2.*` copy over the tracked file. That is the same failure mode that left two pre-flip work packets contradicting their own canonical files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a plan to align public website messaging with job-fit, Match Score, tailoring, and ATS-friendly language.
  * Documented deployment progress, validation results, and remaining operational follow-up items.
  * Added a work plan for preserving existing free access ahead of future monetization changes.

* **Chores**
  * Added ignore rules for duplicate files created by cloud synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->