### PR TITLE
feat(analytics): give the web an is_internal_tester flag, which it never had

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@ POSTHOG_API_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Team addresses whose sessions must not count as real users in activation
+# metrics. Comma, space or newline separated. `+alias` folding is automatic, so
+# one entry covers every future name+qa-whatever@... account.
+# NEXT_PUBLIC_ because identify() runs in the browser: these are readable in the
+# client bundle, exactly as iOS ships INTERNAL_TESTER_EMAILS inside its app
+# bundle. Put nothing here that is not already public.
+NEXT_PUBLIC_INTERNAL_TESTER_EMAILS=

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import { posthog } from "@/lib/posthog";
+import { resolveInternalTester } from "@/lib/internal-tester";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -150,6 +151,7 @@ export function AuthForm({ mode }: AuthFormProps) {
             email: data.user.email,
             full_name: fullName,
             created_at: data.user.created_at,
+            is_internal_tester: resolveInternalTester(data.user.email),
             ...utmParams,
           });
 
@@ -176,6 +178,7 @@ export function AuthForm({ mode }: AuthFormProps) {
         if (data.user) {
           posthog.identify(data.user.id, {
             email: data.user.email,
+            is_internal_tester: resolveInternalTester(data.user.email),
           });
         }
 

--- a/src/components/providers/auth-provider.tsx
+++ b/src/components/providers/auth-provider.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
 import { createClientComponentClient } from "@/lib/supabase";
 import { posthog } from "@/lib/posthog";
+import { resolveInternalTester } from "@/lib/internal-tester";
 
 interface AuthContextType {
   user: User | null;
@@ -41,6 +42,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (user) {
         posthog.identify(user.id, {
           email: user.email,
+          is_internal_tester: resolveInternalTester(user.email),
         });
       }
     };
@@ -56,6 +58,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (nextUser && (event === "SIGNED_IN" || event === "INITIAL_SESSION")) {
           posthog.identify(nextUser.id, {
             email: nextUser.email,
+            is_internal_tester: resolveInternalTester(nextUser.email),
           });
         } else if (event === "SIGNED_OUT") {
           posthog.reset();

--- a/src/lib/__tests__/internal-tester.test.ts
+++ b/src/lib/__tests__/internal-tester.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The web has never had an `is_internal_tester` concept at any level. `identify`
+ * set only email, full name, created_at and UTM params, so every founder and QA
+ * session has counted as a real user in every activation number this product has
+ * ever reported. iOS fixed the same gap in 1.4.9 (21); the web never had it.
+ *
+ * Mirrors the iOS contract deliberately, including `+alias` folding, so one
+ * configured address covers every future `name+qa-whatever@…` without a redeploy
+ * and so the two platforms can be filtered the same way.
+ */
+import {
+  normalizeEmail,
+  parseInternalTesterEmails,
+  isInternalTesterEmail,
+} from '../internal-tester';
+
+describe('normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmail('  Nadav.Yigal@Gmail.com ')).toBe('nadav.yigal@gmail.com');
+  });
+
+  it('folds a +alias into its base address', () => {
+    // QA accounts here are created as plus aliases. A list naming each one drifts
+    // out of date the first time someone makes another.
+    expect(normalizeEmail('nadav.yigal+fable-qa-jul03@gmail.com')).toBe(
+      'nadav.yigal@gmail.com',
+    );
+  });
+
+  it('returns null for input that is not an address', () => {
+    expect(normalizeEmail('')).toBeNull();
+    expect(normalizeEmail(null)).toBeNull();
+    expect(normalizeEmail(undefined)).toBeNull();
+    expect(normalizeEmail('no-at-sign')).toBeNull();
+    expect(normalizeEmail('+only@gmail.com')).toBeNull();
+  });
+});
+
+describe('parseInternalTesterEmails', () => {
+  it('accepts comma, space and newline separated lists', () => {
+    const parsed = parseInternalTesterEmails('a@x.com, b@x.com\nc@x.com d@x.com');
+    expect(parsed).toEqual(new Set(['a@x.com', 'b@x.com', 'c@x.com', 'd@x.com']));
+  });
+
+  it('normalizes entries so a configured alias still matches its base', () => {
+    expect(parseInternalTesterEmails('Nadav.Yigal+qa@Gmail.com')).toEqual(
+      new Set(['nadav.yigal@gmail.com']),
+    );
+  });
+
+  it('is empty for empty or missing config', () => {
+    expect(parseInternalTesterEmails('')).toEqual(new Set());
+    expect(parseInternalTesterEmails(undefined)).toEqual(new Set());
+  });
+});
+
+describe('isInternalTesterEmail', () => {
+  const allowlist = parseInternalTesterEmails('nadav.yigal@gmail.com');
+
+  it('matches the configured address', () => {
+    expect(isInternalTesterEmail('nadav.yigal@gmail.com', allowlist)).toBe(true);
+  });
+
+  it('matches any +alias of the configured address without listing it', () => {
+    expect(isInternalTesterEmail('nadav.yigal+wp49qa@gmail.com', allowlist)).toBe(true);
+    expect(isInternalTesterEmail('nadav.yigal+anything-new@gmail.com', allowlist)).toBe(true);
+  });
+
+  it('does not match a real user', () => {
+    expect(isInternalTesterEmail('yanivshm@gmail.com', allowlist)).toBe(false);
+  });
+
+  it('does not match on a shared local part at another domain', () => {
+    expect(isInternalTesterEmail('nadav.yigal@example.com', allowlist)).toBe(false);
+  });
+
+  it('is false, never throws, for a missing address', () => {
+    expect(isInternalTesterEmail(null, allowlist)).toBe(false);
+    expect(isInternalTesterEmail(undefined, allowlist)).toBe(false);
+  });
+
+  it('is false when nothing is configured, rather than true for everyone', () => {
+    // An empty allowlist must fail closed towards "real user". The opposite
+    // would silently empty the activation cohort.
+    expect(isInternalTesterEmail('nadav.yigal@gmail.com', new Set())).toBe(false);
+  });
+});

