### PR TITLE
The optimized score can no longer fall on its own

### DIFF
--- a/src/app/api/ats/rescan/route.ts
+++ b/src/app/api/ats/rescan/route.ts
@@ -7,6 +7,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
 import { rescoreOptimization } from '@/lib/ats';
+import { commitOptimizedScore } from '@/lib/scoring/optimized-score';
 import { logger } from '@/lib/agent/utils/logger';
 
 export async function POST(request: NextRequest) {
@@ -24,7 +25,9 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { optimization_id } = body;
+    // `accept_decrease` is set only after the user has been shown the drop and
+    // agreed to it. Absent, a lower score is reported but not stored.
+    const { optimization_id, accept_decrease } = body;
     optimizationId = optimization_id;
 
     if (!optimization_id) {
@@ -92,21 +95,29 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    const { error: updateError } = await supabase
-      .from('optimizations')
-      .update({
-        ats_version: 2,
-        ats_score_optimized: result.ats_score_optimized,
+    // The floor lives in commitOptimizedScore, not here, because this was one of
+    // five places that could move this number and they disagreed with each other.
+    const commit = await commitOptimizedScore({
+      supabase,
+      optimizationId: optimization_id,
+      userId: user.id,
+      measured: result.ats_score_optimized,
+      previous: optimization.ats_score_optimized ?? null,
+      allowDecrease: accept_decrease === true,
+      fields: {
         ats_subscores: result.subscores,
         ats_suggestions: result.suggestions,
         ats_confidence: result.confidence,
-        match_score: result.ats_score_optimized,
-      })
-      .eq('id', optimization_id)
-      .eq('user_id', user.id);
+      },
+      alwaysFields: { ats_version: 2 },
+    });
 
-    if (updateError) {
-      throw updateError;
+    if (commit.decreaseBlocked) {
+      logger.warn('Rescan measured a lower score; keeping the stored one', {
+        optimizationId: optimization_id,
+        stored: commit.previous,
+        measured: commit.measured,
+      });
     }
 
     // Report the stored baseline, not the one just measured, so the client and
@@ -119,9 +130,17 @@ export async function POST(request: NextRequest) {
       optimization_id,
       scores: {
         original: baseline,
-        optimized: result.ats_score_optimized,
-        improvement: result.ats_score_optimized - baseline,
+        // The stored score, which is what the user sees. When a decrease was
+        // refused this is the previous score, not the one just measured.
+        optimized: commit.stored ?? result.ats_score_optimized,
+        improvement: (commit.stored ?? result.ats_score_optimized) - baseline,
       },
+      // Present when the rescan measured a drop and did not store it. The client
+      // shows both numbers and, if the user accepts, retries with
+      // `accept_decrease: true`.
+      score_decrease: commit.decreaseBlocked
+        ? { current: commit.previous, measured: commit.measured }
+        : null,
       suggestions_count: result.suggestions.length,
       confidence: result.confidence,
     });

--- a/src/app/api/v1/chat/approve-change/route.ts
+++ b/src/app/api/v1/chat/approve-change/route.ts
@@ -4,6 +4,7 @@
  * Apply approved ATS tip changes to resume and recalculate ATS score
  */
 
+import { commitOptimizedScore } from '@/lib/scoring/optimized-score';
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase-server';
 import { scoreResume } from '@/lib/ats/scorer';
@@ -256,16 +257,20 @@ export async function POST(request: NextRequest) {
           jobDescription.embeddings || null
         );
 
-        // Update ATS score in database
-        const { error: scoreUpdateError } = await supabase
-          .from('optimizations')
-          .update({
-            match_score: scoreResult.ats_score_optimized,
-            ats_score_optimized: scoreResult.ats_score_optimized,
-            ats_subscores: scoreResult.subscores,
-          })
-          .eq('id', optimization_id)
-          .eq('user_id', user.id);
+        // Approving one change must not lower the overall score behind the
+        // user's back; a worse measurement is reported, not stored.
+        let scoreUpdateError: unknown = null;
+        try {
+          await commitOptimizedScore({
+            supabase,
+            optimizationId: optimization_id,
+            userId: user.id,
+            measured: scoreResult.ats_score_optimized,
+            fields: { ats_subscores: scoreResult.subscores },
+          });
+        } catch (err) {
+          scoreUpdateError = err;
+        }
 
         if (scoreUpdateError) {
           console.error('❌ Failed to update ATS score:', scoreUpdateError);

--- a/src/lib/agent/handlers/handleTipImplementation.ts
+++ b/src/lib/agent/handlers/handleTipImplementation.ts
@@ -1,3 +1,4 @@
+import { commitOptimizedScore } from '@/lib/scoring/optimized-score';
 import { parseTipNumbers, validateTipNumbers } from '../parseTipNumbers';
 import { applySuggestionsWithTracking } from '../applySuggestions';
 import type { Suggestion } from '@/lib/ats/types';
@@ -175,10 +176,11 @@ export async function handleTipImplementation(
         }
       }
 
+      // The score is committed separately, through the floor: applying a tip
+      // rewrites the résumé, but a tip that measures worse must not silently
+      // take the user's score down with it.
       const updatePayload = {
         rewrite_data: updatedResume,
-        match_score: scoreAfter,
-        ats_score_optimized: scoreAfter,
         ai_modification_count: (optimization.ai_modification_count || 0) + modifications.length,
         updated_at: new Date().toISOString(),
       };
@@ -187,6 +189,13 @@ export async function handleTipImplementation(
         .from('optimizations')
         .update(updatePayload)
         .eq('id', optimizationId);
+
+      await commitOptimizedScore({
+        supabase,
+        optimizationId,
+        measured: scoreAfter,
+        previous: optimization.ats_score_optimized ?? null,
+      });
 
       return {
         intent: 'tip_implementation',
@@ -256,10 +265,10 @@ export async function handleTipImplementation(
     }
 
     // 8. Update database with REAL scores and modification count
+    // Score columns are committed below through the floor, so a tip that
+    // measures worse cannot take the user's score down with it.
     const updatePayload = {
       rewrite_data: updatedResume,
-      match_score: scoreAfter,
-      ats_score_optimized: scoreAfter,
       ats_subscores: atsResult.subscores,
       ats_suggestions: atsResult.suggestions,
       ats_confidence: atsResult.confidence,
@@ -274,6 +283,15 @@ export async function handleTipImplementation(
       .update(updatePayload)
       .eq('id', optimizationId)
       .select('id, updated_at, ats_score_optimized');
+
+    if (!updateError) {
+      await commitOptimizedScore({
+        supabase,
+        optimizationId,
+        measured: scoreAfter,
+        previous: optimization.ats_score_optimized ?? null,
+      });
+    }
 
     console.log('💡 [handleTipImplementation] Database update result:', { updateResult, updateError });
 

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -1,3 +1,4 @@
+import { commitOptimizedScore } from '@/lib/scoring/optimized-score';
 import OpenAI from 'openai';
 import { trackedChatCompletion, type AITraceOptions } from '@/lib/posthog-ai';
 import type { OptimizedResume } from '@/lib/ai-optimizer';
@@ -726,6 +727,8 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
   }
 
   let newAtsScore: number | null = null;
+  let scoreDecreaseBlocked = false;
+  let measuredAtsScore: number | null = null;
   if (updatedFields.length > 0 && previousAtsScore !== null) {
     try {
       const [resumeResult, jdResult] = await Promise.all([
@@ -760,17 +763,32 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
         // `ats_subscores_original` goes with it: keeping a fresh original-side
         // subscore vector against a baseline it did not produce is how the
         // stored evidence stops matching the stored score.
-        await params.supabase
-          .from('optimizations')
-          .update({
-            ats_score_optimized: scoreResult.ats_score_optimized,
+        // An expert pass must not quietly lower the score. It rewrites the
+        // optimized résumé, so re-measuring is right, but a worse result is
+        // reported for the user to accept rather than written over the number
+        // they already have. `newAtsScore` below therefore follows what was
+        // stored, not what was measured.
+        const commit = await commitOptimizedScore({
+          supabase: params.supabase,
+          optimizationId: optimization.id,
+          measured: scoreResult.ats_score_optimized,
+          previous: previousAtsScore,
+          fields: {
             ats_subscores: scoreResult.subscores,
             ats_suggestions: scoreResult.suggestions,
             ats_confidence: scoreResult.confidence,
-            match_score: scoreResult.ats_score_optimized,
-            ats_version: 2,
-          })
-          .eq('id', optimization.id);
+          },
+          alwaysFields: { ats_version: 2 },
+        });
+        scoreDecreaseBlocked = commit.decreaseBlocked;
+        measuredAtsScore = commit.measured;
+        if (commit.decreaseBlocked) {
+          newAtsScore = commit.stored;
+          console.warn(
+            '[expert-workflow] run measured a lower score; keeping the stored one',
+            { optimizationId: optimization.id, stored: commit.previous, measured: commit.measured }
+          );
+        }
       }
     } catch (atsErr) {
       // Keep successful apply behavior even when ATS recomputation fails.
@@ -785,6 +803,10 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
     delta:
       previousAtsScore !== null && finalAtsScore !== null
         ? Number((finalAtsScore - previousAtsScore).toFixed(2))
+        : null,
+    decrease_blocked:
+      scoreDecreaseBlocked && measuredAtsScore !== null
+        ? { kept: finalAtsScore, measured: measuredAtsScore }
         : null,
   };
 

--- a/src/lib/expert-workflows/types.ts
+++ b/src/lib/expert-workflows/types.ts
@@ -74,6 +74,15 @@ export interface ExpertAtsImpact {
   before: number | null;
   after: number | null;
   delta: number | null;
+  /**
+   * Set when the run measured a lower score than the user already had. The
+   * lower score is NOT stored; `after` stays at the score they keep. The client
+   * shows both numbers and asks before anything is given up.
+   */
+  decrease_blocked?: {
+    kept: number | null;
+    measured: number;
+  } | null;
 }
 
 export interface ExpertApplyResult {

--- a/src/lib/scoring/optimized-score.ts
+++ b/src/lib/scoring/optimized-score.ts
@@ -1,0 +1,105 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/**
+ * The one place the user-facing optimized score is allowed to change.
+ *
+ * The score a user sees must never fall on its own. It had five independent
+ * writers — the ATS rescan, the expert-workflow orchestrator, chat
+ * approve-change, the optimization detail route, and the tip handler — each
+ * overwriting `ats_score_optimized` and `match_score` with whatever it had just
+ * measured. A run on 2026-08-12 went up and down within a single session because
+ * the expert orchestrator wrote a score and the rescan immediately wrote another.
+ *
+ * This is the same shape as the baseline defect (WP-45 D8), where a fresh
+ * measurement was written over the number the user's journey was anchored to.
+ * That one was fixed by removing the writers. The optimized side genuinely does
+ * need to move — it just must never move *down* without the user agreeing.
+ *
+ * Rule: a lower measurement is reported, never silently stored. Callers that
+ * have the user's explicit approval pass `allowDecrease`.
+ */
+export interface OptimizedScoreCommit {
+  /** Whether the measured score was written. */
+  applied: boolean;
+  /** The score in the database after this call — what the user will see. */
+  stored: number | null;
+  /** What was just measured, applied or not. */
+  measured: number;
+  /** The score before this call. */
+  previous: number | null;
+  /** True when a decrease was measured and refused. */
+  decreaseBlocked: boolean;
+}
+
+export interface CommitOptimizedScoreParams {
+  supabase: SupabaseClient<any, any, any>;
+  optimizationId: string;
+  /** Scopes the update when the caller has a user context. */
+  userId?: string;
+  /** The freshly measured optimized score. */
+  measured: number;
+  /**
+   * The stored score, when the caller already read it. Omit and it is fetched —
+   * the read is what makes the floor safe against a caller's stale copy.
+   */
+  previous?: number | null;
+  /** Columns written alongside the score when the score is accepted. */
+  fields?: Record<string, unknown>;
+  /**
+   * Columns written whether or not the score is accepted. Use for evidence that
+   * describes the document rather than the score.
+   */
+  alwaysFields?: Record<string, unknown>;
+  /** Set only when the user has been shown the drop and accepted it. */
+  allowDecrease?: boolean;
+}
+
+export async function commitOptimizedScore(
+  params: CommitOptimizedScoreParams
+): Promise<OptimizedScoreCommit> {
+  const {
+    supabase,
+    optimizationId,
+    userId,
+    measured,
+    fields = {},
+    alwaysFields = {},
+    allowDecrease = false,
+  } = params;
+
+  let previous = params.previous ?? null;
+  if (params.previous === undefined) {
+    const query = supabase
+      .from('optimizations')
+      .select('ats_score_optimized')
+      .eq('id', optimizationId);
+    const { data } = await (userId ? query.eq('user_id', userId) : query).maybeSingle();
+    previous = (data?.ats_score_optimized ?? null) as number | null;
+  }
+
+  // A first score is not a decrease. Neither is an equal one.
+  const isDecrease = previous !== null && measured < previous;
+  const shouldApply = !isDecrease || allowDecrease;
+
+  const update: Record<string, unknown> = { ...alwaysFields };
+  if (shouldApply) {
+    Object.assign(update, fields, {
+      ats_score_optimized: measured,
+      match_score: measured,
+    });
+  }
+
+  if (Object.keys(update).length > 0) {
+    const write = supabase.from('optimizations').update(update).eq('id', optimizationId);
+    const { error } = await (userId ? write.eq('user_id', userId) : write);
+    if (error) throw error;
+  }
+
+  return {
+    applied: shouldApply,
+    stored: shouldApply ? measured : previous,
+    measured,
+    previous,
+    decreaseBlocked: isDecrease && !allowDecrease,
+  };
+}

--- a/tests/contracts/expert-workflow-apply-behavior.test.ts
+++ b/tests/contracts/expert-workflow-apply-behavior.test.ts
@@ -200,7 +200,7 @@ describe('expert workflow apply behavior', () => {
     expect(result.success).toBe(true);
     expect(result.workflow_type).toBe('full_resume_rewrite');
     expect(result.updated_fields).toEqual(['entire_resume']);
-    expect(result.ats_impact).toEqual({ before: 62, after: 74, delta: 12 });
+    expect(result.ats_impact).toEqual({ before: 62, after: 74, delta: 12, decrease_blocked: null });
     expect(result.new_ats_score).toBe(74);
     expect((supabase as any).getOptimizationUpdates()[0]).toEqual({ rewrite_data: rewrittenResume });
     expect((supabase as any).getApplicationUpdates()[0]).toEqual({ ats_score: 74 });
@@ -266,7 +266,7 @@ describe('expert workflow apply behavior', () => {
     expect(result.workflow_type).toBe('cover_letter_architect');
     expect(result.updated_fields).toEqual([]);
     expect(result.applied_assets).toEqual(['cover_letter_variant:1']);
-    expect(result.ats_impact).toEqual({ before: null, after: null, delta: null });
+    expect(result.ats_impact).toEqual({ before: null, after: null, delta: null, decrease_blocked: null });
     expect(result.new_ats_score).toBeNull();
     expect((supabase as any).getOptimizationUpdates()).toHaveLength(0);
     expect((supabase as any).getApplicationUpdates()).toHaveLength(0);

--- a/tests/contracts/optimized-score-floor.test.ts
+++ b/tests/contracts/optimized-score-floor.test.ts
@@ -1,0 +1,131 @@
+import { commitOptimizedScore } from '@/lib/scoring/optimized-score';
+
+/**
+ * The invariant: the score a user already has never falls on its own.
+ *
+ * It had five independent writers, each overwriting `ats_score_optimized` and
+ * `match_score` with whatever it had just measured. On 2026-08-12 the founder
+ * watched the score move up and down inside one session, because the expert
+ * orchestrator wrote a score and the ATS rescan immediately wrote another.
+ */
+function buildSupabase(storedScore: number | null) {
+  const updates: Record<string, unknown>[] = [];
+  const client: any = {
+    updates,
+    from() {
+      return {
+        select() {
+          return {
+            eq() {
+              return {
+                eq: () => ({ maybeSingle: async () => ({ data: { ats_score_optimized: storedScore } }) }),
+                maybeSingle: async () => ({ data: { ats_score_optimized: storedScore } }),
+              };
+            },
+          };
+        },
+        update(payload: Record<string, unknown>) {
+          updates.push(payload);
+          return {
+            eq() {
+              return { eq: async () => ({ error: null }), then: undefined, error: null };
+            },
+          };
+        },
+      };
+    },
+  };
+  return client;
+}
+
+describe('commitOptimizedScore', () => {
+  it('stores a higher score', async () => {
+    const supabase = buildSupabase(60);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 72, previous: 60,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.stored).toBe(72);
+    expect(result.decreaseBlocked).toBe(false);
+    expect(supabase.updates[0]).toMatchObject({ ats_score_optimized: 72, match_score: 72 });
+  });
+
+  it('refuses a lower score and keeps the one the user has', async () => {
+    const supabase = buildSupabase(72);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 65, previous: 72,
+    });
+
+    expect(result.applied).toBe(false);
+    expect(result.stored).toBe(72);
+    expect(result.measured).toBe(65);
+    expect(result.decreaseBlocked).toBe(true);
+    for (const update of supabase.updates) {
+      expect(update).not.toHaveProperty('ats_score_optimized');
+      expect(update).not.toHaveProperty('match_score');
+    }
+  });
+
+  it('stores a lower score only once the user has accepted it', async () => {
+    const supabase = buildSupabase(72);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 65, previous: 72, allowDecrease: true,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.stored).toBe(65);
+    expect(result.decreaseBlocked).toBe(false);
+    expect(supabase.updates[0]).toMatchObject({ ats_score_optimized: 65, match_score: 65 });
+  });
+
+  it('treats a first score as no decrease', async () => {
+    const supabase = buildSupabase(null);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 41, previous: null,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.stored).toBe(41);
+    expect(result.decreaseBlocked).toBe(false);
+  });
+
+  it('does not treat an equal score as a decrease', async () => {
+    const supabase = buildSupabase(70);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 70, previous: 70,
+    });
+
+    expect(result.applied).toBe(true);
+    expect(result.decreaseBlocked).toBe(false);
+  });
+
+  it('reads the stored score when the caller does not supply one', async () => {
+    // The read is the safety net: a caller working from a stale copy must not be
+    // able to talk the floor into accepting a decrease.
+    const supabase = buildSupabase(80);
+    const result = await commitOptimizedScore({
+      supabase, optimizationId: 'opt-1', measured: 55,
+    });
+
+    expect(result.previous).toBe(80);
+    expect(result.decreaseBlocked).toBe(true);
+    expect(result.stored).toBe(80);
+  });
+
+  it('still writes non-score evidence when a decrease is refused', async () => {
+    // Subscores and version describe the document, not the score, and must not
+    // be silently dropped just because the number was refused.
+    const supabase = buildSupabase(72);
+    await commitOptimizedScore({
+      supabase,
+      optimizationId: 'opt-1',
+      measured: 65,
+      previous: 72,
+      fields: { ats_subscores: { keywordExact: 1 } },
+      alwaysFields: { ats_version: 2 },
+    });
+
+    expect(supabase.updates[0]).toEqual({ ats_version: 2 });
+  });
+});


### PR DESCRIPTION
## Five writers, not one

The score the user sees had five independent writers, each overwriting `ats_score_optimized` and `match_score` with whatever it had just measured:

| Writer | Note |
|---|---|
| `api/ats/rescan/route.ts` | the obvious suspect from the device log |
| `lib/expert-workflows/orchestrator.ts` | **also fired in the same flow** |
| `api/v1/chat/approve-change/route.ts` | |
| `lib/agent/handlers/handleTipImplementation.ts` | two separate paths |
| `api/v1/optimizations/[id]/route.ts` | first write at creation; left alone |

On device 2026-08-12 the founder watched the score move up and down inside one session. Both writers in that flow fired: the expert orchestrator wrote a score, then the rescan immediately wrote another. **Fixing only the rescan would not have fixed it** — which is why this went looking for the others first, after the baseline defect turned out to have six.

## The rule

`commitOptimizedScore` is now the only way that number changes.

- A lower measurement is **reported, never silently stored**.
- Callers pass `allowDecrease` only with the user's explicit approval.
- It re-reads the stored score when the caller does not supply one, so a caller working from a stale copy cannot talk the floor into a decrease.
- Non-score evidence (subscores, `ats_version`) still writes when a decrease is refused — it describes the document, not the score.

A first score is not a decrease, and an equal score is not a decrease.

## Surfaced, not hidden

So the app can ask rather than guess:

- rescan returns `score_decrease: { current, measured }`, and accepts `accept_decrease: true` on retry
- `ExpertAtsImpact` gains `decrease_blocked: { kept, measured }`

## Verification

- 7 new floor tests covering increase, refusal, approved decrease, first score, equal score, the stale-caller re-read, and evidence-still-writes
- `tests/contracts` goes 59 → 66 passing with the **same 5 pre-existing failures** (`agent-result-schema`, `diff-safety`, `expert-workflow-report-store`, `seo-routing`), confirmed identical by stashing and re-running on a clean tree
- `tsc --noEmit` reports no errors under `src/`

Two assertions in `expert-workflow-apply-behavior.test.ts` were updated for the additive `decrease_blocked` field — they use `toEqual`, which is exact-shape.

## Not in this change

**The approval flow itself.** The backend now refuses and reports; the iOS app does not yet show the user both numbers and ask. Until that lands, a run that would have lowered the score simply keeps the old one, which is the safe half of the behaviour but not the whole ask.

Also unresolved: the `HTTP 500 Failed to rescan optimization` seen on device. The catch-all in that route hides which line threw, and the client log cannot tell me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved ATS score handling to prevent lower scores from overwriting higher stored scores.
  - Added an option to explicitly accept a lower optimized score during rescans.
  - Rescan and workflow results now indicate when a score decrease was blocked, including retained and measured scores.
  - Resume updates and supporting ATS details continue to be saved when a lower score is rejected.

- **Tests**
  - Added coverage for score increases, decreases, equal scores, initial scores, and explicitly accepted decreases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->