### PR TITLE
Refuse a score-reducing expert run instead of apologising for it

### DIFF
--- a/src/app/api/v1/expert-workflows/runs/[id]/apply/route.ts
+++ b/src/app/api/v1/expert-workflows/runs/[id]/apply/route.ts
@@ -18,6 +18,9 @@ export async function POST(
     ? body.selected_fields.filter((value: unknown) => typeof value === 'string')
     : undefined;
 
+  // Set only after the user has been shown the drop and chosen to apply anyway.
+  const acceptScoreDecrease = body.accept_score_decrease === true;
+
   const supabase = await createRouteHandlerClient();
   const {
     data: { user },
@@ -55,6 +58,7 @@ export async function POST(
       selectionIndex,
       selectedIndices,
       selectedFields,
+      acceptScoreDecrease,
     });
 
     await captureServerEvent(user.id, 'expert_mode_apply_completed', {

--- a/src/lib/expert-workflows/orchestrator.ts
+++ b/src/lib/expert-workflows/orchestrator.ts
@@ -43,6 +43,12 @@ type ApplyWorkflowParams = {
   selectionIndex?: number;
   selectedIndices?: number[];
   selectedFields?: string[];
+  /**
+   * Set only after the user has been shown that this run would lower their
+   * match score and has chosen to apply it anyway. Without it a score-reducing
+   * run writes nothing at all.
+   */
+  acceptScoreDecrease?: boolean;
 };
 
 type RunRow = {
@@ -715,20 +721,24 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
     stories.forEach((_, index) => appliedAssets.push(`story:${index}`));
   }
 
-  if (updatedFields.length > 0) {
-    const { error: updateError } = await params.supabase
-      .from('optimizations')
-      .update({ rewrite_data: updatedResume })
-      .eq('id', optimization.id);
-
-    if (updateError) {
-      throw new Error(updateError.message || 'Failed to apply expert workflow output.');
-    }
-  }
-
+  // Score the candidate résumé BEFORE anything is persisted.
+  //
+  // This used to write `rewrite_data` first and score afterwards, which made a
+  // score drop unactionable: by the time the number was known the résumé had
+  // already been rewritten, and there is no revert for résumé content (only
+  // design has one; `approve-change/route.ts` still carries the TODO for a
+  // `resume_versions` snapshot). The user could be told their score fell but
+  // not offered anything to do about it.
+  //
+  // Scoring first turns the refusal into a real choice: when a run would lower
+  // the score and the user has not accepted it, nothing is written at all —
+  // not the résumé, not the score — and both numbers come back so the app can
+  // ask. Approving re-runs this with `acceptScoreDecrease`.
   let newAtsScore: number | null = null;
   let scoreDecreaseBlocked = false;
   let measuredAtsScore: number | null = null;
+  let scoreResultForCommit: Awaited<ReturnType<typeof scoreOptimization>> | null = null;
+
   if (updatedFields.length > 0 && previousAtsScore !== null) {
     try {
       const [resumeResult, jdResult] = await Promise.all([
@@ -749,6 +759,10 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
         });
 
         newAtsScore = scoreResult.ats_score_optimized;
+        measuredAtsScore = scoreResult.ats_score_optimized;
+        scoreResultForCommit = scoreResult;
+        scoreDecreaseBlocked =
+          scoreResult.ats_score_optimized < previousAtsScore && params.acceptScoreDecrease !== true;
 
         // `ats_score_original` is deliberately absent from this update.
         //
@@ -763,37 +777,71 @@ export async function applyExpertWorkflowRun(params: ApplyWorkflowParams): Promi
         // `ats_subscores_original` goes with it: keeping a fresh original-side
         // subscore vector against a baseline it did not produce is how the
         // stored evidence stops matching the stored score.
-        // An expert pass must not quietly lower the score. It rewrites the
-        // optimized résumé, so re-measuring is right, but a worse result is
-        // reported for the user to accept rather than written over the number
-        // they already have. `newAtsScore` below therefore follows what was
-        // stored, not what was measured.
-        const commit = await commitOptimizedScore({
-          supabase: params.supabase,
-          optimizationId: optimization.id,
-          measured: scoreResult.ats_score_optimized,
-          previous: previousAtsScore,
-          fields: {
-            ats_subscores: scoreResult.subscores,
-            ats_suggestions: scoreResult.suggestions,
-            ats_confidence: scoreResult.confidence,
-          },
-          alwaysFields: { ats_version: 2 },
-        });
-        scoreDecreaseBlocked = commit.decreaseBlocked;
-        measuredAtsScore = commit.measured;
-        if (commit.decreaseBlocked) {
-          newAtsScore = commit.stored;
-          console.warn(
-            '[expert-workflow] run measured a lower score; keeping the stored one',
-            { optimizationId: optimization.id, stored: commit.previous, measured: commit.measured }
-          );
+        if (scoreDecreaseBlocked) {
+          // Report the score the user keeps, not the one just measured.
+          newAtsScore = previousAtsScore;
+          console.warn('[expert-workflow] run would lower the score; nothing applied', {
+            optimizationId: optimization.id,
+            current: previousAtsScore,
+            measured: scoreResult.ats_score_optimized,
+          });
         }
       }
     } catch (atsErr) {
-      // Keep successful apply behavior even when ATS recomputation fails.
+      // Keep successful apply behavior even when ATS recomputation fails. A run
+      // we could not score is not a run we know to be worse, so it applies.
       console.error('[expert-workflow] ATS rescoring failed for optimization', optimization.id, atsErr);
     }
+  }
+
+  // Nothing has been persisted yet. A refused run stops here, leaving the
+  // résumé and the score exactly as the user left them, and reports both
+  // numbers so the app can ask whether to apply it anyway.
+  if (scoreDecreaseBlocked && measuredAtsScore !== null) {
+    return {
+      success: false,
+      workflow_type: runRow.workflow_type,
+      updated_fields: [],
+      applied_assets: [],
+      new_ats_score: previousAtsScore,
+      ats_impact: {
+        before: previousAtsScore,
+        after: previousAtsScore,
+        delta: 0,
+        decrease_blocked: { kept: previousAtsScore, measured: measuredAtsScore },
+      },
+      apply_mode: applyMode,
+      selection_index: selectionIndex,
+    };
+  }
+
+  if (updatedFields.length > 0) {
+    const { error: updateError } = await params.supabase
+      .from('optimizations')
+      .update({ rewrite_data: updatedResume })
+      .eq('id', optimization.id);
+
+    if (updateError) {
+      throw new Error(updateError.message || 'Failed to apply expert workflow output.');
+    }
+  }
+
+  if (scoreResultForCommit) {
+    // allowDecrease is true because the decision was already made above: either
+    // the score did not fall, or the user accepted that it would.
+    await commitOptimizedScore({
+      supabase: params.supabase,
+      optimizationId: optimization.id,
+      measured: scoreResultForCommit.ats_score_optimized,
+      previous: previousAtsScore,
+      allowDecrease: true,
+      fields: {
+        ats_subscores: scoreResultForCommit.subscores,
+        ats_suggestions: scoreResultForCommit.suggestions,
+        ats_confidence: scoreResultForCommit.confidence,
+      },
+      alwaysFields: { ats_version: 2 },
+    });
   }
 
   const finalAtsScore = previousAtsScore === null ? null : newAtsScore ?? previousAtsScore;

--- a/tests/contracts/expert-workflow-apply-behavior.test.ts
+++ b/tests/contracts/expert-workflow-apply-behavior.test.ts
@@ -212,6 +212,112 @@ describe('expert workflow apply behavior', () => {
     });
   });
 
+  it('applies nothing when the run would lower the score', async () => {
+    // The whole point of scoring before writing. There is no revert for résumé
+    // content, so a run that measures worse must leave the document and the
+    // score exactly as the user left them, and report both numbers so the app
+    // can ask. Writing first and apologising later is what this replaces.
+    const { applyExpertWorkflowRun, scoreOptimization } = loadApplyHarness();
+    scoreOptimization.mockResolvedValue({
+      ats_score_original: 55,
+      ats_score_optimized: 51,
+      subscores: {},
+      subscores_original: {},
+      suggestions: [],
+      confidence: 'high',
+    });
+
+    const supabase = buildSupabaseMock({
+      runResult: {
+        data: {
+          id: 'run-1',
+          user_id: 'user-1',
+          optimization_id: 'opt-1',
+          workflow_type: 'full_resume_rewrite',
+          output_json: { rewritten_resume: { summary: 'Worse summary' } },
+        },
+        error: null,
+      },
+      optimizationResult: {
+        data: {
+          id: 'opt-1',
+          rewrite_data: { summary: 'Old summary' },
+          resume_id: 'resume-1',
+          jd_id: 'jd-1',
+          ats_score_optimized: 62,
+          match_score: 62,
+        },
+        error: null,
+      },
+      resumeResult: { data: { raw_text: 'Original resume text' }, error: null },
+      jobDescriptionResult: {
+        data: { raw_text: 'JD raw', clean_text: 'JD clean', title: 'Engineer' },
+        error: null,
+      },
+    });
+
+    const result = await applyExpertWorkflowRun({ supabase, userId: 'user-1', runId: 'run-1' });
+
+    expect(result.success).toBe(false);
+    expect(result.updated_fields).toEqual([]);
+    expect(result.new_ats_score).toBe(62);
+    expect(result.ats_impact.decrease_blocked).toEqual({ kept: 62, measured: 51 });
+    expect((supabase as any).getOptimizationUpdates()).toHaveLength(0);
+  });
+
+  it('applies the lower score once the user has accepted it', async () => {
+    const { applyExpertWorkflowRun, scoreOptimization } = loadApplyHarness();
+    scoreOptimization.mockResolvedValue({
+      ats_score_original: 55,
+      ats_score_optimized: 51,
+      subscores: {},
+      subscores_original: {},
+      suggestions: [],
+      confidence: 'high',
+    });
+
+    const rewritten = { summary: 'Worse summary' };
+    const supabase = buildSupabaseMock({
+      runResult: {
+        data: {
+          id: 'run-1',
+          user_id: 'user-1',
+          optimization_id: 'opt-1',
+          workflow_type: 'full_resume_rewrite',
+          output_json: { rewritten_resume: rewritten },
+        },
+        error: null,
+      },
+      optimizationResult: {
+        data: {
+          id: 'opt-1',
+          rewrite_data: { summary: 'Old summary' },
+          resume_id: 'resume-1',
+          jd_id: 'jd-1',
+          ats_score_optimized: 62,
+          match_score: 62,
+        },
+        error: null,
+      },
+      resumeResult: { data: { raw_text: 'Original resume text' }, error: null },
+      jobDescriptionResult: {
+        data: { raw_text: 'JD raw', clean_text: 'JD clean', title: 'Engineer' },
+        error: null,
+      },
+    });
+
+    const result = await applyExpertWorkflowRun({
+      supabase,
+      userId: 'user-1',
+      runId: 'run-1',
+      acceptScoreDecrease: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.ats_impact.decrease_blocked).toBeNull();
+    expect((supabase as any).getOptimizationUpdates()[0]).toEqual({ rewrite_data: rewritten });
+  });
+
   it('stores selected assets and keeps ATS impact null-safe for non-resume workflows', async () => {
     const { applyExpertWorkflowRun, scoreOptimization } = loadApplyHarness();
 


### PR DESCRIPTION
Backend half of the approval gate.

## The problem with fixing this in the app

The apply path wrote `rewrite_data` and scored afterwards. By the time a drop was known the résumé had already been rewritten — and **there is no revert for résumé content**. Only design has one; `approve-change/route.ts` still carries the TODO for a `resume_versions` snapshot. So a prompt at that point could only say "your score fell, accept it?", which is not a choice.

## Score first, write second

`scoreOptimization` already took the candidate résumé from memory, so this is a reorder rather than new work.

When a run would lower the score and the user has not accepted it, **nothing is written at all** — not the résumé, not the score — and both numbers come back as `ats_impact.decrease_blocked: { kept, measured }`. Declining costs the user nothing, because nothing happened.

`accept_score_decrease` on the apply route re-runs it with the decision made.

A run that fails to score still applies: a run we could not measure is not a run we know to be worse.

## Verification

7 tests in `expert-workflow-apply-behavior` pass, including two new ones — a reducing run writes nothing, and the same run applies once accepted. `tests/contracts` holds at 66 passing with the same 5 pre-existing failures. No errors under `src/`.

Pairs with iOS [#165](https://github.com/nadavyigal/ResumeBuilder-IOS-APP/pull/165), which shows the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added protection against applying résumé changes that lower the measured ATS score.
  * Users can explicitly approve score-reducing changes when desired.
  * Declined changes report both the retained score and the newly measured score.

* **Bug Fixes**
  * Ensured résumé updates and score records remain unchanged when a score decrease is not approved.
  * Improved the order of scoring and saving to prevent inconsistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->