### PR TITLE
feat(analytics): give the web an is_internal_tester flag, which it never had

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@ POSTHOG_API_KEY=
 POSTHOG_HOST=https://us.i.posthog.com
 NEXT_PUBLIC_POSTHOG_KEY=
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Team addresses whose sessions must not count as real users in activation
+# metrics. Comma, space or newline separated. `+alias` folding is automatic, so
+# one entry covers every future name+qa-whatever@... account.
+# NEXT_PUBLIC_ because identify() runs in the browser: these are readable in the
+# client bundle, exactly as iOS ships INTERNAL_TESTER_EMAILS inside its app
+# bundle. Put nothing here that is not already public.
+NEXT_PUBLIC_INTERNAL_TESTER_EMAILS=

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -6,6 +6,7 @@ import { useLocale, useTranslations } from "next-intl";
 import { Link, useRouter } from "@/navigation";
 import { createClientComponentClient } from "@/lib/supabase";
 import { posthog } from "@/lib/posthog";
+import { resolveInternalTester } from "@/lib/internal-tester";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -150,6 +151,7 @@ export function AuthForm({ mode }: AuthFormProps) {
             email: data.user.email,
             full_name: fullName,
             created_at: data.user.created_at,
+            is_internal_tester: resolveInternalTester(data.user.email),
             ...utmParams,
           });
 
