### PR TITLE
The anonymous check has never extracted job data (job_title null, no fit verdict)

### DIFF
--- a/src/app/api/public/ats-check/route.ts
+++ b/src/app/api/public/ats-check/route.ts
@@ -12,6 +12,7 @@ import { isPdfUpload } from '@/lib/utils/pdf-validation';
 import { scrapeJobDescription } from '@/lib/job-scraper';
 import { extractJob } from '@/lib/scraper/jobExtractor';
 import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
+import { extractJobData } from '@/lib/ats/extractors/jd-extractor';
 import {
   buildPublicAtsCheckResponse,
   type FitSource,
@@ -169,18 +170,25 @@ export async function POST(request: NextRequest) {
   const jobHash = hashContent(jobDescription);
   const supabase = createServiceRoleClient();
 
-  // Extract job data from job description for better quick wins
+  // Extract job data from the job description TEXT.
+  //
+  // This used to call `extractJob`, the URL scraper, whose very first statement
+  // is `new URL(url)`. By this point `jobDescription` is always text — the URL
+  // path resolves the posting further up and hands the text down — so that call
+  // threw `TypeError: Invalid URL` on every ordinary paste, the catch below
+  // swallowed it, and `jobData` stayed `DEFAULT_JOB_DATA`. Two consequences:
+  // `job_title` was written null, so a converted user's carried job read
+  // "Job Position at Company Name"; and every free score was computed with no
+  // extracted requirements at all.
+  //
+  // (A description beginning "Position: ..." parses as a URL with the scheme
+  // `position:` and then failed a page fetch instead — same outcome, different
+  // exception, which is part of why this read as environmental.)
   let jobData: JobExtraction = DEFAULT_JOB_DATA;
   try {
-    const extractedJob = await extractJob(jobDescription);
-    const requirements = extractedJob.requirements || [];
-    if (requirements.length > 0) {
-      jobData = {
-        title: extractedJob.job_title || '',
-        must_have: requirements,
-        nice_to_have: extractedJob.nice_to_have || [],
-        responsibilities: extractedJob.responsibilities || [],
-      };
+    const extracted = extractJobData(jobDescription);
+    if (extracted.must_have.length > 0 || extracted.title) {
+      jobData = extracted;
       console.log('✅ Extracted job data:', {
         title: jobData.title,
         must_have_count: jobData.must_have.length,

--- a/tests/api/ats-check-carryover-persistence.test.ts
+++ b/tests/api/ats-check-carryover-persistence.test.ts
@@ -10,7 +10,39 @@ const longJobDescription = Array(24)
   .fill('Senior product engineer role requiring SwiftUI, TypeScript, analytics, experimentation, collaboration, and shipped customer impact.')
   .join(' ');
 
-function buildResumeFormData() {
+// Deliberately starts with prose. A description beginning "Position: ..."
+// happens to parse as a URL with the scheme `position:`, which dodges the very
+// failure this test exists to pin.
+const pastedJobDescription = [
+  'We are looking for a Senior Product Engineer.',
+  '',
+  'You will own our mobile and web surfaces end to end.',
+  '',
+  'Requirements:',
+  '- 5+ years building production software with SwiftUI and TypeScript',
+  '- Experience with analytics instrumentation and experimentation',
+  '- Track record of shipping customer-facing features end to end',
+  '- Comfortable owning measurement, not just delivery',
+  '',
+  'Responsibilities:',
+  '- Ship and measure activation improvements across iOS and web',
+  '- Partner with design on funnel quality and onboarding',
+  '- Keep the analytics contract honest as the product changes',
+  '- Own the release train for both platforms and keep the funnel instrumented',
+  '- Review analytics contracts before they ship and reject unjoinable events',
+  '',
+  'Nice to have:',
+  '- Familiarity with Supabase, Postgres row level security and PostHog',
+  '- Experience with resume parsing, applicant tracking systems or search ranking',
+  '- Prior work on activation, onboarding funnels or growth engineering teams',
+  '- Comfort reading production telemetry and writing HogQL against it',
+  '',
+  'About the team: we are a small product engineering group that owns the whole',
+  'journey from the first anonymous visit through signup, optimization and export.',
+  'You will work directly with the founder on measurement quality and activation.',
+].join('\n');
+
+function buildResumeFormData(jobDescription: string = longJobDescription) {
   // jsdom's File has no arrayBuffer(), which the route needs before validation.
   const bytes = Buffer.from('%PDF-1.4 fake');
   const resumeFile = new File([bytes], 'resume.pdf', { type: 'application/pdf' });
@@ -20,7 +52,7 @@ function buildResumeFormData() {
 
   const formData = new FormData();
   formData.append('resume', resumeFile);
-  formData.append('jobDescription', longJobDescription);
+  formData.append('jobDescription', jobDescription);
   return formData;
 }
 
@@ -82,7 +114,7 @@ function createAnonymousScoreStore(options: { undefinedColumn?: boolean } = {}) 
   };
 }
 
-function loadRouteHarness(options: { undefinedColumn?: boolean } = {}) {
+function loadRouteHarness(options: { undefinedColumn?: boolean; realJobExtraction?: boolean } = {}) {
   jest.resetModules();
 
   const anonymousStore = createAnonymousScoreStore(options);
@@ -132,15 +164,28 @@ function loadRouteHarness(options: { undefinedColumn?: boolean } = {}) {
       quick_wins: [],
     })),
   }));
-  jest.doMock('@/lib/scraper/jobExtractor', () => ({
-    __esModule: true,
-    extractJob: jest.fn(async () => ({
-      job_title: 'Senior Product Engineer',
-      requirements: ['SwiftUI', 'TypeScript', 'analytics'],
-      nice_to_have: [],
-      responsibilities: [],
-    })),
-  }));
+  // This mock is why the paste path's extraction failure went unnoticed for so
+  // long: it makes the URL scraper succeed on input that is not a URL, which
+  // the real one cannot do. Tests that care about extraction must opt out.
+  //
+  // `dontMock` is required, not merely skipping the registration below:
+  // `jest.resetModules()` clears the module registry but NOT the `doMock`
+  // registrations, so a mock registered by an earlier test in this file is
+  // still in force here.
+  if (options.realJobExtraction) {
+    jest.dontMock('@/lib/scraper/jobExtractor');
+    jest.dontMock('@/lib/ats/extractors/jd-extractor');
+  } else {
+    jest.doMock('@/lib/scraper/jobExtractor', () => ({
+      __esModule: true,
+      extractJob: jest.fn(async () => ({
+        job_title: 'Senior Product Engineer',
+        requirements: ['SwiftUI', 'TypeScript', 'analytics'],
+        nice_to_have: [],
+        responsibilities: [],
+      })),
+    }));
+  }
   jest.doMock('@/lib/rate-limiting/check-rate-limit', () => ({
     __esModule: true,
     checkRateLimit: jest.fn(async () => ({
@@ -175,11 +220,44 @@ describe('POST /api/public/ats-check carryover persistence', () => {
 
     expect(response.status).toBe(200);
     expect(anonymousStore.insertPayloads).toHaveLength(1);
+    // No `job_title` assertion here on purpose. This fixture is a wall of
+    // repeated sentences with no title in it, so the real extractor correctly
+    // finds none. The old expectation of 'Senior Product Engineer' came from
+    // the mocked URL scraper, not from the text — title extraction is covered
+    // by the test below, against input that actually contains one.
     expect(anonymousStore.insertPayloads[0]).toMatchObject({
       resume_text: 'PDF resume text with SwiftUI and analytics.',
       job_description_text: longJobDescription,
-      job_title: 'Senior Product Engineer',
     });
+  });
+
+  /**
+   * The anonymous check is given a pasted job description, never a URL — the
+   * URL path resolves to text further up and hands the text down. Running the
+   * *URL* scraper over that text throws `TypeError: Invalid URL` on its very
+   * first line, the catch swallows it, and every anonymous check scores against
+   * an empty `JobExtraction`.
+   *
+   * Two consequences, one visible and one not. `job_title` is written null, so
+   * a converted user's carried job reads "Job Position at Company Name" — the
+   * first thing they see on the screen that is supposed to prove the app
+   * remembered them. And the free score itself is computed with no extracted
+   * requirements at all.
+   *
+   * Runs the real extractor deliberately. With the scraper mocked this passes
+   * while production fails.
+   */
+  it('extracts the job title from the pasted description rather than scraping it as a URL', async () => {
+    const formData = buildResumeFormData(pastedJobDescription);
+
+    const { POST, anonymousStore } = loadRouteHarness({ realJobExtraction: true });
+    const response = await POST({
+      headers: { get: () => 'session-1' },
+      formData: async () => formData,
+    } as any);
+
+    expect(response.status).toBe(200);
+    expect(anonymousStore.insertPayloads[0].job_title).toBe('Senior Product Engineer');
   });
 
   it('still returns a score when the carryover migration has not been applied', async () => {

--- a/tests/api/ats-check-resume-id-route.test.ts
+++ b/tests/api/ats-check-resume-id-route.test.ts
@@ -1,8 +1,34 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
-const longJobDescription = Array(24)
-  .fill('Senior product engineer role requiring SwiftUI, TypeScript, analytics, experimentation, collaboration, and shipped customer impact.')
-  .join(' ');
+// A realistic posting, not 24 copies of one sentence. The route now runs the
+// real text extractor, and WP-45 S4 withholds the fit verdict when the
+// extraction is thin or mostly page furniture — which a degenerate wall of
+// repeated text correctly trips. Structured input is what a user actually
+// pastes, and it is what these assertions are about.
+const longJobDescription = [
+  'We are looking for a Senior Product Engineer.',
+  '',
+  'You will own our mobile and web surfaces end to end, from the first',
+  'anonymous visit through signup, optimization and export.',
+  '',
+  'Requirements:',
+  '- 5+ years building production software with SwiftUI and TypeScript',
+  '- Experience with analytics instrumentation and experimentation',
+  '- Track record of shipping customer-facing features end to end',
+  '- Comfortable owning measurement, not just delivery',
+  '- Strong Postgres and SQL fundamentals',
+  '',
+  'Responsibilities:',
+  '- Ship and measure activation improvements across iOS and web',
+  '- Partner with design on funnel quality and onboarding',
+  '- Keep the analytics contract honest as the product changes',
+  '- Own the release train for both platforms',
+  '',
+  'Nice to have:',
+  '- Familiarity with Supabase, row level security and PostHog',
+  '- Experience with resume parsing or applicant tracking systems',
+  '- Prior work on activation, onboarding funnels or growth engineering',
+].join('\n');
 
 function buildRequest(fields: Record<string, string>, file?: File) {
   const formData = new FormData();


### PR DESCRIPTION
## This is not a dev-env artifact

The `job_title: null` / "Job Position at Company Name" symptom found during the 2026-08-14 WP-49 verification was flagged as possibly local. **It isn't.** It reproduces everywhere, for every anonymous check, and it always has.

`ats-check` calls `extractJob` — the **URL scraper**, whose first statement is `new URL(url)`. By that point `jobDescription` is always **text**: the URL path resolves the posting further up and hands the text down. So every ordinary paste throws `TypeError: Invalid URL`, the catch swallows it, and `jobData` stays `DEFAULT_JOB_DATA`.

```
new URL('We are looking for a Senior Product Engineer...')  →  TypeError: Invalid URL
new URL('Position: Senior Product Engineer...')             →  parses! scheme "position:"
```

That second case is part of why this read as environmental — a description starting `Position:` parses as a URL and then fails a *page fetch* instead, a different exception for the same outcome.

## What it cost

| | |
|---|---|
| **Visible** | `job_title` written null → a converted user's carried job reads "Job Position at Company Name", on the screen whose whole job is to prove the app remembered them |
| **Not visible** | Every free ATS score computed with `job_extracted_json` empty. WP-45 S4 then correctly withholds the fit verdict when extraction is thin — so the free check has been showing **no verdict at all** |

## The fix

A one-line swap to `extractJobData`, the text-based extractor that already exists in `@/lib/ats/extractors/jd-extractor` and returns the same `JobExtraction` shape. The name collision between `extractJob` (URL) and `extractJobData` (text) is the entire bug.

## Why the tests never caught it: they mocked the scraper

Both route suites registered a `jest.doMock` for `@/lib/scraper/jobExtractor` returning a clean extraction **for input that is not a URL** — something the real module cannot do. They asserted `job_title: 'Senior Product Engineer'` and passed, against a production path that returns `null`.

`ats-check-carryover-persistence` now runs the real extractor for the extraction test. One trap worth knowing: opting out needs `jest.dontMock`, not merely skipping the registration — **`jest.resetModules()` clears the module registry but NOT `doMock` registrations**, so a mock from an earlier test in the same file is still in force. My first "red" passed for that reason.

Two fixtures were degenerate (24 copies of one sentence) and are now realistic postings. That matters: a wall of repeated text produces a low-credibility extraction which trips the WP-45 S4 gate — correct behaviour on garbage, but it was masking what the assertions were about. The two verdict assertions in `ats-check-resume-id-route` now pass **for the right reason**: a structured posting yields credible requirements and the verdict comes back. One `job_title` assertion was dropped from the carryover test, whose fixture genuinely contains no title; extraction is covered by a test with input that has one.

## ⚠️ Measurement boundary

**This changes the free ATS score itself**, because requirements now actually reach the scorer, and the fit verdict goes from absent to present for well-formed postings. Scores before and after this deploy are **not comparable** — split on the deploy boundary, the way `optimization_completed` had to be split on 2026-08-12.

Better scores are not the goal here; *correct* ones are. But the discontinuity is real and will show up in any trend that crosses it.

## Evidence

**Red first:** with the real extractor forced, `job_title` came back `null` — the production symptom reproduced in a test.

| Gate | Result |
|---|---|
| Four carryover suites | **16/16 passed** |
| `ats-check-resume-id-route` | **5/5 passed** |
| `tsc --noEmit` | **0 errors in `src/`** |
| `eslint` on touched files | clean, exit 0 |

**Full-suite control:** 16 failed suites / 76 failed tests on the **clean tree**, and 16 / 76 with this change — identical. (An intermediate state was 17 / 78; that regression was real, traced to the WP-45 S4 gate firing on the degenerate fixture, and fixed rather than accepted.) Passing tests **373 → 374**.

Committed with `--no-verify` per the documented pre-commit hang; scanner run standalone first.

## Not covered

No production request was made — this is diagnosed from the code path and reproduced in tests. Worth one live check of a converted user's carried job title after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
