### PR TITLE
WP-49: tie a converted anonymous check to the optimization it produced

### DIFF
--- a/src/app/api/v1/optimization-reviews/[id]/apply/route.ts
+++ b/src/app/api/v1/optimization-reviews/[id]/apply/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createRouteHandlerClient } from "@/lib/supabase-server";
+import { createRouteHandlerClient, createServiceRoleClient } from "@/lib/supabase-server";
 import {
   applyOptimizationReviewRun,
   getOptimizationReviewRun,
@@ -35,6 +35,9 @@ export async function POST(
 
     const result = await applyOptimizationReviewRun({
       supabase,
+      // The carryover link is written under RLS that only lets an *unclaimed*
+      // row be updated, so the request client cannot do it (WP-49).
+      serviceRole: createServiceRoleClient(),
       userId: user.id,
       reviewRun,
       approvedGroupIds,

--- a/src/lib/anonymous-carryover.ts
+++ b/src/lib/anonymous-carryover.ts
@@ -31,6 +31,13 @@ export type CarryoverArtifacts = {
   jobDescriptionId: string | null;
 };
 
+export type CarryoverOptimizationLink = {
+  userId: string;
+  resumeId: string | null;
+  jobDescriptionId: string | null;
+  optimizationId: string;
+};
+
 const CARRIED_RESUME_FILENAME = 'ats-check-resume.pdf';
 
 /** Columns that exist once migration 20260720000000 is applied. */
@@ -191,5 +198,71 @@ export async function materializeAnonymousCarryover(
   } catch (error) {
     console.error('Anonymous carryover materialization error:', error);
     return { resumeId: null, jobDescriptionId: null };
+  }
+}
+
+/**
+ * Tie a converted anonymous check to the optimization its artifacts produced.
+ *
+ * `anonymous_ats_scores.optimization_id` has existed since the table was
+ * created and has never been written, so a carried-over session could run all
+ * the way to a finished résumé and the two ends could not be joined. The
+ * feature's contribution to activation was therefore unmeasurable even when it
+ * worked — the same defect class as WP-48 S2-A on iOS, where a funnel step had
+ * no join key and every rate built on it was guesswork.
+ *
+ * Matched on the owner **and** both artifact ids. `resume_id` /
+ * `job_description_id` are written only by `materializeAnonymousCarryover`, so
+ * nothing but a genuinely carried-over session can match, and an ordinary
+ * upload can never be miscounted as a carryover.
+ *
+ * `optimization_id is null` keeps the attribution on the **first** optimization
+ * the carried artifacts produced. Re-optimizing the same résumé against the
+ * same job would otherwise keep moving the link, and the activation would be
+ * dated by the most recent run rather than the one that converted the user.
+ * It also makes a replayed apply idempotent.
+ *
+ * **Must be called with a service-role client.** The table's RLS update policy
+ * is `using (user_id is null)` — it exists to let an anonymous row be claimed at
+ * signup — so once the row is converted a user-scoped client matches zero rows.
+ * PostgREST reports that as success with an empty result, so passing the request
+ * client here would silently record nothing and look like it worked.
+ *
+ * Best-effort, like the rest of this module: the optimization row already exists
+ * by the time this runs, so throwing would fail an apply that has already
+ * succeeded in order to protect a measurement.
+ *
+ * @returns whether a row was actually linked.
+ */
+export async function linkCarryoverOptimization(
+  serviceRole: SupabaseClient,
+  { userId, resumeId, jobDescriptionId, optimizationId }: CarryoverOptimizationLink,
+): Promise<boolean> {
+  // Nothing was carried, so there is nothing this optimization could belong to.
+  if (!resumeId || !jobDescriptionId) {
+    return false;
+  }
+
+  try {
+    const { data, error } = await serviceRole
+      .from('anonymous_ats_scores')
+      .update({ optimization_id: optimizationId })
+      .eq('user_id', userId)
+      .eq('resume_id', resumeId)
+      .eq('job_description_id', jobDescriptionId)
+      .is('optimization_id', null)
+      .select('id');
+
+    if (error) {
+      console.error('Anonymous carryover optimization link failed:', error);
+      return false;
+    }
+
+    // Zero rows is the ordinary case: most optimizations have no anonymous
+    // check behind them at all.
+    return (data?.length ?? 0) > 0;
+  } catch (error) {
+    console.error('Anonymous carryover optimization link error:', error);
+    return false;
   }
 }

--- a/src/lib/optimization-review/service.ts
+++ b/src/lib/optimization-review/service.ts
@@ -1,4 +1,5 @@
 import type { OptimizedResume } from "@/lib/ai-optimizer";
+import { linkCarryoverOptimization } from "@/lib/anonymous-carryover";
 import { captureServerEvent } from "@/lib/posthog-server";
 import { scoreOptimization } from "@/lib/ats/integration";
 import {
@@ -49,6 +50,15 @@ interface CreateReviewRunParams {
 
 interface ApplyReviewRunParams {
   supabase: AppSupabaseClient;
+  /**
+   * Service-role client, used only to tie a converted anonymous check to the
+   * optimization this apply mints (WP-49).
+   *
+   * Required rather than optional on purpose: the link is the only thing that
+   * makes the carryover countable, and an optional parameter is exactly how a
+   * second caller would silently stop recording it.
+   */
+  serviceRole: AppSupabaseClient;
   userId: string;
   reviewRun: OptimizationReviewRun;
   approvedGroupIds: string[];
@@ -178,6 +188,7 @@ function stringifyValue(value: unknown): string | null {
 
 export async function applyOptimizationReviewRun({
   supabase,
+  serviceRole,
   userId,
   reviewRun,
   approvedGroupIds,
@@ -361,9 +372,21 @@ export async function applyOptimizationReviewRun({
     throw new Error(reviewUpdateError.message || "Failed to mark the review as applied.");
   }
 
+  // If this optimization grew out of a converted anonymous check, record that
+  // on the anonymous row. Best-effort: the optimization already exists, so a
+  // failure here costs a measurement, not the user's résumé.
+  const carriedFromAnonymous = await linkCarryoverOptimization(serviceRole, {
+    userId,
+    resumeId: reviewRun.resume_id,
+    jobDescriptionId: reviewRun.jd_id,
+    optimizationId: optimization.id,
+  });
+
   await captureServerEvent(userId, "optimization_completed", {
     optimization_id: optimization.id,
     review_id: reviewRun.id,
+    // Lets the carryover cohort be split in PostHog without a warehouse join.
+    carried_from_anonymous: carriedFromAnonymous,
     ats_score_original: finalATSPreview?.before ?? reviewRun.ats_preview_json?.before ?? null,
     ats_score_optimized: finalATSPreview?.after ?? reviewRun.ats_preview_json?.after ?? null,
     improvement:

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -405,7 +405,7 @@ export interface Database {
           resume_hash: string;
           job_description_hash: string;
           user_id: string | null;
-          optimization_id: number | null;
+          optimization_id: string | null;
           converted_at: string | null;
           created_at: string;
           expires_at: string;
@@ -427,7 +427,7 @@ export interface Database {
           resume_hash: string;
           job_description_hash: string;
           user_id?: string | null;
-          optimization_id?: number | null;
+          optimization_id?: string | null;
           converted_at?: string | null;
           created_at?: string;
           expires_at?: string;
@@ -449,7 +449,7 @@ export interface Database {
           resume_hash?: string;
           job_description_hash?: string;
           user_id?: string | null;
-          optimization_id?: number | null;
+          optimization_id?: string | null;
           converted_at?: string | null;
           created_at?: string;
           expires_at?: string;

--- a/tests/lib/anonymous-carryover.test.ts
+++ b/tests/lib/anonymous-carryover.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
+  linkCarryoverOptimization,
   materializeAnonymousCarryover,
   type AnonymousCarryoverRow,
 } from '@/lib/anonymous-carryover';
@@ -143,5 +144,144 @@ describe('materializeAnonymousCarryover', () => {
     expect(result).toEqual({ resumeId: null, jobDescriptionId: null });
     // The row is never linked, so the score still carries over on its own.
     expect(serviceRole.updates).toHaveLength(0);
+  });
+});
+
+type LinkFilter = { op: string; column: string; value: unknown };
+type LinkCall = { table: string; values: Record<string, unknown>; filters: LinkFilter[] };
+
+function createLinkClient(
+  result: { data?: Array<{ id: number }> | null; error?: { message: string } | null } = {},
+) {
+  const calls: LinkCall[] = [];
+
+  const client = {
+    calls,
+    from: jest.fn((table: string) => ({
+      update: jest.fn((values: Record<string, unknown>) => {
+        const call: LinkCall = { table, values, filters: [] };
+        calls.push(call);
+        const builder: Record<string, unknown> = {
+          eq: jest.fn((column: string, value: unknown) => {
+            call.filters.push({ op: 'eq', column, value });
+            return builder;
+          }),
+          is: jest.fn((column: string, value: unknown) => {
+            call.filters.push({ op: 'is', column, value });
+            return builder;
+          }),
+          select: jest.fn(async () => ({
+            data: result.data === undefined ? [{ id: 1 }] : result.data,
+            error: result.error ?? null,
+          })),
+        };
+        return builder;
+      }),
+    })),
+  };
+
+  return client;
+}
+
+/**
+ * The join that makes the carryover countable.
+ *
+ * An anonymous check that converts and then produces an optimization is the
+ * whole point of WP-49, and without this link the two ends cannot be tied
+ * together — so the feature's contribution to the activation number is
+ * unmeasurable even when the feature works perfectly, which it now does.
+ */
+describe('linkCarryoverOptimization', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('stamps the optimization onto the anonymous check whose artifacts produced it', async () => {
+    const serviceRole = createLinkClient();
+
+    const linked = await linkCarryoverOptimization(serviceRole as any, {
+      userId: 'user-1',
+      resumeId: 'resume-1',
+      jobDescriptionId: 'jd-1',
+      optimizationId: 'opt-1',
+    });
+
+    expect(linked).toBe(true);
+
+    const call = serviceRole.calls[0];
+    expect(call.table).toBe('anonymous_ats_scores');
+    expect(call.values).toEqual({ optimization_id: 'opt-1' });
+    // Matched on the owner AND both artifacts: those two columns are written
+    // only by materializeAnonymousCarryover, so nothing except a genuinely
+    // carried-over session can match.
+    expect(call.filters).toEqual(
+      expect.arrayContaining([
+        { op: 'eq', column: 'user_id', value: 'user-1' },
+        { op: 'eq', column: 'resume_id', value: 'resume-1' },
+        { op: 'eq', column: 'job_description_id', value: 'jd-1' },
+      ]),
+    );
+  });
+
+  it('attributes the anonymous check to the first optimization it produced, not the latest', async () => {
+    const serviceRole = createLinkClient();
+
+    await linkCarryoverOptimization(serviceRole as any, {
+      userId: 'user-1',
+      resumeId: 'resume-1',
+      jobDescriptionId: 'jd-1',
+      optimizationId: 'opt-2',
+    });
+
+    // Without this guard, re-optimizing the same carried résumé would keep
+    // moving the link and the activation would be dated by the most recent run.
+    expect(serviceRole.calls[0].filters).toContainEqual({
+      op: 'is',
+      column: 'optimization_id',
+      value: null,
+    });
+  });
+
+  it('writes nothing when the optimization did not come from a carried session', async () => {
+    const serviceRole = createLinkClient();
+
+    const linked = await linkCarryoverOptimization(serviceRole as any, {
+      userId: 'user-1',
+      resumeId: null,
+      jobDescriptionId: null,
+      optimizationId: 'opt-1',
+    });
+
+    expect(linked).toBe(false);
+    expect(serviceRole.calls).toHaveLength(0);
+  });
+
+  it('reports not linked, without throwing, when the stamp fails', async () => {
+    const serviceRole = createLinkClient({ data: null, error: { message: 'permission denied' } });
+
+    // The optimization row already exists by this point. Throwing here would
+    // fail an apply that has already succeeded, to protect a measurement.
+    await expect(
+      linkCarryoverOptimization(serviceRole as any, {
+        userId: 'user-1',
+        resumeId: 'resume-1',
+        jobDescriptionId: 'jd-1',
+        optimizationId: 'opt-1',
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('reports not linked when the user never had an anonymous check', async () => {
+    const serviceRole = createLinkClient({ data: [] });
+
+    await expect(
+      linkCarryoverOptimization(serviceRole as any, {
+        userId: 'user-1',
+        resumeId: 'resume-1',
+        jobDescriptionId: 'jd-1',
+        optimizationId: 'opt-1',
+      }),
+    ).resolves.toBe(false);
   });
 });


### PR DESCRIPTION
## The gap

`anonymous_ats_scores.optimization_id` has existed since the table was created on **2025-12-25** and has **never once been written**.

So a carried-over session could run the whole way — anonymous check → signup → one-click optimize → finished résumé — and the two ends could not be joined. WP-49's contribution to the activation number was unmeasurable *even when the feature worked perfectly*, which as of the 2026-08-14 live verification it does.

Same defect class as WP-48 S2-A on iOS: a funnel step with no join key, and every rate built on top of it guesswork.

## The fix

`linkCarryoverOptimization` stamps the optimization onto the anonymous row when the review is applied.

**Matched on the owner AND both artifact ids.** `resume_id` / `job_description_id` are written only by `materializeAnonymousCarryover`, so nothing but a genuinely carried-over session can match — an ordinary upload can never be miscounted as a carryover.

**`optimization_id is null` keeps the attribution on the first optimization** the carried artifacts produced. Without it, re-optimizing the same résumé against the same job would keep moving the link and the activation would be dated by the most recent run rather than the one that converted the user. It also makes a replayed apply idempotent.

`optimization_completed` now also carries `carried_from_anonymous`, so the cohort can be split in PostHog without a warehouse join.

## Three things this had to get right, each of which fails silently

**1. It must use the service role.** The table's RLS update policy is `using (user_id is null)` — it exists so an anonymous row can be *claimed* at signup — so once the row is converted a user-scoped client matches **zero rows**. PostgREST reports that as success with an empty result. Passing the request client here would have recorded nothing and looked like it worked.

**2. `serviceRole` is a required field of `ApplyReviewRunParams`, not optional.** An optional parameter is exactly how a second caller would silently stop recording the link. TypeScript now refuses to compile a caller that omits it.

**3. `database.ts` typed `optimization_id` as `number | null` while the column is `uuid`.** Any correct write would have failed type-checking — plausibly why this was never wired up in the first place. Fixed to `string | null` across the Row/Insert/Update shapes.

## Evidence

**Red first:** the 5 new tests failed with `linkCarryoverOptimization is not a function`.

| Gate | Result |
|---|---|
| `tests/lib/anonymous-carryover.test.ts` | **10/10 passed** |
| Four carryover suites together | **20/20 passed** |
| `tsc --noEmit` | **0 errors in `src/`** |
| `eslint` on every touched file | clean, exit 0 |

**Full-suite control run.** 16 failed suites / 76 failed tests on the **clean tree**, and 16 / 76 with this change — identical. Those are Playwright e2e specs that jest picks up; pre-existing and unrelated. Passing tests go **373 → 378**, the five added here.

Committed with `--no-verify` per the documented pre-commit hang; the scanner was run standalone against the staged diff first (exit 0).

## Scope

Covers the review-apply path, which is the carryover path — the dashboard's one-click CTA goes to `/api/optimize`, which always returns a `reviewId`, and `applyOptimizationReviewRun` is the only place an `optimizations` row is minted from a review. If a direct optimize path that skips review is ever added, it needs the same call.

## Not covered

No test exercises `applyOptimizationReviewRun` end to end — this repo has no harness for it, and building one is a much larger piece of work than this fix. The plumbing is guaranteed by the required parameter (compile-time), and the behaviour by the unit tests; what is not machine-checked is that the call sits in the right place in that function. Worth one production check on the next real carryover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
