### PR TITLE
Stop clients writing their own credit balance and plan tier

### DIFF
--- a/supabase/migrations/20260811093000_lock_down_profiles_and_credit_ledger_writes.sql
+++ b/supabase/migrations/20260811093000_lock_down_profiles_and_credit_ledger_writes.sql
@@ -1,0 +1,43 @@
+-- Close two confirmed privilege-escalation holes.
+--
+-- Proven by live probe on 2026-08-11 with an ordinary `authenticated` JWT
+-- against production, using only the public anon key that ships in the app:
+--   * PATCH /rest/v1/profiles            -> credit_balance set to 9999 (HTTP 200, persisted)
+--   * POST  /rest/v1/credit_transactions -> forged 9999 ledger row      (HTTP 201)
+-- `plan_type` and `role` live on the same profiles row and gate premium
+-- features (see the `plan_type === 'premium'` checks in the chat and
+-- expert-workflow routes), so the same PATCH also granted entitlements.
+--
+-- Root cause: anon and authenticated held Supabase's default blanket
+-- INSERT/UPDATE/DELETE/TRUNCATE grants on both tables, and the RLS policies
+-- were permissive `{public}` policies keyed only on `auth.uid() = user_id` --
+-- which authorises writing your OWN row, including the columns that represent
+-- money. RLS cannot restrict columns, so the grant is the correct control.
+-- TRUNCATE bypasses RLS altogether and was also granted.
+--
+-- Pre-existing, not introduced by anonymous sign-in: any of the 35 real users
+-- could always have done this. Enabling anonymous auth would have made it free
+-- and unlimited (mint identities via curl, no account required), which is how
+-- it was found.
+--
+-- Safe because nothing legitimate writes these tables from a client:
+--   * `updateProfile` / `createProfile` in src/lib/supabase/auth.ts are dead
+--     code with zero call sites.
+--   * iOS never touches either table directly; it goes through API routes.
+--   * Every server-side usage is a .select(); the only writers are SECURITY
+--     DEFINER functions owned by postgres (`consume_credit`, `handle_new_user`),
+--     which bypass both RLS and grants. Verified by running consume_credit
+--     after this migration: balance moved 3 -> 2 as expected.
+-- SELECT is deliberately retained; RLS already scopes it to the caller's row.
+--
+-- Verified after applying, same three requests: all now 403 "permission denied",
+-- while a legitimate read of one's own profile still returns 200.
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.profiles FROM anon, authenticated;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.credit_transactions FROM anon, authenticated;
+
+-- Drop the policies that authorised those writes, so the intent is readable in
+-- the schema rather than surviving as dead permissions a future GRANT re-arms.
+DROP POLICY IF EXISTS "Users can update own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can insert own profile" ON public.profiles;
+DROP POLICY IF EXISTS "Users can insert own credit transactions" ON public.credit_transactions;

--- a/supabase/migrations/20260811093100_revoke_client_writes_on_design_templates_catalog.sql
+++ b/supabase/migrations/20260811093100_revoke_client_writes_on_design_templates_catalog.sql
@@ -1,0 +1,21 @@
+-- Defence in depth for the design template catalogue.
+--
+-- Not an open hole: its RLS write policies already require
+-- `auth.role() = 'service_role'`, so client writes are denied today. But the
+-- default blanket INSERT/UPDATE/DELETE/TRUNCATE grants to anon/authenticated
+-- are still present, which means a single future policy edit -- or a permissive
+-- policy added for an unrelated reason -- silently re-opens catalogue tampering
+-- (flipping `is_premium` to false unlocks paid templates for everyone).
+--
+-- This is a shared catalogue with no `user_id`: nothing client-side writes it,
+-- and every legitimate write is service_role. Removing the grant makes the
+-- policy the second line of defence rather than the only one.
+-- TRUNCATE is included because it bypasses RLS entirely.
+--
+-- Found by a sweep for tables that combine client write grants with a
+-- privileged column. The sweep's other hits were false positives: `plans`,
+-- `applications`, `optimizations`, `chat_sessions` and `conversation_messages`
+-- all carry a `status`/`role` column but are user-owned rows correctly scoped
+-- by RLS, where writing your own row is the intended behaviour.
+
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.design_templates FROM anon, authenticated;


### PR DESCRIPTION
## What

Two migrations, already applied to production, now committed so the schema history reflects reality.

## The hole

Any authenticated user could set their own `credit_balance`, `plan_type` and `role` by PATCHing `/rest/v1/profiles` directly, using only the public anon key that ships in the app binary. Proven against production:

| attack | before | after |
|---|---|---|
| `PATCH profiles` → `credit_balance: 9999` | **200, persisted** | **403** |
| `PATCH profiles` → `plan_type: premium` | would have worked | **403** |
| `POST credit_transactions` → forged 9999 row | **201** | **403** |
| read own profile (legitimate) | 200 | **200** |
| `consume_credit` RPC | works | **works** (3 → 2) |

`plan_type === 'premium'` gates features in the chat and expert-workflow routes, so this was an entitlement bypass as well as a credit one.

## Root cause: a grant, not a policy

`anon` and `authenticated` held Supabase's default blanket `INSERT/UPDATE/DELETE/TRUNCATE` on both tables. The RLS policies were permissive `{public}` policies keyed only on `auth.uid() = user_id` — which authorises writing **your own row**, including the columns that represent money. RLS cannot restrict columns, so the grant is the correct control. `TRUNCATE` bypasses RLS entirely and was also granted.

## Pre-existing, and how it surfaced

All 35 real users could always have done this. It came up while verifying Supabase anonymous sign-in, which would have made it free and unlimited — mint identities via curl, no account required. **The anonymous toggle is currently off pending this fix.**

## Why revoking is safe

- `updateProfile` / `createProfile` in `src/lib/supabase/auth.ts` are dead code with zero call sites.
- iOS never writes these tables; it goes through API routes.
- Every server-side usage is a `.select()`.
- The only real writers are `SECURITY DEFINER` functions owned by `postgres` (`consume_credit`, `handle_new_user`), which bypass both RLS and grants — verified by running `consume_credit` after the migration.
- `SELECT` is retained; RLS already scopes it to the caller's row.

## Second migration

`design_templates` is **not** an open hole — its RLS write policies already require `auth.role() = 'service_role'`. But the blanket grant remains, so one future policy edit would silently re-open catalogue tampering (`is_premium`). Defence in depth.

## Audit sweep

Swept every `public` table combining client write grants with a privileged column. Other hits were false positives: `plans`, `applications`, `optimizations`, `chat_sessions`, `conversation_messages` all carry `status`/`role` columns but are user-owned rows correctly scoped by RLS, where writing your own row is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened data protection by preventing client-side changes to profiles, credit transactions, and design template catalogs.
  * Preserved read access while restricting write operations to authorized server-side processes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->