### PR TITLE
WP-69 S6: persist SCORE_VERSION as stored text

### DIFF
--- a/src/app/api/ats/rescan/route.ts
+++ b/src/app/api/ats/rescan/route.ts
@@ -6,7 +6,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
-import { rescoreOptimization } from '@/lib/ats';
+import { rescoreOptimization, SCORE_VERSION } from '@/lib/ats';
 import { logger } from '@/lib/agent/utils/logger';
 
 export async function POST(request: NextRequest) {
@@ -96,6 +96,7 @@ export async function POST(request: NextRequest) {
       .from('optimizations')
       .update({
         ats_version: 2,
+        score_version: result.metadata?.score_version ?? SCORE_VERSION,
         ats_score_optimized: result.ats_score_optimized,
         ats_subscores: result.subscores,
         ats_suggestions: result.suggestions,

--- a/src/app/api/public/ats-check/route.ts
+++ b/src/app/api/public/ats-check/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { parsePdf } from '@/lib/pdf-parser';
-import { scoreResume } from '@/lib/ats';
+import { scoreResume, SCORE_VERSION } from '@/lib/ats';
 import { generateFormatReport } from '@/lib/ats/integration';
 import { generateQuickWins } from '@/lib/ats/quick-wins/generator';
 import type { ATSScoreInput, JobExtraction } from '@/lib/ats/types';
@@ -241,6 +241,13 @@ export async function POST(request: NextRequest) {
     job_description_hash: jobHash,
   };
 
+  // WP-69: which engine produced this score. Spread separately from baseScoreRow so the
+  // undefined-column fallback below drops it too if migration 20260805000000 has not been
+  // applied yet — a missing column must not cost the user their free check.
+  const versionColumn = {
+    score_version: scoreResult.metadata?.score_version ?? SCORE_VERSION,
+  };
+
   // WP-49: retained only so signup can carry the check into the new account;
   // cleared on conversion, expired otherwise.
   const carryoverColumns = {
@@ -252,7 +259,7 @@ export async function POST(request: NextRequest) {
 
   let { data: insertedScore, error: insertError } = await supabase
     .from('anonymous_ats_scores')
-    .insert({ ...baseScoreRow, ...carryoverColumns })
+    .insert({ ...baseScoreRow, ...carryoverColumns, ...versionColumn })
     .select('*')
     .single();
 

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -2,6 +2,7 @@ import OpenAI from 'openai';
 import { trackedChatCompletion, type AITraceOptions } from '@/lib/posthog-ai';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
 import { scoreOptimization } from '@/lib/ats/integration';
+import { SCORE_VERSION } from '@/lib/ats';
 import { buildRewritePrompt } from './prompts/rewrite';
 import { buildQuantifierPrompt } from './prompts/quantifier';
 import { buildATSReportPrompt } from './prompts/ats-report';
@@ -769,6 +770,7 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
             ats_confidence: scoreResult.confidence,
             match_score: scoreResult.ats_score_optimized,
             ats_version: 2,
+            score_version: scoreResult.metadata?.score_version ?? SCORE_VERSION,
           })
           .eq('id', optimization.id);
       }

--- a/src/lib/optimization-review/service.ts
+++ b/src/lib/optimization-review/service.ts
@@ -1,6 +1,7 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { scoreOptimization } from "@/lib/ats/integration";
+import { SCORE_VERSION } from "@/lib/ats";
 import {
   isImpossibleMeasurement,
   ImpossibleMeasurementError,
@@ -304,6 +305,7 @@ export async function applyOptimizationReviewRun({
       template_key: "natural",
       status: "completed",
       ats_version: 2,
+      score_version: finalATSResult?.metadata?.score_version ?? SCORE_VERSION,
       ats_score_original: finalATSPreview?.before ?? reviewRun.ats_preview_json?.before ?? null,
       ats_score_optimized: finalATSPreview?.after ?? reviewRun.ats_preview_json?.after ?? null,
       ats_subscores: finalATSResult?.subscores ?? null,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -151,6 +151,7 @@ export interface Database {
           ats_suggestions: Json | null;
           ats_confidence: number | null;
           ats_version: number | null;
+          score_version: string | null;
           ai_modification_count: number | null;
         },
         {
@@ -175,6 +176,7 @@ export interface Database {
           ats_suggestions?: Json | null;
           ats_confidence?: number | null;
           ats_version?: number | null;
+          score_version?: string | null;
           ai_modification_count?: number | null;
         },
         {
@@ -199,6 +201,7 @@ export interface Database {
           ats_suggestions?: Json | null;
           ats_confidence?: number | null;
           ats_version?: number | null;
+          score_version?: string | null;
           ai_modification_count?: number | null;
         },
         [
@@ -415,6 +418,7 @@ export interface Database {
           job_source_url: string | null;
           resume_id: string | null;
           job_description_id: string | null;
+          score_version: string | null;
         },
         {
           id?: number;
@@ -437,6 +441,7 @@ export interface Database {
           job_source_url?: string | null;
           resume_id?: string | null;
           job_description_id?: string | null;
+          score_version?: string | null;
         },
         {
           id?: number;
@@ -459,6 +464,7 @@ export interface Database {
           job_source_url?: string | null;
           resume_id?: string | null;
           job_description_id?: string | null;
+          score_version?: string | null;
         }
       >;
       rate_limits: Table<

--- a/supabase/migrations/20260805000000_persist_score_version.sql
+++ b/supabase/migrations/20260805000000_persist_score_version.sql
@@ -1,0 +1,27 @@
+-- WP-69 story 6 — persist the scoring regime as stored text.
+--
+-- `optimizations.ats_version` is an INTEGER and every write site hardcodes it to 2, so
+-- 90 days of rows all read `2` no matter which engine scored them. `anonymous_ats_scores`
+-- carried no version at all. The regime discipline (WP-45 S9: scores are not comparable
+-- across versions) therefore had to classify stored rows by `created_at`, which misbins
+-- every row written near a regime change — and a regime change is exactly when the
+-- classification matters.
+--
+-- NO BACKFILL, deliberately. A row whose scorer is unknown stays NULL rather than being
+-- inferred from its timestamp. Inferring is the failure this column exists to remove;
+-- doing it once here would bake that guess in permanently and make it look measured.
+
+ALTER TABLE public.optimizations
+  ADD COLUMN IF NOT EXISTS score_version TEXT;
+
+ALTER TABLE public.anonymous_ats_scores
+  ADD COLUMN IF NOT EXISTS score_version TEXT;
+
+COMMENT ON COLUMN public.optimizations.score_version IS
+  'SCORE_VERSION of the ATS engine that produced this row (src/lib/ats/core.ts). NULL means unknown — never infer it from created_at.';
+
+COMMENT ON COLUMN public.anonymous_ats_scores.score_version IS
+  'SCORE_VERSION of the ATS engine that produced this row (src/lib/ats/core.ts). NULL means unknown — never infer it from created_at.';
+
+CREATE INDEX IF NOT EXISTS idx_optimizations_score_version
+  ON public.optimizations(score_version);


### PR DESCRIPTION
**Draft on purpose: the migration must be applied before this merges.** I could not apply it — the stored Supabase pooler URL in `supabase/.temp/pooler-url` carries a placeholder password, and `DATABASE_URL` in `.env.local` points at an unrelated Neon database (`neondb`), not the Supabase project the app uses.

## The problem

`optimizations.ats_version` is an INTEGER and every write site hardcodes it to `2`, so 90 days of rows all read `2` no matter which engine scored them. `anonymous_ats_scores` carried no version at all. The regime discipline (WP-45 S9 — scores are not comparable across versions) therefore had to classify stored rows by `created_at`, which misbins exactly the rows written near a regime change, which is when the classification matters.

## The change

A nullable `score_version TEXT` on both tables, written at the four sites that produce a score:

| Site | |
|---|---|
| `src/app/api/ats/rescan/route.ts` | rescan update |
| `src/lib/expert-workflows/orchestrator.ts` | expert-pass rescore |
| `src/lib/optimization-review/service.ts` | review completion insert |
| `src/app/api/public/ats-check/route.ts` | anonymous free check |

Each prefers the scoring result's own `metadata.score_version` over the `SCORE_VERSION` constant, so a row records what actually scored it rather than what happens to be current at write time.

**No backfill.** A row whose scorer is unknown stays NULL rather than being inferred from its timestamp. Inferring is the failure this column exists to remove, and doing it once here would bake the guess in permanently while making it look measured.

On the anonymous path the column is spread separately from `baseScoreRow`, so the existing `isUndefinedColumnError` fallback drops it if the migration has not been applied — the guard WP-39 left behind after code shipped ahead of a migration. The three `optimizations` writes have no such guard, which is why this is a draft.

## Apply order

```bash
npx supabase db push
```

or paste `supabase/migrations/20260805000000_persist_score_version.sql` into the SQL editor. Then mark this ready and merge.

## Verification

- `npx tsc --noEmit` — the five files with errors are identical to the pre-existing set on the current tree (`tests/security-fixes.test.ts` and four `tests/contracts/expert-workflow*`); none of the changed files appears.
- `npx jest src/lib/ats tests/contracts/ats` — 14 suites, 141 passed, 6 skipped, 0 failures.
- `npx jest` on the anonymous carryover and ats-check suites, including `anonymous-carryover-migration-fallback` — 5 suites, 22 passed.
- The migration itself is **not** verified against a database. Nobody has run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)