### PR TITLE
fix(test): stop jest collecting a stale duplicate of the whole suite

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,8 +9,16 @@ const createJestConfig = nextJest({
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
-  // Avoid scanning nested duplicate project tree to prevent haste collisions
-  modulePathIgnorePatterns: ['<rootDir>/resume-builder-ai/'],
+  // Avoid scanning nested duplicate project trees to prevent haste collisions.
+  // `.claude/worktrees/` holds live git worktrees checked out INSIDE the repo, so
+  // without this jest collects a second, older copy of the whole suite and reports
+  // its failures as if they were this tree's. Measured 2026-08-05: 148 suites /
+  // 869 tests with it, 74 / 435 without — exactly half the run was a stale clone,
+  // contributing 80 of 156 failures.
+  modulePathIgnorePatterns: [
+    '<rootDir>/resume-builder-ai/',
+    '<rootDir>/.claude/worktrees/',
+  ],
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },


### PR DESCRIPTION
Found while verifying PR #112, whose four "failures" all turned out to belong to a different tree.

## The defect

`.claude/worktrees/` holds live git worktrees checked out **inside** the repo. `modulePathIgnorePatterns` excluded `resume-builder-ai/` but not those, so every jest run also collected a second, older copy of the entire suite and reported its failures as this tree's.

Measured at `2faa817`:

| | suites | tests | failing |
|---|---|---|---|
| as configured | 148 | 869 | 156 |
| nested worktrees excluded | 74 | 435 | 76 |

Exactly half the run was a stale clone, contributing 80 of the 156 failures.

## Why it matters beyond noise

The **"17 failed suites / 80 failed tests" baseline cited across `tasks/progress.md`** was measured with the duplicate present, so it has partly been counting an old copy of itself. Any future "identical to baseline" claim needs re-measuring against the numbers in this PR.

Same defect class as the iCloud ` 2.ts` duplicates deleted in `8968a62` (PR #128): a glob picking up the wrong copy. That one was source files; this one was tests.

## Verification

One-line config change, no source touched. After the fix, a plain `npx jest` reports 74 suites / 435 tests / 76 failing — identical to running the pre-fix config with the ignore pattern passed on the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)