### PR TITLE
Guard anonymous /api/optimize callers by IP, not by a rotatable user id

### DIFF
--- a/src/app/api/optimize/route.ts
+++ b/src/app/api/optimize/route.ts
@@ -4,6 +4,13 @@ import { runOptimizePipeline } from "@/lib/ai-optimizer/optimize-pipeline";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { resolveJobDescriptionText } from "@/lib/ats/job-data-resolver";
 import { checkRateLimit, getRateLimitHeaders, RATE_LIMITS } from "@/lib/utils/rate-limit";
+import { checkRateLimit as checkPersistentRateLimit } from "@/lib/rate-limiting/check-rate-limit";
+import { getClientIP } from "@/lib/rate-limiting/get-client-ip";
+import {
+  ANONYMOUS_OPTIMIZE_ENDPOINT,
+  ANONYMOUS_OPTIMIZE_LIMIT,
+  requiresAnonymousRateLimit,
+} from "@/lib/rate-limiting/anonymous-optimize-limit";
 import { logger } from "@/lib/agent/utils/logger";
 import { createOptimizationReviewRun } from "@/lib/optimization-review/service";
 
@@ -16,6 +23,54 @@ export async function POST(req: NextRequest) {
 
   if (!user) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Anonymous callers can rotate `user.id` at will, so the per-user limit below
+  // does not bind for them. Guard on IP instead — see
+  // `@/lib/rate-limiting/anonymous-optimize-limit` for why signed-in users are
+  // exempt and why this stays inert until anonymous sign-ins are enabled.
+  //
+  // Uses the Supabase-backed limiter, not `checkRateLimit` from
+  // `@/lib/utils/rate-limit`: that one is an in-memory Map, so it is
+  // per-instance and resets on restart, which makes it useless as an abuse
+  // control on serverless. This is the same limiter `/api/public/ats-check`
+  // already relies on.
+  if (requiresAnonymousRateLimit(user)) {
+    const ip = getClientIP(req);
+    try {
+      const anonymousLimit = await checkPersistentRateLimit(
+        ip,
+        ANONYMOUS_OPTIMIZE_ENDPOINT,
+        ANONYMOUS_OPTIMIZE_LIMIT,
+      );
+
+      if (!anonymousLimit.allowed) {
+        const retryAfter = Math.max(
+          1,
+          Math.ceil((anonymousLimit.resetAt.getTime() - Date.now()) / 1000),
+        );
+        return NextResponse.json(
+          { error: "Free optimization limit reached. Create an account to keep going." },
+          {
+            status: 429,
+            headers: {
+              "Retry-After": retryAfter.toString(),
+              "X-RateLimit-Limit": ANONYMOUS_OPTIMIZE_LIMIT.maxRequests.toString(),
+              "X-RateLimit-Remaining": "0",
+            },
+          },
+        );
+      }
+    } catch (error) {
+      // Fail closed. This is the most expensive endpoint in the app, and an
+      // outage in the limiter must not become an open door on it. Matches the
+      // posture `/api/public/ats-check` already takes on the same failure.
+      logger.error("[optimize] anonymous rate limit check failed", { error });
+      return NextResponse.json(
+        { error: "Service temporarily unavailable. Please try again." },
+        { status: 503 },
+      );
+    }
   }
 
   let resumeId: string | undefined;

--- a/src/lib/rate-limiting/anonymous-optimize-limit.ts
+++ b/src/lib/rate-limiting/anonymous-optimize-limit.ts
@@ -1,0 +1,41 @@
+import type { RateLimitConfig } from './check-rate-limit';
+
+/**
+ * Abuse ceiling for anonymous optimize traffic, keyed on IP.
+ *
+ * Why this exists: an anonymous Supabase user holds a real `auth.uid()`, so the
+ * per-user limit on `/api/optimize` (`optimize:${user.id}`) is bypassed by
+ * simply minting another anonymous identity. IP is the only identifier an
+ * anonymous caller cannot cheaply rotate.
+ *
+ * Sized deliberately: the product-level guest cap is 5 exports/month and is
+ * enforced client-side in `UserDefaults`, which is a conversion nudge, not an
+ * abuse control. This ceiling sits well above any legitimate single-person day
+ * so it only ever catches farming, never a real person iterating on a couple of
+ * resumes.
+ */
+export const ANONYMOUS_OPTIMIZE_LIMIT: RateLimitConfig = {
+  maxRequests: 20,
+  windowMs: 24 * 60 * 60 * 1000,
+};
+
+/** Endpoint key for the `rate_limits` table. Distinct from the public ATS check. */
+export const ANONYMOUS_OPTIMIZE_ENDPOINT = 'optimize-anonymous';
+
+/**
+ * Whether a request should be held to the anonymous IP ceiling.
+ *
+ * Signed-in users are exempt on purpose: IP-limiting them would punish everyone
+ * behind a shared NAT — an office, a university, carrier CGNAT — for one heavy
+ * neighbour, and they already carry a stable per-user limit that they cannot
+ * rotate away from.
+ *
+ * Returns false when the flag is absent, which is the state on a project with
+ * anonymous sign-ins disabled. That makes this guard inert until the toggle is
+ * turned on, so it can land before the toggle rather than after it.
+ */
+export function requiresAnonymousRateLimit(
+  user: { is_anonymous?: boolean } | null | undefined,
+): boolean {
+  return user?.is_anonymous === true;
+}

--- a/tests/api/anonymous-optimize-limit.test.ts
+++ b/tests/api/anonymous-optimize-limit.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The guard that stops an anonymous caller farming /api/optimize.
+ *
+ * An anonymous Supabase user holds a real auth.uid(), which is what lets them
+ * through the route's `getUser()` check at all — and it is also why the
+ * existing per-user limit (`optimize:${user.id}`) does not bind for them: a
+ * fresh anonymous identity is free. IP is the identifier they cannot rotate.
+ */
+
+import {
+  ANONYMOUS_OPTIMIZE_ENDPOINT,
+  ANONYMOUS_OPTIMIZE_LIMIT,
+  requiresAnonymousRateLimit,
+} from '@/lib/rate-limiting/anonymous-optimize-limit';
+
+describe('who the anonymous optimize ceiling applies to', () => {
+  it('guards an anonymous user', () => {
+    expect(requiresAnonymousRateLimit({ is_anonymous: true })).toBe(true);
+  });
+
+  it('exempts a signed-in user', () => {
+    // IP-limiting real users would punish an entire office or carrier CGNAT
+    // range for one heavy neighbour, and they already carry a per-user limit
+    // they cannot rotate away from.
+    expect(requiresAnonymousRateLimit({ is_anonymous: false })).toBe(false);
+  });
+
+  it('stays inert while anonymous sign-ins are disabled', () => {
+    // With the Supabase toggle off the flag is simply absent. The guard must
+    // read that as "not anonymous" so it can ship before the toggle is flipped
+    // rather than having to land in the same change.
+    expect(requiresAnonymousRateLimit({})).toBe(false);
+    expect(requiresAnonymousRateLimit(undefined)).toBe(false);
+    expect(requiresAnonymousRateLimit(null)).toBe(false);
+  });
+
+  it('does not treat a truthy non-true value as anonymous', () => {
+    // Guards against a provider returning a string; only a real boolean counts.
+    expect(requiresAnonymousRateLimit({ is_anonymous: 'yes' } as never)).toBe(false);
+  });
+});
+
+describe('how the ceiling is sized', () => {
+  it('sits well above the product-level guest cap', () => {
+    // The 5/month guest export cap is a client-side conversion nudge, not an
+    // abuse control. This ceiling must never be the thing a real person hits,
+    // so it has to clear that cap by a wide margin.
+    const PRODUCT_GUEST_CAP = 5;
+    expect(ANONYMOUS_OPTIMIZE_LIMIT.maxRequests).toBeGreaterThan(PRODUCT_GUEST_CAP * 2);
+  });
+
+  it('caps farming to a bounded number per IP per day', () => {
+    expect(ANONYMOUS_OPTIMIZE_LIMIT.windowMs).toBe(24 * 60 * 60 * 1000);
+    // Without an upper bound this stops being a control at all.
+    expect(ANONYMOUS_OPTIMIZE_LIMIT.maxRequests).toBeLessThanOrEqual(50);
+  });
+
+  it('books against its own endpoint key', () => {
+    // Sharing a key with the public ATS check would let free score checks eat
+    // the optimize budget and vice versa.
+    expect(ANONYMOUS_OPTIMIZE_ENDPOINT).toBe('optimize-anonymous');
+    expect(ANONYMOUS_OPTIMIZE_ENDPOINT).not.toBe('ats-check');
+  });
+});


### PR DESCRIPTION
## What

Adds an IP-keyed abuse ceiling for **anonymous** callers on `/api/optimize`. Prerequisite for enabling Supabase anonymous sign-in, which is how guests will reach the optimize pipeline at all.

## Why

This route limits on `optimize:${user.id}`:

```ts
const rateKey = `optimize:${user.id}`;
const rateResult = checkRateLimit(rateKey, RATE_LIMITS.ai);
```

An anonymous Supabase user holds a real `auth.uid()` — that's precisely what lets them past `getUser()` and through the `auth.uid() = user_id` RLS policies. It also means they can mint a fresh `user.id` for free, so the per-user limit stops binding the moment anonymous sign-ins are enabled. IP is the one identifier an anonymous caller cannot cheaply rotate.

The product-level guest cap (5/month) lives in iOS `UserDefaults` — a conversion nudge, not an abuse control. This is the actual control.

## Design decisions

**Anonymous only.** Signed-in users are exempt. IP-limiting them would punish an entire office, university, or carrier CGNAT range for one heavy neighbour, and they already carry a per-user limit they can't rotate away from.

**Supabase-backed limiter, not the in-memory one.** The route's existing `checkRateLimit` (`@/lib/utils/rate-limit`) is an in-memory `Map` — per-instance, resets on restart, useless as an abuse control on serverless. This uses `@/lib/rate-limiting/check-rate-limit`, the DB-backed limiter `/api/public/ats-check` already relies on (`increment_rate_limit` RPC, confirmed present on the project).

**Fails closed.** An outage in the limiter must not become an open door on the most expensive endpoint in the app. Matches the posture `ats-check` already takes.

**Ships before the toggle.** With anonymous sign-ins disabled, `is_anonymous` is never true, so this is inert today. Deliberate — it means the guard is already in place when the toggle flips, rather than racing it.

**20 per IP per 24h.** Well above any legitimate single-person day (so it never catches a real user iterating on a couple of resumes), bounded enough to stop farming.

## Verification

- 7 new tests, all passing (`tests/api/anonymous-optimize-limit.test.ts`).
- `tsc --noEmit`: unchanged at the documented 23 baseline errors across 5 pre-existing test files, **none in `src/`**.
- `eslint` clean on all three touched files.

## Follow-up

Enabling Authentication → Sign In / Providers → **Anonymous sign-ins** is the next step and is what activates this. Context and the full safety analysis are in the iOS repo spec (`docs/superpowers/specs/2026-08-10-funnel-ending-design.md`, Risk 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IP-based protection for anonymous optimization requests, allowing up to 20 requests per 24 hours.
  * Rate-limited requests now return clear retry and limit information.
  * Anonymous protection applies only to explicitly anonymous users.

* **Bug Fixes**
  * Added safe handling for rate-limiter failures, returning a temporary service-unavailable response instead of processing requests without protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->