@@ -176,6 +178,7 @@ export function AuthForm({ mode }: AuthFormProps) {
         if (data.user) {
           posthog.identify(data.user.id, {
             email: data.user.email,
+            is_internal_tester: resolveInternalTester(data.user.email),
           });
         }
 

--- a/src/components/providers/auth-provider.tsx
+++ b/src/components/providers/auth-provider.tsx
@@ -4,6 +4,7 @@ import { createContext, useContext, useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
 import { createClientComponentClient } from "@/lib/supabase";
 import { posthog } from "@/lib/posthog";
+import { resolveInternalTester } from "@/lib/internal-tester";
 
 interface AuthContextType {
   user: User | null;
@@ -41,6 +42,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (user) {
         posthog.identify(user.id, {
           email: user.email,
+          is_internal_tester: resolveInternalTester(user.email),
         });
       }
     };
@@ -56,6 +58,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         if (nextUser && (event === "SIGNED_IN" || event === "INITIAL_SESSION")) {
           posthog.identify(nextUser.id, {
             email: nextUser.email,
+            is_internal_tester: resolveInternalTester(nextUser.email),
           });
         } else if (event === "SIGNED_OUT") {
           posthog.reset();

--- a/src/lib/__tests__/internal-tester.test.ts
+++ b/src/lib/__tests__/internal-tester.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The web has never had an `is_internal_tester` concept at any level. `identify`
+ * set only email, full name, created_at and UTM params, so every founder and QA
+ * session has counted as a real user in every activation number this product has
+ * ever reported. iOS fixed the same gap in 1.4.9 (21); the web never had it.
+ *
+ * Mirrors the iOS contract deliberately, including `+alias` folding, so one
+ * configured address covers every future `name+qa-whatever@…` without a redeploy
+ * and so the two platforms can be filtered the same way.
+ */
+import {
+  normalizeEmail,
+  parseInternalTesterEmails,
+  isInternalTesterEmail,
+} from '../internal-tester';
+
+describe('normalizeEmail', () => {
+  it('lowercases and trims', () => {
+    expect(normalizeEmail('  Nadav.Yigal@Gmail.com ')).toBe('nadav.yigal@gmail.com');
+  });
+
+  it('folds a +alias into its base address', () => {
+    // QA accounts here are created as plus aliases. A list naming each one drifts
+    // out of date the first time someone makes another.
+    expect(normalizeEmail('nadav.yigal+fable-qa-jul03@gmail.com')).toBe(
+      'nadav.yigal@gmail.com',
+    );
+  });
+
+  it('returns null for input that is not an address', () => {
+    expect(normalizeEmail('')).toBeNull();
+    expect(normalizeEmail(null)).toBeNull();
+    expect(normalizeEmail(undefined)).toBeNull();
+    expect(normalizeEmail('no-at-sign')).toBeNull();
+    expect(normalizeEmail('+only@gmail.com')).toBeNull();
+  });
+});
+
+describe('parseInternalTesterEmails', () => {
+  it('accepts comma, space and newline separated lists', () => {
+    const parsed = parseInternalTesterEmails('a@x.com, b@x.com\nc@x.com d@x.com');
+    expect(parsed).toEqual(new Set(['a@x.com', 'b@x.com', 'c@x.com', 'd@x.com']));
+  });
+
+  it('normalizes entries so a configured alias still matches its base', () => {
+    expect(parseInternalTesterEmails('Nadav.Yigal+qa@Gmail.com')).toEqual(
+      new Set(['nadav.yigal@gmail.com']),
+    );
+  });
+
+  it('is empty for empty or missing config', () => {
+    expect(parseInternalTesterEmails('')).toEqual(new Set());
+    expect(parseInternalTesterEmails(undefined)).toEqual(new Set());
+  });
+});
+
+describe('isInternalTesterEmail', () => {
+  const allowlist = parseInternalTesterEmails('nadav.yigal@gmail.com');
+
+  it('matches the configured address', () => {
+    expect(isInternalTesterEmail('nadav.yigal@gmail.com', allowlist)).toBe(true);
+  });
+
+  it('matches any +alias of the configured address without listing it', () => {
+    expect(isInternalTesterEmail('nadav.yigal+wp49qa@gmail.com', allowlist)).toBe(true);
+    expect(isInternalTesterEmail('nadav.yigal+anything-new@gmail.com', allowlist)).toBe(true);
+  });
+
+  it('does not match a real user', () => {
+    expect(isInternalTesterEmail('yanivshm@gmail.com', allowlist)).toBe(false);
+  });
+
+  it('does not match on a shared local part at another domain', () => {
+    expect(isInternalTesterEmail('nadav.yigal@example.com', allowlist)).toBe(false);
+  });
+
+  it('is false, never throws, for a missing address', () => {
+    expect(isInternalTesterEmail(null, allowlist)).toBe(false);
+    expect(isInternalTesterEmail(undefined, allowlist)).toBe(false);
+  });
+
+  it('is false when nothing is configured, rather than true for everyone', () => {
+    // An empty allowlist must fail closed towards "real user". The opposite
+    // would silently empty the activation cohort.
+    expect(isInternalTesterEmail('nadav.yigal@gmail.com', new Set())).toBe(false);
+  });
+});

--- a/src/lib/internal-tester.ts
+++ b/src/lib/internal-tester.ts
@@ -1,0 +1,78 @@
+/**
+ * Whether a session belongs to the team rather than to a real user.
+ *
+ * The web has never had this concept at any level. `identify` set only email,
+ * full name, created_at and UTM params, so every founder and QA session has
+ * counted as a real user in every activation number this product has reported.
+ * iOS closed the same gap in 1.4.9 (21) with `resolveInternalTester`; this is
+ * the web half, and it is deliberately the same contract so a cohort can be
+ * filtered identically on both platforms.
+ *
+ * Configure with `NEXT_PUBLIC_INTERNAL_TESTER_EMAILS` (comma, space or newline
+ * separated). It is a `NEXT_PUBLIC_` value because `identify` runs in the
+ * browser, so the addresses are readable in the client bundle. That is the same
+ * exposure iOS already accepts by shipping `INTERNAL_TESTER_EMAILS` inside the
+ * app bundle, and these are team addresses, not secrets. Never put anything
+ * here that is not already public.
+ *
+ * This flag cannot repair the past. PostHog's person-on-events snapshots
+ * properties at ingest, so events recorded before this ships keep whatever they
+ * had. It starts a clean boundary; it does not move the old one.
+ */
+
+/**
+ * Lowercased and trimmed, with any `+suffix` removed from the local part.
+ *
+ * QA accounts here are created as plus aliases, so one configured address has to
+ * cover every future `name+qa-whatever@…` without a redeploy. A list that named
+ * each one would drift out of date the first time someone made another.
+ */
+export function normalizeEmail(email: string | null | undefined): string | null {
+  if (!email) return null;
+  const trimmed = email.trim().toLowerCase();
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex <= 0) return null;
+
+  const local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex);
+  const base = local.split('+', 1)[0];
+  if (!base) return null;
+
+  return base + domain;
+}
+
+/** Parse a comma / space / newline separated allowlist into normalized addresses. */
+export function parseInternalTesterEmails(raw: string | null | undefined): Set<string> {
+  if (!raw) return new Set();
+  const entries = raw
+    .split(/[,\s]+/)
+    .map((entry) => normalizeEmail(entry))
+    .filter((entry): entry is string => Boolean(entry));
+  return new Set(entries);
+}
+
+/**
+ * Pure membership test. Fails closed towards "real user": an unconfigured or
+ * empty allowlist returns false for everyone rather than true, because the
+ * opposite would silently empty the activation cohort instead of merely
+ * failing to clean it.
+ */
+export function isInternalTesterEmail(
+  email: string | null | undefined,
+  allowlist: Set<string>,
+): boolean {
+  if (allowlist.size === 0) return false;
+  const normalized = normalizeEmail(email);
+  if (!normalized) return false;
+  return allowlist.has(normalized);
+}
+
+/** The configured allowlist, read once per module load. */
+export function configuredInternalTesterEmails(): Set<string> {
+  return parseInternalTesterEmails(process.env.NEXT_PUBLIC_INTERNAL_TESTER_EMAILS);
+}
+
+/** Convenience wrapper used by the `identify` call sites. */
+export function resolveInternalTester(email: string | null | undefined): boolean {
+  return isInternalTesterEmail(email, configuredInternalTesterEmails());
+}


### PR DESCRIPTION
Replaces #145, which was cut from a stale local base (this checkout's `git fetch` hangs, so local `main` could not be advanced). Verified before re-applying: `main`'s copy of every touched file is byte-identical to the base this work was written against, and two of the five files are new.

## The gap

The web has never had this concept at any level. `identify` set only email, full name, created_at and UTM params, so **every founder and QA session has counted as a real user in every activation number this product has ever reported**. iOS closed the same gap in 1.4.9 (21); the web never had it.

## The change

`src/lib/internal-tester.ts` mirrors iOS's `resolveInternalTester` contract deliberately, including `+alias` folding, so one configured address covers every future `name+qa-whatever@…` without a redeploy and both platforms can be filtered identically. All four `identify` call sites set the property.

**Fails closed towards "real user."** An empty or unconfigured allowlist returns false for everyone rather than true. The opposite would silently empty the activation cohort instead of merely failing to clean it. This also means the PR is **inert until `NEXT_PUBLIC_INTERNAL_TESTER_EMAILS` is set in Vercel**, so merging it changes nothing on its own.

## What this does not do

It cannot repair the past. Person-on-events snapshots properties at ingest, so events recorded before this ships keep what they had. This starts a clean boundary; it does not move the old one.

## Verification

- 12 new tests, **watched failing first** (module absent), then passing.
- `tsc --noEmit` clean, `eslint` clean on all touched files.
- Full-suite **control on the same tree without this change is identical**: 17 failed suites / 78 failed tests, all pre-existing Playwright and contract specs. This adds 1 passing suite and 12 passing tests and regresses nothing.

## Two things found on the way, neither in this PR

1. **`main`'s test baseline moved to 17/78.** The last recorded baseline was 16/76, and 17/78 was explicitly identified then as a real regression that was traced and fixed. It is back on `main` after today's merges. Worth its own look.
2. **This checkout's `node_modules` was corrupt**, not evicted: jest died with `Class extends value undefined`, then `graceful-fs` with `polyfills is not a function`, on files that were present and non-empty. `npm ci` fixed it in 34s. A targeted `npm install` made it worse by pulling jest 30.1.3 into a 30.2.0 tree, so reach for `npm ci` here, not `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)