### PR TITLE
Fix WP-64 recurrence through review apply

### DIFF
--- a/src/app/api/v1/optimizations/[id]/route.ts
+++ b/src/app/api/v1/optimizations/[id]/route.ts
@@ -169,14 +169,22 @@ export async function GET(
   // Improve Match is a one-time mutation for each saved optimization. Read the
   // durable server record so every client, including a fresh install, knows an
   // applied ATS report must not be offered again.
-  const { data: appliedATSRuns } = await supabase
+  const { data: appliedATSRuns, error: appliedATSRunsErr } = await supabase
     .from("expert_workflow_runs")
     .select("id")
     .eq("optimization_id", id)
     .eq("workflow_type", "ats_optimization_report")
     .not("applied_at", "is", null)
     .limit(1);
-  const atsImprovementApplied = (appliedATSRuns?.length ?? 0) > 0;
+  if (appliedATSRunsErr) {
+    console.error("Unable to read ATS improvement completion state:", appliedATSRunsErr);
+  }
+  // Fail closed when completion state cannot be read. The preview remains
+  // available, but a non-idempotent improvement is never offered twice merely
+  // because its guard query failed.
+  const atsImprovementApplied = appliedATSRunsErr
+    ? true
+    : (appliedATSRuns?.length ?? 0) > 0;
 
   const rewriteData = row.rewrite_data as OptimizedResume | null;
   const sections = rewriteData ? rewriteDataToSections(rewriteData) : [];
@@ -264,6 +272,7 @@ export async function PATCH(
   if (!rewriteData) {
     return NextResponse.json({ error: "rewrite_data is required" }, { status: 400 });
   }
+  const normalizedRewriteData = normalizeExperienceBullets(rewriteData);
 
   try {
     const userId = user.id;
@@ -308,7 +317,7 @@ export async function PATCH(
     try {
       const scored = await scoreOptimization({
         resumeOriginalText: (resumeRow as any)?.raw_text || "",
-        resumeOptimizedJson: rewriteData,
+        resumeOptimizedJson: normalizedRewriteData,
         jobDescriptionText: resolveJobDescriptionText({
           raw_text: (jdRow as any)?.raw_text,
           clean_text: (jdRow as any)?.clean_text,
@@ -325,7 +334,7 @@ export async function PATCH(
     await supabase
       .from("optimizations")
       .update({
-        rewrite_data: rewriteData,
+        rewrite_data: normalizedRewriteData,
         match_score: atsResult.ats_score_optimized ?? undefined,
         ats_score_optimized: atsResult.ats_score_optimized,
         ats_subscores: (atsResult as any).subscores ?? null,
@@ -349,7 +358,7 @@ export async function PATCH(
       optimization_id: id,
       session_id: null,
       version_number: nextVersion,
-      content: rewriteData,
+      content: normalizedRewriteData,
       change_summary: changeSummary || "Manual edit",
     });
 

--- a/src/app/api/v1/optimizations/[id]/route.ts
+++ b/src/app/api/v1/optimizations/[id]/route.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createRouteHandlerClient } from "@/lib/supabase-server";
 import type { OptimizedResume } from "@/lib/ai-optimizer";
+import { normalizeExperienceBullets } from "@/lib/ai-optimizer/normalize-experience";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { scoreOptimization } from "@/lib/ats/integration";
 import { assessLift } from "@/lib/ats/lift";
@@ -53,8 +54,9 @@ function flattenSkills(data: OptimizedResume): string {
 }
 
 function flattenExperience(data: OptimizedResume): string {
-  if (!Array.isArray(data.experience)) return "";
-  return data.experience
+  const normalized = normalizeExperienceBullets(data);
+  if (!Array.isArray(normalized.experience)) return "";
+  return normalized.experience
     .map((exp) => {
       const head = [exp.title, exp.company].filter(Boolean).join(" • ");
       const bullets = Array.isArray(exp.achievements)
@@ -164,6 +166,18 @@ export async function GET(
     return NextResponse.json({ error: "Optimization not found" }, { status: 404 });
   }
 
+  // Improve Match is a one-time mutation for each saved optimization. Read the
+  // durable server record so every client, including a fresh install, knows an
+  // applied ATS report must not be offered again.
+  const { data: appliedATSRuns } = await supabase
+    .from("expert_workflow_runs")
+    .select("id")
+    .eq("optimization_id", id)
+    .eq("workflow_type", "ats_optimization_report")
+    .not("applied_at", "is", null)
+    .limit(1);
+  const atsImprovementApplied = (appliedATSRuns?.length ?? 0) > 0;
+
   const rewriteData = row.rewrite_data as OptimizedResume | null;
   const sections = rewriteData ? rewriteDataToSections(rewriteData) : [];
   const contact = rewriteData ? rewriteDataToContact(rewriteData) : null;
@@ -209,6 +223,8 @@ export async function GET(
     ats_score_after: toIntPercent(row.ats_score_optimized),
     atsBlockers: blockers,
     ats_blockers: blockers,
+    atsImprovementApplied,
+    ats_improvement_applied: atsImprovementApplied,
     // WP-45 S2/S8. The scores above stay honest; `lift` tells the client
     // whether they are worth SHOWING. A run that moved the score by +2, or
     // moved it down, is a pipeline failure, and a before/after pair reads as a

--- a/src/lib/design-manager/render-preview-html.ts
+++ b/src/lib/design-manager/render-preview-html.ts
@@ -209,6 +209,8 @@ function transformToJsonResume(resumeData: unknown): JsonResume {
     summary: asString(data.summary),
     work: experience.map((item) => {
       const exp = asRecord(item);
+      const achievements = asStringArray(exp.achievements);
+      const responsibilities = asStringArray(exp.responsibilities);
       return {
         name: asString(exp.company),
         position: asString(exp.title) || asString(exp.position),
@@ -216,7 +218,11 @@ function transformToJsonResume(resumeData: unknown): JsonResume {
         startDate: asString(exp.startDate),
         endDate: asString(exp.endDate) || 'Present',
         summary: asString(exp.description),
-        highlights: asStringArray(exp.achievements),
+        // Historical rows and the canonical review path may carry the role's
+        // real bullets under `responsibilities`. Prefer canonical achievements,
+        // but never render a headline-only role when the compatible alias has
+        // content (WP-64 recurrence, 2026-08-08).
+        highlights: achievements.length > 0 ? achievements : responsibilities,
       };
     }),
     education: education.map((item) => {

--- a/src/lib/resume/canonicalize.ts
+++ b/src/lib/resume/canonicalize.ts
@@ -162,14 +162,21 @@ export function normalizeOptimizedResume(
               item && typeof item === "object" && !Array.isArray(item)
                 ? (item as Record<string, unknown>)
                 : {};
+            const achievements = toStringArray(row.achievements);
+            const responsibilities = toStringArray(row.responsibilities);
             return {
               title: firstNonEmptyString(row.title),
               company: firstNonEmptyString(row.company),
               location: firstNonEmptyString(row.location),
               startDate: firstNonEmptyString(row.startDate),
               endDate: firstNonEmptyString(row.endDate),
-              achievements: toStringArray(row.achievements),
-              responsibilities: toStringArray(row.responsibilities),
+              // Every renderer and scorer consumes `achievements`. The
+              // canonical parser deliberately accepts `responsibilities`, so
+              // normalize that alias here too. Otherwise the review/apply path
+              // can undo WP-64's parse-boundary fix and persist role headers
+              // with every bullet stranded under the unread alias.
+              achievements: achievements.length > 0 ? achievements : responsibilities,
+              responsibilities,
             };
           })
           .filter((item) => item.title || item.company || item.achievements.length > 0)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -134,6 +134,14 @@ other. Both flattered the product.
 
 ---
 
+## Normalize compatibility aliases at every persistence boundary
+
+**Mistake:** Fixing `responsibilities` versus `achievements` only where the AI JSON is parsed, while a later canonicalizer accepts both keys and can persist `achievements: []` again.
+**Why it fails:** The optimizer output is not the final stored object. Review selection rebuilds and normalizes the résumé before insert, so a correct upstream object can be replaced by an original canonical role whose bullets remain under the alias. Renderers and scorers still read only the canonical key.
+**Fix:** Enforce the canonical field at every rebuild or persistence boundary, and keep tolerant fallbacks on read paths for historical rows. Regression fixtures must exercise the full review/apply shape, not only the model parse function.
+
+---
+
 ## Wrong Supabase project in env
 
 **Mistake:** `NEXT_PUBLIC_SUPABASE_URL` points at the wrong project (dev vs. prod).

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,13 +1,23 @@
 # Project Progress
 
-- Status: WP-70 complete except the PR #100 product decision
-- Current Phase: WP-70 — land the stalled ResumeBuilder Web PRs
-- Active Story: none
-- Last Completed Story: WP-70 stories 1, 2, 3, 5, 6 — PRs #117, #118, #112 merged; working tree cleared; PostHog dashboards audited
-- Next Recommended Story: founder decision on PR #100 (grandfather free users), then apply migration `20260720000000`
-- Blockers: **Founder decision required on PR #100.** Migration `20260720000000` remains unapplied by design.
-- Last Validation: 2026-08-05 — build OK, lint clean on touched files, tsc 19 errors identical to baseline, i18n 0 missing HE keys, suite 74 suites / 435 tests
-- Last Updated: 2026-08-05
+- Status: P0 WP-64 recurrence fixed locally, not deployed
+- Current Phase: Review-path bullet preservation and one-pass fit contract
+- Active Story: make responsibilities-only rows readable and expose durable ATS-improvement completion
+- Last Completed Story: local implementation and regression verification
+- Next Recommended Story: review and merge this PR, deploy through the normal backend path, then verify the existing affected optimization read-only
+- Blockers: live verification requires the normal deploy; deployment is explicitly outside this session
+- Last Validation: 2026-08-09, 4 targeted suites / 21 tests passing, touched-file ESLint clean
+- Last Updated: 2026-08-09
+
+## 2026-08-09 — WP-64 recurred through the review path after the parser fix shipped
+
+**A new live row reproduced the same destructive shape after WP-64 was deployed and backfilled.** The founder's 2026-08-08 optimization contained five roles, zero `achievements`, and 17 populated `responsibilities`; its score was stored as 43 to 64. Read-only inspection only, no row was modified.
+
+**The prior fix was correct but incomplete.** Both AI parse sites normalize bullet aliases, but the optimization-review flow calls `normalizeOptimizedResume`. That canonicalizer explicitly retained `responsibilities` while leaving `achievements` empty. Applying a review could therefore reintroduce the exact invalid shape after the pipeline had repaired it. The detail and design-render paths then read only `achievements`, so the stored résumé appeared as role headlines with no content.
+
+**Fix:** canonicalization now promotes non-empty responsibilities when achievements are empty. The optimization-detail and design-preview read paths also accept that alias, which makes historical rows readable without a backfill. Optimization detail now returns `ats_improvement_applied` from applied `ats_optimization_report` runs so clients can enforce one improvement per saved optimization across devices. The live row already has three such applied runs, which confirms the need for a server-backed flag.
+
+**Validation:** `normalize-experience`, iOS optimization/design contracts, and both optimization-review provider suites pass, 21 tests total. Touched-file ESLint is clean. Full-repo `tsc` retains the existing unrelated test-contract errors. No deployment or production write was performed.
 
 ## 2026-08-05 — WP-70: four stalled PRs landed, and two measurement defects found on the way
 

--- a/tests/contracts/ios-optimization-design-contracts.test.ts
+++ b/tests/contracts/ios-optimization-design-contracts.test.ts
@@ -27,7 +27,7 @@ function mockNextServer() {
   }));
 }
 
-function optimizationDetailSupabase() {
+function optimizationDetailSupabase(options: { appliedRunsError?: { message: string } | null } = {}) {
   return {
     auth: {
       getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
@@ -99,7 +99,10 @@ function optimizationDetailSupabase() {
                     return {
                       not() {
                         return {
-                          limit: async () => ({ data: [{ id: 'run-applied' }], error: null }),
+                          limit: async () => ({
+                            data: options.appliedRunsError ? null : [{ id: 'run-applied' }],
+                            error: options.appliedRunsError ?? null,
+                          }),
                         };
                       },
                     };
@@ -107,6 +110,116 @@ function optimizationDetailSupabase() {
                 };
               },
             };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+}
+
+function optimizationPatchSupabase() {
+  const optimizationUpdates: Array<Record<string, unknown>> = [];
+  const versionInserts: Array<Record<string, unknown>> = [];
+
+  return {
+    optimizationUpdates,
+    versionInserts,
+    auth: {
+      getUser: jest.fn().mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null }),
+    },
+    from(table: string) {
+      if (table === 'optimizations') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  eq() {
+                    return {
+                      maybeSingle: async () => ({
+                        data: {
+                          resume_id: 'resume-1',
+                          jd_id: 'jd-1',
+                          ats_score_original: 43,
+                          ats_subscores_original: null,
+                          jd_text: 'Build reliable iOS apps',
+                        },
+                        error: null,
+                      }),
+                    };
+                  },
+                };
+              },
+            };
+          },
+          update(payload: Record<string, unknown>) {
+            optimizationUpdates.push(payload);
+            return {
+              eq() {
+                return {
+                  eq: async () => ({ data: null, error: null }),
+                };
+              },
+            };
+          },
+        };
+      }
+
+      if (table === 'job_descriptions') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle: async () => ({
+                    data: { raw_text: 'Build reliable iOS apps', clean_text: null, parsed_data: null },
+                    error: null,
+                  }),
+                };
+              },
+            };
+          },
+        };
+      }
+
+      if (table === 'resumes') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle: async () => ({ data: { raw_text: 'Original resume' }, error: null }),
+                };
+              },
+            };
+          },
+        };
+      }
+
+      if (table === 'resume_versions') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  order() {
+                    return {
+                      limit() {
+                        return {
+                          maybeSingle: async () => ({ data: { version_number: 2 }, error: null }),
+                        };
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+          insert(payload: Record<string, unknown>) {
+            versionInserts.push(payload);
+            return Promise.resolve({ data: null, error: null });
           },
         };
       }
@@ -157,6 +270,78 @@ describe('iOS optimization/design contracts', () => {
     expect(payload.job_title).toBe('iOS Engineer');
     expect(payload.ats_score_after).toBe(82);
     expect(payload.ats_improvement_applied).toBe(true);
+  });
+
+  it('fails closed when ATS improvement completion state cannot be read', async () => {
+    mockNextServer();
+    const createRouteHandlerClient = jest.fn().mockResolvedValue(
+      optimizationDetailSupabase({ appliedRunsError: { message: 'temporary read failure' } })
+    );
+    jest.doMock('@/lib/supabase-server', () => ({
+      __esModule: true,
+      createRouteHandlerClient,
+    }));
+
+    const { GET } = require('@/app/api/v1/optimizations/[id]/route');
+    const response = await GET({} as any, {
+      params: Promise.resolve({ id: 'opt-1' }),
+    });
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload.ats_improvement_applied).toBe(true);
+  });
+
+  it('normalizes responsibilities before PATCH scoring and persistence', async () => {
+    mockNextServer();
+    const supabase = optimizationPatchSupabase();
+    const createRouteHandlerClient = jest.fn().mockResolvedValue(supabase);
+    const scoreOptimization = jest.fn().mockResolvedValue({
+      ats_score_original: 43,
+      ats_score_optimized: 64,
+    });
+    jest.doMock('@/lib/supabase-server', () => ({
+      __esModule: true,
+      createRouteHandlerClient,
+    }));
+    jest.doMock('@/lib/ats/integration', () => ({
+      __esModule: true,
+      scoreOptimization,
+    }));
+
+    const rewriteData = {
+      summary: 'Product leader',
+      contact: {},
+      skills: { technical: [], soft: [] },
+      experience: [{
+        title: 'Head of Product',
+        company: 'Acme',
+        achievements: [],
+        responsibilities: ['Led discovery', 'Shipped the new funnel'],
+      }],
+      education: [],
+      certifications: [],
+    };
+    const { PATCH } = require('@/app/api/v1/optimizations/[id]/route');
+    const response = await PATCH(jsonRequest({ rewrite_data: rewriteData }), {
+      params: Promise.resolve({ id: 'opt-1' }),
+    });
+
+    expect(response.status).toBe(200);
+    const normalized = expect.objectContaining({
+      experience: [expect.objectContaining({
+        achievements: ['Led discovery', 'Shipped the new funnel'],
+      })],
+    });
+    expect(scoreOptimization).toHaveBeenCalledWith(
+      expect.objectContaining({ resumeOptimizedJson: normalized })
+    );
+    expect(supabase.optimizationUpdates[0]).toEqual(
+      expect.objectContaining({ rewrite_data: normalized })
+    );
+    expect(supabase.versionInserts[0]).toEqual(
+      expect.objectContaining({ content: normalized })
+    );
   });
 
   it('renders UUID-backed templates differently and honors iOS customization keys', async () => {

--- a/tests/contracts/ios-optimization-design-contracts.test.ts
+++ b/tests/contracts/ios-optimization-design-contracts.test.ts
@@ -89,6 +89,28 @@ function optimizationDetailSupabase() {
         };
       }
 
+      if (table === 'expert_workflow_runs') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  eq() {
+                    return {
+                      not() {
+                        return {
+                          limit: async () => ({ data: [{ id: 'run-applied' }], error: null }),
+                        };
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+
       throw new Error(`Unexpected table: ${table}`);
     },
   };
@@ -134,6 +156,7 @@ describe('iOS optimization/design contracts', () => {
     });
     expect(payload.job_title).toBe('iOS Engineer');
     expect(payload.ats_score_after).toBe(82);
+    expect(payload.ats_improvement_applied).toBe(true);
   });
 
   it('renders UUID-backed templates differently and honors iOS customization keys', async () => {

--- a/tests/unit/normalize-experience.test.ts
+++ b/tests/unit/normalize-experience.test.ts
@@ -16,6 +16,8 @@ import {
   countBullets,
   BULLET_KEY_ALIASES,
 } from '@/lib/ai-optimizer/normalize-experience';
+import { normalizeOptimizedResume } from '@/lib/resume/canonicalize';
+import { renderDesignPreviewHtml } from '@/lib/design-manager/render-preview-html';
 
 describe('normalizeExperienceBullets', () => {
   it('promotes `responsibilities` into `achievements` when achievements is empty — the live WP-64 failure', () => {
@@ -182,5 +184,41 @@ describe('countBullets', () => {
     expect(countBullets({ experience: [{ achievements: ['a', 'b'] }, { achievements: ['c'] }] } as never)).toBe(3);
     expect(countBullets({} as never)).toBe(0);
     expect(countBullets({ experience: [] } as never)).toBe(0);
+  });
+});
+
+describe('WP-64 review-path compatibility', () => {
+  const responsibilitiesOnlyResume = {
+    summary: 'Product leader',
+    contact: {},
+    skills: {},
+    experience: [
+      {
+        title: 'Head of Product',
+        company: 'Acme',
+        achievements: [],
+        responsibilities: ['Led discovery', 'Shipped the new funnel'],
+      },
+    ],
+  };
+
+  it('canonicalization promotes responsibilities so review apply cannot reintroduce empty achievements', () => {
+    const normalized = normalizeOptimizedResume(responsibilitiesOnlyResume);
+
+    expect(normalized.experience[0].achievements).toEqual([
+      'Led discovery',
+      'Shipped the new funnel',
+    ]);
+  });
+
+  it('the design preview renders responsibilities-only historical rows with their content', () => {
+    const html = renderDesignPreviewHtml({
+      templateId: 'ats-clean',
+      resumeData: responsibilitiesOnlyResume,
+    });
+
+    expect(html).toContain('Head of Product');
+    expect(html).toContain('Led discovery');
+    expect(html).toContain('Shipped the new funnel');
   });
 });


### PR DESCRIPTION
## What changed

- preserve experience bullets when review canonicalization receives `responsibilities` instead of `achievements`
- render historical responsibilities-only rows in optimization detail and design previews
- return a durable `ats_improvement_applied` flag for the iOS one-pass fit experience

## Evidence

The founder's 2026-08-08 production optimization stored 5 roles with 0 achievements and 17 responsibilities. Its scores were original 43 and stored optimized 64. Three applied ATS improvement runs existed for the same optimization. Production was inspected read-only.

## Validation

- 4 targeted Jest suites, 21 tests passed
- touched-file ESLint passed
- Next.js production build passed
- full-repo TypeScript command retains only the documented pre-existing contract-test baseline errors

No production data change or deployment was performed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved résumé work highlights when experience data uses responsibilities instead of achievements.
  * Normalized edited résumé content before ATS scoring and saving.
  * Improved optimization details to accurately report whether ATS improvements were applied.
  * Maintained compatibility with previously saved résumé data.

* **Tests**
  * Added coverage for normalization, design previews, and ATS optimization status reporting.

* **Documentation**
  * Updated guidance and progress notes for résumé compatibility and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->