--- a/src/lib/internal-tester.ts
+++ b/src/lib/internal-tester.ts
@@ -1,0 +1,78 @@
+/**
+ * Whether a session belongs to the team rather than to a real user.
+ *
+ * The web has never had this concept at any level. `identify` set only email,
+ * full name, created_at and UTM params, so every founder and QA session has
+ * counted as a real user in every activation number this product has reported.
+ * iOS closed the same gap in 1.4.9 (21) with `resolveInternalTester`; this is
+ * the web half, and it is deliberately the same contract so a cohort can be
+ * filtered identically on both platforms.
+ *
+ * Configure with `NEXT_PUBLIC_INTERNAL_TESTER_EMAILS` (comma, space or newline
+ * separated). It is a `NEXT_PUBLIC_` value because `identify` runs in the
+ * browser, so the addresses are readable in the client bundle. That is the same
+ * exposure iOS already accepts by shipping `INTERNAL_TESTER_EMAILS` inside the
+ * app bundle, and these are team addresses, not secrets. Never put anything
+ * here that is not already public.
+ *
+ * This flag cannot repair the past. PostHog's person-on-events snapshots
+ * properties at ingest, so events recorded before this ships keep whatever they
+ * had. It starts a clean boundary; it does not move the old one.
+ */
+
+/**
+ * Lowercased and trimmed, with any `+suffix` removed from the local part.
+ *
+ * QA accounts here are created as plus aliases, so one configured address has to
+ * cover every future `name+qa-whatever@…` without a redeploy. A list that named
+ * each one would drift out of date the first time someone made another.
+ */
+export function normalizeEmail(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex <= 0) return null;
+
+  const local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex);
+  const base = local.split('+', 1)[0];
+  if (!base) return null;
+
+  return base + domain;
+}
+
+/** Parse a comma / space / newline separated allowlist into normalized addresses. */
+export function parseInternalTesterEmails(raw: string | null | undefined): Set<string> {
+  if (!raw) return new Set();
+  const entries = raw
+    .split(/[,\s]+/)
+    .map((entry) => normalizeEmail(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return new Set(entries);
+}
+
+/**
+ * Pure membership test. Fails closed towards "real user": an unconfigured or
+ * empty allowlist returns false for everyone rather than true, because the
+ * opposite would silently empty the activation cohort instead of merely
+ * failing to clean it.
+ */
+export function isInternalTesterEmail(
+  email: string | null | undefined,
+  allowlist: Set<string>,
+): boolean {
+  if (allowlist.size === 0) return false;
+  const normalized = normalizeEmail(email);
+  if (!normalized) return false;
+  return allowlist.has(normalized);
+}
+
+/** The configured allowlist, read once per module load. */
+export function configuredInternalTesterEmails(): Set<string> {
+  return parseInternalTesterEmails(process.env.NEXT_PUBLIC_INTERNAL_TESTER_EMAILS);
+}
+
+/** Convenience wrapper used by the `identify` call sites. */
+export function resolveInternalTester(email: string | null | undefined): boolean {
+  return isInternalTesterEmail(email, configuredInternalTesterEmails());
+}

--- a/tasks/progress.md
+++ b/tasks/progress.md
@@ -1,5 +1,73 @@
 # Project Progress
 
+- Status: WP-49 follow-ups implemented; two PRs open, neither deployed
+- Current Phase: making the anonymous carryover both correct and countable
+- Active Story: none — PRs #140 and #141 await review
+- Last Completed Story: the carryover optimization join, and the job extraction that never ran
+- Next Recommended Story: give the web an `is_internal_tester` person property — it has none, so every founder and QA session counts as a real user in every activation number
+- Blockers: none. Neither fix is observable until deployed.
+- Last Validation: 2026-08-14 — 16/16 carryover suites, 5/5 resume-id route, tsc clean in src/, eslint clean; full-suite control identical to the clean tree (16 failed suites / 76 failed tests, pre-existing Playwright specs)
+- Last Updated: 2026-08-14
+
+## 2026-08-14 — The carryover works, could not be counted, and was never extracting the job
+
+**`anonymous_ats_scores.optimization_id` had never been written.** The column
+has existed since the table was created on 2025-12-25. So a carried-over
+session could run the whole way — anonymous check, signup, one-click optimize,
+finished résumé — and the two ends could not be joined. WP-49's contribution to
+activation was unmeasurable even though the 2026-08-14 live verification proved
+the feature works. Same defect class as WP-48 S2-A on iOS: a funnel step with
+no join key, and every rate built on it guesswork. PR #140.
+
+Three things that fix had to get right, each of which fails silently. It must
+use the **service role** — the table's RLS update policy is
+`using (user_id is null)`, so once a row is converted a user-scoped client
+matches zero rows and PostgREST reports that as success. `serviceRole` is a
+**required** field of `ApplyReviewRunParams`, because an optional one is exactly
+how a second caller would quietly stop recording the link. And `database.ts`
+typed `optimization_id` as `number` while the column is `uuid`, so any correct
+write would have failed type-checking — plausibly why this was never wired up.
+
+**The anonymous check has never extracted job data, anywhere.** It called
+`extractJob`, the URL scraper, whose first statement is `new URL(url)`, with the
+job description **text**. Every ordinary paste threw `TypeError: Invalid URL`,
+the catch swallowed it, and `jobData` stayed `DEFAULT_JOB_DATA`. Reported as a
+possible dev-env artifact; it is not. `job_title` was written null — hence
+"Job Position at Company Name" on a converted user's carried job — and every
+free score was computed with no requirements, so WP-45 S4 correctly withheld the
+fit verdict. PR #141.
+
+**The tests hid it by mocking the scraper.** Both route suites mocked
+`@/lib/scraper/jobExtractor` to succeed on input that is not a URL, asserted
+`job_title: 'Senior Product Engineer'`, and passed against a path returning
+null. Opting out needs `jest.dontMock`: `jest.resetModules()` clears the module
+registry but **not** `doMock` registrations, so an earlier test's mock is still
+in force. Two degenerate fixtures (24 copies of one sentence) are now realistic
+postings, which is what the WP-45 S4 credibility gate is designed for.
+
+**Measurement boundary.** PR #141 changes the free ATS score itself, because
+requirements now reach the scorer, and the fit verdict goes from absent to
+present for well-formed postings. Scores before and after that deploy are not
+comparable — split on it, the way `optimization_completed` had to be split on
+2026-08-12.
+
+**Migration history aligned.** The Supabase MCP had stamped
+`20260720000000_anonymous_carryover_artifacts.sql` as version `20260814065135`,
+so `supabase db push` would have re-run the repo file for ever. One row in
+`supabase_migrations.schema_migrations` was updated to the file's version — not
+inserted alongside, which would have left a remote-only migration with no local
+file. Verified: exactly one row, `20260720000000`. A byte-identical untracked
+Finder duplicate of the migration (`... 2.sql`) was removed from the working
+tree; `db push` reads the directory, not git.
+
+**The web has no `is_internal_tester` at all.** Not at person level, not at
+event level — `identify` sets only email, full name, created_at and UTM params.
+So the QA account created by the live verification
+(`nadav.yigal+wp49qa…@gmail.com`) counts as a real user, as does every founder
+session on the web. iOS fixed this in 1.4.9 (21); the web never had it. Until
+it does, exclude by the `email` person property, and note that `+alias` folding
+is not automatic there the way `normalizedEmail` does it on iOS.
+
 - Status: P0 WP-64 recurrence fixed locally, not deployed
 - Current Phase: Review-path bullet preservation and one-pass fit contract
 - Active Story: make responsibilities-only rows readable and expose durable ATS-improvement completion


### PR DESCRIPTION
## The gap

The web has never had this concept at any level. `identify` set only email, full name, created_at and UTM params, so **every founder and QA session has counted as a real user in every activation number this product has ever reported**. iOS closed the same gap in 1.4.9 (21); the web never had it.

## The change

`src/lib/internal-tester.ts` mirrors iOS's `resolveInternalTester` contract deliberately, including `+alias` folding, so one configured address covers every future `name+qa-whatever@…` without a redeploy and both platforms can be filtered identically. All four `identify` call sites set the property.

**Fails closed towards "real user."** An empty or unconfigured allowlist returns false for everyone rather than true. The opposite would silently empty the activation cohort instead of merely failing to clean it.

## Configuration

`NEXT_PUBLIC_INTERNAL_TESTER_EMAILS`, documented in `.env.example`. It is `NEXT_PUBLIC_` because `identify()` runs in the browser, so the addresses are readable in the client bundle. That is the same exposure iOS already accepts by shipping `INTERNAL_TESTER_EMAILS` inside its app bundle, and these are team addresses, not secrets. **The var must be set in Vercel for this to do anything.**

## What this does not do

It cannot repair the past. Person-on-events snapshots properties at ingest, so events recorded before this ships keep what they had. This starts a clean boundary; it does not move the old one. Same caveat already recorded for iOS in WP-48 S2-B.

## Verification

- 12 new tests, **watched failing first** (module absent), then passing.
- `tsc --noEmit` clean, `eslint` clean on all touched files.
- Full-suite **control on the same tree without this change is identical**: 17 failed suites / 78 failed tests, all pre-existing Playwright and contract specs. This adds 1 passing suite and 12 passing tests and regresses nothing.

## Two things found on the way, neither in this PR

1. **`main`'s test baseline moved to 17/78.** The last recorded baseline was 16 failed suites / 76 failed tests, and 17/78 was explicitly identified then as a real regression that was traced and fixed. It is back on `main` as of today's merges. Worth its own look.
2. **This checkout's `node_modules` was corrupt**, not evicted: jest died with `Class extends value undefined`, then `graceful-fs` with `polyfills is not a function`, on files that were present and non-empty. `npm ci` fixed it in 34s. A targeted `npm install` made it worse by pulling jest 30.1.3 into a 30.2.0 tree, so reach for `npm ci` here, not `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying configured internal testers in analytics.
  * Added flexible email matching, including case normalization and alias handling.
  * Added configuration documentation for internal tester email lists.

* **Bug Fixes**
  * Ensured tester identification is applied consistently during sign-up, sign-in, and session loading.
  * Invalid or missing configuration now safely excludes users from the tester group.

* **Tests**
  * Added coverage for email normalization, configuration parsing, matching, and fail-safe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->