### PR TITLE
WP-59: repair the ATS score's measurement, not its ceiling

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,7 +18,14 @@ const eslintConfig = [
       "out/**",
       "build/**",
       "next-env.d.ts",
-      // Exclude nested copy of the project and duplicate scripts folder
+      // Exclude nested copies of the project and duplicate scripts folder.
+      // `.claude/worktrees/` holds live git worktrees checked out INSIDE the
+      // repo — 567MB and two more full checkouts as of 2026-08-19. Without
+      // this, `next/typescript`'s type-aware rules build a TS program over
+      // three copies of the codebase and a lint of eight files takes over
+      // half an hour. jest already excludes it (see modulePathIgnorePatterns
+      // in jest.config.js); tsconfig and eslint never got the same fix.
+      ".claude/worktrees/**",
       "resume-builder-ai/**",
       "scripts/scripts/**",
     ],

--- a/src/app/api/public/ats-check/route.ts
+++ b/src/app/api/public/ats-check/route.ts
@@ -18,6 +18,10 @@ import {
 } from '@/lib/ats/public-ats-check-response';
 import { PUBLIC_ATS_MIN_JOB_DESCRIPTION_WORDS } from '@/lib/ats/public-ats-check-constants';
 import { isUndefinedColumnError } from '@/lib/anonymous-carryover';
+import {
+  buildJobDataFromExtractedJson,
+  normalizeParsedJobData,
+} from '@/lib/ats/job-data-resolver';
 
 export const runtime = 'nodejs';
 
@@ -169,24 +173,39 @@ export async function POST(request: NextRequest) {
   const jobHash = hashContent(jobDescription);
   const supabase = createServiceRoleClient();
 
-  // Extract job data from job description for better quick wins
+  // Build job data exactly the way the signed-in optimize path does (WP-59 S2).
+  //
+  // This used to assemble the object inline: `must_have = extractedJob.requirements`,
+  // straight from the scraper. The optimize path instead runs the scraper output
+  // through `normalizeParsedJobData` (which drops section furniture and truncated
+  // fragments) and then `buildJobDataFromExtractedJson` (which ATOMIZES sentence-
+  // shaped requirements into short skill phrases via `extractSkillPhrases`).
+  //
+  // So the free checker was scoring "Experience building and operating distributed
+  // systems at scale" as a single must-have, and `scoreSkillCoverage` averaged the
+  // fraction of that sentence's tokens appearing in the résumé. Full credit was
+  // close to unreachable, on the component carrying 25% of the score — while the
+  // same résumé and the same job scored against clean atomized terms one screen
+  // later. That is the 55-here-59-there split, and it is the same
+  // two-different-functions defect WP-45 S3/D5 fixed for the format report.
+  //
+  // The old code also bailed to DEFAULT_JOB_DATA whenever the scraper returned no
+  // requirements at all, which scores the résumé against an EMPTY job.
+  // `buildJobDataFromExtractedJson` falls back to `extractJobData` over the raw
+  // text instead, so a hard-to-parse posting degrades rather than disappears.
   let jobData: JobExtraction = DEFAULT_JOB_DATA;
   try {
     const extractedJob = await extractJob(jobDescription);
-    const requirements = extractedJob.requirements || [];
-    if (requirements.length > 0) {
-      jobData = {
-        title: extractedJob.job_title || '',
-        must_have: requirements,
-        nice_to_have: extractedJob.nice_to_have || [],
-        responsibilities: extractedJob.responsibilities || [],
-      };
-      console.log('✅ Extracted job data:', {
-        title: jobData.title,
-        must_have_count: jobData.must_have.length,
-        nice_to_have_count: jobData.nice_to_have.length,
-      });
-    }
+    jobData = buildJobDataFromExtractedJson(
+      normalizeParsedJobData(extractedJob),
+      jobDescription
+    );
+    console.log('✅ Extracted job data:', {
+      title: jobData.title,
+      must_have_count: jobData.must_have.length,
+      must_have_sample: jobData.must_have.slice(0, 10),
+      nice_to_have_count: jobData.nice_to_have.length,
+    });
   } catch (error) {
     console.error('Job extraction failed, using defaults:', error);
     // Continue with DEFAULT_JOB_DATA

--- a/src/components/ats/SuggestionsList.tsx
+++ b/src/components/ats/SuggestionsList.tsx
@@ -11,6 +11,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Lightbulb, Zap, TrendingUp } from '@/lib/icons';
 import { useTranslations } from 'next-intl';
+import { SUGGESTION_THRESHOLDS } from '@/lib/ats/config/thresholds';
 
 interface SuggestionsListProps {
   suggestions: Suggestion[];
@@ -43,8 +44,14 @@ export function SuggestionsList({
   }
 
   const quickWins = displayedSuggestions.filter(s => s.quick_win);
-  const highImpact = displayedSuggestions.filter(s => !s.quick_win && s.estimated_gain >= 8);
-  const otherSuggestions = displayedSuggestions.filter(s => !s.quick_win && s.estimated_gain < 8);
+  // Threshold lives in SUGGESTION_THRESHOLDS so it moves with the estimator's
+  // scale. The literal 8 here was set when every gain was a clamped 15 (WP-59 S1).
+  const highImpact = displayedSuggestions.filter(
+    s => !s.quick_win && s.estimated_gain >= SUGGESTION_THRESHOLDS.high_impact_threshold
+  );
+  const otherSuggestions = displayedSuggestions.filter(
+    s => !s.quick_win && s.estimated_gain < SUGGESTION_THRESHOLDS.high_impact_threshold
+  );
 
   return (
     <Card>

--- a/src/components/chat/ATSSuggestionsBanner.tsx
+++ b/src/components/chat/ATSSuggestionsBanner.tsx
@@ -9,6 +9,7 @@ import type { Suggestion } from '@/lib/ats/types';
 import { ChevronDown, ChevronUp, Lightbulb, Zap, TrendingUp } from '@/lib/icons';
 import { useTranslations } from 'next-intl';
 import { MainIssuesSummary } from '@/components/ats/MainIssuesSummary';
+import { SUGGESTION_THRESHOLDS } from '@/lib/ats/config/thresholds';
 
 interface ATSSuggestionsBannerProps {
   suggestions: Suggestion[];
@@ -29,7 +30,11 @@ export function ATSSuggestionsBanner({ suggestions }: ATSSuggestionsBannerProps)
   const numberedSuggestions: NumberedSuggestion[] = suggestions.map((s, index) => ({ ...s, number: index + 1 }));
 
   const quickWins = numberedSuggestions.filter(s => s.quick_win).slice(0, 3);
-  const highImpact = numberedSuggestions.filter(s => !s.quick_win && s.estimated_gain >= 8).slice(0, 2);
+  // See SUGGESTION_THRESHOLDS: the literal 8 belonged to the pre-WP-59 scale
+  // where every estimated gain was clamped to 15.
+  const highImpact = numberedSuggestions
+    .filter(s => !s.quick_win && s.estimated_gain >= SUGGESTION_THRESHOLDS.high_impact_threshold)
+    .slice(0, 2);
   const displaySuggestions: NumberedSuggestion[] = [...quickWins, ...highImpact];
 
   return (

--- a/src/lib/ats/__tests__/calibration-benchmark.test.ts
+++ b/src/lib/ats/__tests__/calibration-benchmark.test.ts
@@ -22,12 +22,16 @@
 import {
   runBenchmark,
   summarise,
+  summariseSubscores,
+  formatCeilingReport,
   deriveThresholds,
   bandFor,
   scoreCase,
   degradedCount,
   PUBLISHED_BANDS,
 } from '../benchmark/runner';
+import { SUB_SCORE_WEIGHTS } from '../config/weights';
+import type { SubScoreKey } from '../types';
 import { CALIBRATION_CASES, HOLDOUT_CASES, BENCHMARK_CASES } from '../benchmark/cases';
 
 jest.setTimeout(300000);
@@ -247,5 +251,67 @@ describe('WP-45 S5: no artificial uplift', () => {
     for (const score of weakScores) {
       expect(bandFor(score, derived)).not.toBe('strong');
     }
+  });
+});
+
+/**
+ * WP-59 S0 — where the ceiling actually is, before anything is changed.
+ *
+ * The composite is a weighted sum, so its reachable maximum is the weighted sum
+ * of what each component can actually reach — not 100. Reading the code finds
+ * the constants; only running the labelled set shows how many points each one
+ * costs every résumé regardless of quality.
+ *
+ * These tests assert the ceiling EXISTS rather than asserting a particular
+ * number, so they document the problem without becoming a tripwire that fires
+ * on every legitimate scoring change. The numbers themselves are printed, to be
+ * pasted into the work log and compared against the same run after the repairs.
+ */
+describe('WP-59 S0: the reachable ceiling', () => {
+  let results: Awaited<ReturnType<typeof runBenchmark>>;
+
+  beforeAll(async () => {
+    results = await runBenchmark(PUBLISHED_BANDS, BENCHMARK_CASES);
+  }, 600000);
+
+  it('reports each component observed range', () => {
+    // Printed, not asserted: this is the before-picture for the recalibration.
+    // eslint-disable-next-line no-console
+    console.log('\n' + formatCeilingReport(results) + '\n');
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('names every component that never moves across the whole set', () => {
+    const stats = summariseSubscores(results);
+    const constants = (Object.keys(stats) as SubScoreKey[])
+      .filter(key => stats[key].constant && SUB_SCORE_WEIGHTS[key] > 0)
+      .map(key => `${key} (fixed at ${stats[key].max}, ${(SUB_SCORE_WEIGHTS[key] * 100).toFixed(1)}% of the score)`);
+
+    // eslint-disable-next-line no-console
+    console.log('constant components:', constants.length ? constants : 'none');
+
+    // A weighted component that returns the same value for 32 different résumés
+    // is spending its weight without measuring anything. Recording it, not
+    // failing on it — the repair is Story 3, and this test is the evidence it
+    // was needed.
+    expect(Array.isArray(constants)).toBe(true);
+  });
+
+  it('shows the weighted sum of per-component maxima falling short of 100', () => {
+    const stats = summariseSubscores(results);
+    const theoreticalCeiling = (Object.keys(stats) as SubScoreKey[]).reduce(
+      (sum, key) => sum + stats[key].max * SUB_SCORE_WEIGHTS[key],
+      0
+    );
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `theoretical ceiling ${theoreticalCeiling.toFixed(1)}; ` +
+        `observed ceiling ${summarise(results).observedCeiling}`
+    );
+
+    // The claim under test: no résumé in a 32-case set spanning strong, stretch
+    // and weak can approach the top of the ring, because the components cannot.
+    expect(theoreticalCeiling).toBeLessThan(100);
   });
 });

--- a/src/lib/ats/__tests__/calibration-benchmark.test.ts
+++ b/src/lib/ats/__tests__/calibration-benchmark.test.ts
@@ -297,6 +297,22 @@ describe('WP-59 S0: the reachable ceiling', () => {
     expect(Array.isArray(constants)).toBe(true);
   });
 
+  it('reports the thresholds this scale would derive', () => {
+    // Printed, not asserted. When a scorer change moves the scale, the shipped
+    // 57/42 stop fitting and the sweep says so — that is the signal to
+    // recalibrate deliberately (WP-59 Story 4), not to quietly move the bands
+    // until the suite goes green.
+    const derived = deriveThresholds(results);
+    const summary = summarise(results);
+    // eslint-disable-next-line no-console
+    console.log(
+      `derived bands strong>=${derived.strong} stretch>=${derived.stretch} ` +
+        `(shipped ${PUBLISHED_BANDS.strong}/${PUBLISHED_BANDS.stretch}); ` +
+        `accuracy ${summary.accuracy.toFixed(3)} falseWeak ${summary.falseWeakCount}`
+    );
+    expect(derived.strong).toBeGreaterThan(derived.stretch);
+  });
+
   it('shows the weighted sum of per-component maxima falling short of 100', () => {
     const stats = summariseSubscores(results);
     const theoreticalCeiling = (Object.keys(stats) as SubScoreKey[]).reduce(

--- a/src/lib/ats/__tests__/calibration-benchmark.test.ts
+++ b/src/lib/ats/__tests__/calibration-benchmark.test.ts
@@ -276,7 +276,6 @@ describe('WP-59 S0: the reachable ceiling', () => {
 
   it('reports each component observed range', () => {
     // Printed, not asserted: this is the before-picture for the recalibration.
-    // eslint-disable-next-line no-console
     console.log('\n' + formatCeilingReport(results) + '\n');
     expect(results.length).toBeGreaterThan(0);
   });
@@ -287,7 +286,6 @@ describe('WP-59 S0: the reachable ceiling', () => {
       .filter(key => stats[key].constant && SUB_SCORE_WEIGHTS[key] > 0)
       .map(key => `${key} (fixed at ${stats[key].max}, ${(SUB_SCORE_WEIGHTS[key] * 100).toFixed(1)}% of the score)`);
 
-    // eslint-disable-next-line no-console
     console.log('constant components:', constants.length ? constants : 'none');
 
     // A weighted component that returns the same value for 32 different résumés
@@ -304,7 +302,6 @@ describe('WP-59 S0: the reachable ceiling', () => {
     // until the suite goes green.
     const derived = deriveThresholds(results);
     const summary = summarise(results);
-    // eslint-disable-next-line no-console
     console.log(
       `derived bands strong>=${derived.strong} stretch>=${derived.stretch} ` +
         `(shipped ${PUBLISHED_BANDS.strong}/${PUBLISHED_BANDS.stretch}); ` +
@@ -320,7 +317,6 @@ describe('WP-59 S0: the reachable ceiling', () => {
       0
     );
 
-    // eslint-disable-next-line no-console
     console.log(
       `theoretical ceiling ${theoreticalCeiling.toFixed(1)}; ` +
         `observed ceiling ${summarise(results).observedCeiling}`

--- a/src/lib/ats/__tests__/job-data-parity.test.ts
+++ b/src/lib/ats/__tests__/job-data-parity.test.ts
@@ -1,0 +1,103 @@
+/** @jest-environment node */
+/**
+ * WP-59 S2 — the free checker and the signed-in optimize path must derive the
+ * same job data from the same job description.
+ *
+ * The free route used to assemble `job_data` inline straight from the scraper:
+ *
+ *     must_have: extractedJob.requirements
+ *
+ * while `scoreOptimization` ran the same scraper output through
+ * `normalizeParsedJobData` and `buildJobDataFromExtractedJson`, which drop
+ * section furniture and ATOMIZE sentence-shaped requirements into short skill
+ * phrases. So one surface matched the résumé against "Experience building and
+ * operating distributed systems at scale" as a single must-have — scored by the
+ * average fraction of that sentence's tokens present — and the other matched it
+ * against `distributed systems`. Same résumé, same job, 25% of the score
+ * computed two different ways.
+ *
+ * These tests assert the shared derivation, not a particular score. A future
+ * change to atomization should move both surfaces together or fail here.
+ */
+
+import {
+  buildJobDataFromExtractedJson,
+  normalizeParsedJobData,
+} from '../job-data-resolver';
+import { scoreSkillCoverage } from '../skill-match';
+import type { ExtractedJobData } from '@/lib/scraper/jobExtractor';
+
+const SENTENCE_REQUIREMENTS = [
+  'Experience building and operating distributed systems at scale',
+  'Strong background in PostgreSQL and database performance tuning',
+  'Hands-on experience with Kubernetes in production',
+  'Key Responsibilities',
+];
+
+const SCRAPED: ExtractedJobData = {
+  job_title: 'Senior Backend Engineer',
+  requirements: SENTENCE_REQUIREMENTS,
+  nice_to_have: null,
+  responsibilities: null,
+  qualifications: null,
+} as unknown as ExtractedJobData;
+
+const JOB_TEXT = SENTENCE_REQUIREMENTS.join('\n');
+
+/** What the free route used to do, kept here as the thing being ruled out. */
+function legacyInlineJobData(extracted: ExtractedJobData) {
+  return {
+    title: extracted.job_title || '',
+    must_have: extracted.requirements || [],
+    nice_to_have: extracted.nice_to_have || [],
+    responsibilities: extracted.responsibilities || [],
+  };
+}
+
+describe('WP-59 S2: free and optimize derive job data identically', () => {
+  const shared = buildJobDataFromExtractedJson(normalizeParsedJobData(SCRAPED), JOB_TEXT);
+
+  it('atomizes sentence-shaped requirements into skill phrases', () => {
+    // Nothing in must_have should still be a whole sentence.
+    for (const requirement of shared.must_have) {
+      expect(requirement.split(/\s+/).length).toBeLessThanOrEqual(4);
+    }
+    expect(shared.must_have.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the real technologies the sentences carried', () => {
+    const joined = shared.must_have.join(' ').toLowerCase();
+    expect(joined).toContain('postgresql');
+    expect(joined).toContain('kubernetes');
+  });
+
+  it('drops section furniture that is not a requirement', () => {
+    const joined = shared.must_have.join(' ').toLowerCase();
+    expect(joined).not.toContain('key responsibilities');
+  });
+
+  it('scores a matching résumé materially higher than the inline build did', () => {
+    // A résumé that genuinely has the stack. Under the sentence-level build it
+    // is penalised for not echoing the job's prose; under the shared build it
+    // is credited for having the skills.
+    const resume = `Senior Backend Engineer
+      Built and operated distributed systems serving production traffic.
+      PostgreSQL, Kubernetes, Go, AWS.`;
+
+    const legacy = scoreSkillCoverage(legacyInlineJobData(SCRAPED).must_have, resume).score;
+    const current = scoreSkillCoverage(shared.must_have, resume).score;
+
+    expect(current).toBeGreaterThan(legacy);
+  });
+
+  it('does not fall back to an empty job when the scraper finds no requirements', () => {
+    // The old route left DEFAULT_JOB_DATA in place here, which scores the
+    // résumé against nothing at all.
+    const noRequirements = { ...SCRAPED, requirements: null } as unknown as ExtractedJobData;
+    const resolved = buildJobDataFromExtractedJson(
+      normalizeParsedJobData(noRequirements),
+      JOB_TEXT
+    );
+    expect(resolved.must_have.length).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/ats/__tests__/keyword-extraction.test.ts
+++ b/src/lib/ats/__tests__/keyword-extraction.test.ts
@@ -1,0 +1,123 @@
+/** @jest-environment node */
+/**
+ * WP-59 S3c — what the scorer is allowed to call a "requirement".
+ *
+ * Three defects, all measured on a candidate holding every skill a job asked
+ * for, whose keyword_exact read 45.8 against 80.0 for a human's list of the
+ * same skills:
+ *
+ *   1. `normalizeText` used `[^\w\s]`, and `\w` is ASCII-only in JavaScript
+ *      without the `u` flag — so every Hebrew character was replaced with a
+ *      space. A Hebrew job description was scored on its English technology
+ *      names alone, and a requirement written only in Hebrew normalized to the
+ *      empty string.
+ *   2. Filler was stripped only from the FRONT of a clause, so `proficiency`,
+ *      `familiarity`, `building` and `background postgresql` were emitted as
+ *      must-haves — and shown to users as gaps in their resume.
+ *   3. `min_keyword_length: 3` silently deleted Go, AI, ML, QA and UX from both
+ *      the job and the resume, so a job requiring Go never measured it.
+ */
+
+import { normalizeText, tokenize, isShortSkillToken } from '../utils/text-utils';
+import { extractSkillPhrases } from '../extractors/skill-phrase-extractor';
+import { skillMatchesResume, skillCoverage } from '../skill-match';
+
+describe('normalizeText is Unicode-aware', () => {
+  it('keeps Hebrew instead of deleting it', () => {
+    const out = normalizeText('מהנדס תוכנה בכיר עם ניסיון ב Kubernetes ו PostgreSQL');
+    expect(out).toContain('מהנדס');
+    expect(out).toContain('kubernetes');
+  });
+
+  it('does not reduce a Hebrew-only requirement to the empty string', () => {
+    expect(normalizeText('ניסיון בפיתוח')).not.toBe('');
+  });
+
+  it('keeps accented Latin', () => {
+    expect(normalizeText('José café')).toContain('josé');
+  });
+
+  it('still strips real punctuation', () => {
+    expect(normalizeText('Node.js, React!')).toBe('node js react');
+  });
+});
+
+describe('short technology names survive tokenization', () => {
+  it('keeps known short skills', () => {
+    expect(tokenize('Built services in Go and some ML')).toContain('go');
+    expect(isShortSkillToken('go')).toBe(true);
+    expect(isShortSkillToken('ml')).toBe(true);
+  });
+
+  it('does not admit single letters or ordinary short words', () => {
+    expect(isShortSkillToken('r')).toBe(false);
+    expect(isShortSkillToken('c')).toBe(false);
+    expect(isShortSkillToken('an')).toBe(false);
+  });
+});
+
+describe('word boundaries are Unicode-aware', () => {
+  it('does not match a Hebrew stem buried inside a longer word', () => {
+    expect(skillMatchesResume('יתוח', 'פיתוח')).toBe(false);
+  });
+
+  it('tolerates a Hebrew particle glued to the front', () => {
+    // The job says "in development", the resume says "development".
+    expect(skillMatchesResume('פיתוח', 'ניסיון בפיתוח מערכות')).toBe(true);
+  });
+
+  it('matches Go as a word but not inside another word', () => {
+    expect(skillMatchesResume('go', 'built backend services in go')).toBe(true);
+    expect(skillMatchesResume('go', 'used gopher tooling')).toBe(false);
+  });
+});
+
+describe('the atomizer emits skills, not filler', () => {
+  const REQUIREMENTS = [
+    'Experience building and operating distributed systems at scale',
+    'Strong background in PostgreSQL and database performance tuning',
+    'Hands-on experience with Kubernetes in production environments',
+    'Proficiency with Go or another statically typed language',
+    'Familiarity with Terraform and infrastructure as code',
+  ];
+  const phrases = extractSkillPhrases(REQUIREMENTS);
+
+  it.each([
+    'proficiency',
+    'familiarity',
+    'building',
+    'hands experience',
+    'background postgresql',
+  ])('never emits %p as a requirement', (junk) => {
+    expect(phrases).not.toContain(junk);
+  });
+
+  it('keeps the technologies the sentences carried', () => {
+    expect(phrases).toContain('postgresql');
+    expect(phrases).toContain('terraform');
+    expect(phrases).toContain('go');
+  });
+
+  it('lets a candidate who has everything actually score for it', () => {
+    const perfect = `Senior Backend Engineer
+      Built and operated distributed systems serving production traffic.
+      PostgreSQL, Kubernetes, Go, AWS, Terraform, Python.
+      Tuned database performance and owned infrastructure as code.`;
+
+    // Measured 45.8 before this change on exactly this pair.
+    const coverage =
+      phrases.reduce((sum, p) => sum + skillCoverage(p, perfect), 0) / phrases.length;
+    expect(coverage * 100).toBeGreaterThan(75);
+  });
+
+  it('extracts Hebrew requirements at all, and drops Hebrew filler', () => {
+    const hebrew = extractSkillPhrases([
+      'ניסיון בפיתוח מערכות מבוזרות',
+      'שליטה בשפת Go',
+    ]);
+    expect(hebrew.length).toBeGreaterThan(0);
+    // בשפת — "in the language of" — is filler carrying a glued particle.
+    expect(hebrew.join(' ')).not.toContain('בשפת');
+    expect(hebrew.join(' ')).toContain('go');
+  });
+});

--- a/src/lib/ats/__tests__/metrics-patterns.test.ts
+++ b/src/lib/ats/__tests__/metrics-patterns.test.ts
@@ -1,0 +1,47 @@
+/** @jest-environment node */
+/**
+ * WP-59 S3d — what counts as a quantified achievement.
+ *
+ * The original five patterns required a `%`, a `$`, a `#`, an `x` or an
+ * uppercase K/M/B. Every ordinary quantity an engineer writes counted as NO
+ * metric, `metrics_presence` hard-clamps to 0 when nothing matches, and the
+ * component forfeits its whole 11.4% weight. Across the 32-case benchmark it
+ * meaned 5.3 out of 100 — on fixtures written to contain metrics.
+ *
+ * The line these tests defend: a number must be bound to a unit, a countable
+ * noun, or an explicit before/after. A bare integer is still not a metric, so
+ * dates and phone numbers stay out.
+ */
+
+import { METRICS_THRESHOLDS } from '../config/thresholds';
+
+const isMetric = (text: string) =>
+  METRICS_THRESHOLDS.metric_patterns.some((pattern) => pattern.test(text));
+
+describe('counts real quantified achievements', () => {
+  it.each([
+    'reduced p99 latency from 800ms to 120ms',
+    'led a team of 12 engineers',
+    'served 3 million requests per day',
+    'cut deploy time from 40 minutes to 6',
+    'improved conversion by 25%',
+    'saved $50,000 annually',
+    'ranked #1 in the region',
+    'grew throughput 3x',
+    'migrated 2TB of data',
+    'supported 15000 users',
+  ])('%p counts', (text) => {
+    expect(isMetric(text)).toBe(true);
+  });
+});
+
+describe('does not count numbers that are not achievements', () => {
+  it.each([
+    'Software Engineer 2019 - 2023',
+    '5 years of experience',
+    'Tel Aviv, Israel',
+    'B.Sc. Computer Science',
+  ])('%p does not count', (text) => {
+    expect(isMetric(text)).toBe(false);
+  });
+});

--- a/src/lib/ats/__tests__/scorer-integrity.test.ts
+++ b/src/lib/ats/__tests__/scorer-integrity.test.ts
@@ -217,10 +217,21 @@ describe('WP-45 D2: no double penalty for missing metrics', () => {
   });
 
   it('scores the two reference fixtures at their exact expected values', () => {
-    // Absolute values, not band membership. Reverting either D1 (weights) or
-    // D2 (penalty) moves these, which band assertions alone would not catch.
+    // Absolute values, not band membership. Reverting D1 (weights), D2 (metrics
+    // penalty) or the WP-59 S3e/S3b penalty withdrawals moves these, which band
+    // assertions alone would not catch.
     expect(compositeFor(STRONG_CANDIDATE_WITHOUT_METRICS)).toBe(87);
-    expect(compositeFor(TYPICAL_OPTIMIZED)).toBe(44);
+
+    // 44 -> 52 on 2026-08-19, and the arithmetic is the whole justification:
+    // exactly +3 for the withdrawn title_mismatch_penalty (WP-59 S3e) and +5
+    // for the withdrawn semantic_keyword_gap_penalty (S3b). This fixture has
+    // title_alignment below 40 and keyword_exact below 40, so it was paying
+    // both — one for a title comparison that never happened, one for a
+    // condition the semantic cap already handles.
+    //
+    // Deliberately re-pinned rather than relaxed. The point of an absolute
+    // value is that someone has to justify moving it.
+    expect(compositeFor(TYPICAL_OPTIMIZED)).toBe(52);
   });
 
   it('still penalises genuine format risk', () => {

--- a/src/lib/ats/__tests__/title-and-semantic.test.ts
+++ b/src/lib/ats/__tests__/title-and-semantic.test.ts
@@ -1,0 +1,102 @@
+/** @jest-environment node */
+/**
+ * WP-59 S3e / S3b — the last two double-charges, and two components that could
+ * not tell a good match from a bad one.
+ *
+ * `applyPenalties` charged three separate deductions for facts the weighted
+ * components already carried. WP-45 D2 withdrew the first (metrics). These are
+ * the other two, and both fired hardest on measurements that were not findings
+ * at all:
+ *
+ *   - title_alignment returns a CONSTANT 20 when the text-path extractor cannot
+ *     parse titles out of a resume. 20 is below the penalty's 40 threshold, so
+ *     every unparseable resume was charged a "title mismatch" for a comparison
+ *     that never happened.
+ *   - semantic_relevance caps itself at 70 when keyword_exact < 40, and the gap
+ *     penalty fired when semantic minus keyword exceeded 30 — which at a capped
+ *     70 is exactly when keyword_exact < 40. Same condition, charged twice.
+ */
+
+import { applyPenalties } from '../scorers/penalties';
+import { extractJobData } from '../extractors/jd-extractor';
+import { SEMANTIC_THRESHOLDS } from '../config/thresholds';
+import type { SubScores } from '../types';
+
+const baseSubscores = (overrides: Partial<SubScores>): SubScores => ({
+  keyword_exact: 60,
+  keyword_phrase: 0,
+  semantic_relevance: 60,
+  title_alignment: 60,
+  metrics_presence: 60,
+  section_completeness: 100,
+  format_parseability: 85,
+  recency_fit: 80,
+  ...overrides,
+});
+
+describe('WP-59 S3e: the title penalty is withdrawn', () => {
+  it('does not charge a resume whose titles simply could not be parsed', () => {
+    // 20 is the analyzer's "no job titles found in resume" constant.
+    const { penalizedScore, appliedPenalties } = applyPenalties(
+      70,
+      baseSubscores({ title_alignment: 20 }),
+      {}
+    );
+    expect(appliedPenalties.map(p => p.reason)).not.toContain('Job title and seniority mismatch');
+    expect(penalizedScore).toBe(70);
+  });
+});
+
+describe('WP-59 S3b: the semantic-keyword gap penalty is withdrawn', () => {
+  it('does not charge twice for the condition the cap already handles', () => {
+    // keyword_exact below 40 is what triggers the cap AND what triggered this.
+    const { penalizedScore, appliedPenalties } = applyPenalties(
+      65,
+      baseSubscores({ keyword_exact: 20, semantic_relevance: 70 }),
+      {}
+    );
+    expect(appliedPenalties).toHaveLength(0);
+    expect(penalizedScore).toBe(65);
+  });
+
+  it('still penalises genuinely unparseable formatting', () => {
+    // The format penalty is not a double-charge and must survive.
+    const { appliedPenalties } = applyPenalties(
+      70,
+      baseSubscores({ format_parseability: 30 }),
+      {}
+    );
+    expect(appliedPenalties.map(p => p.reason)).toContain('High ATS format risk detected');
+  });
+});
+
+describe('WP-59 S3b: semantic uses the range embeddings actually produce', () => {
+  it('anchors are ordered and inside the plausible cosine range', () => {
+    expect(SEMANTIC_THRESHOLDS.cosine_floor).toBeLessThan(SEMANTIC_THRESHOLDS.cosine_ceiling);
+    expect(SEMANTIC_THRESHOLDS.cosine_floor).toBeGreaterThanOrEqual(0);
+    expect(SEMANTIC_THRESHOLDS.cosine_ceiling).toBeLessThanOrEqual(1);
+  });
+
+  it('spreads the observed cosine range across most of 0-100', () => {
+    // The measured pre-change span was 61-84 out of 100. Anything narrower than
+    // half the scale means the component still cannot discriminate.
+    const { cosine_floor: lo, cosine_ceiling: hi } = SEMANTIC_THRESHOLDS;
+    const at = (cos: number) => Math.max(0, Math.min(1, (cos - lo) / (hi - lo))) * 100;
+    expect(at(0.68) - at(0.22)).toBeGreaterThan(50);
+  });
+});
+
+describe('WP-59 S3e: Hebrew job descriptions yield a target title', () => {
+  it.each([
+    ['דרוש מהנדס תוכנה בכיר לחברת סטארטאפ', 'מהנדס תוכנה בכיר'],
+    ['משרה: מפתח Backend', 'מפתח Backend'],
+  ])('extracts a title from %p', (text, expected) => {
+    expect(extractJobData(text).title).toContain(expected.split(' ')[0]);
+  });
+
+  it('leaves English extraction working', () => {
+    expect(extractJobData('Position: Senior Backend Engineer').title).toBe(
+      'Senior Backend Engineer'
+    );
+  });
+});

--- a/src/lib/ats/analyzers/semantic.ts
+++ b/src/lib/ats/analyzers/semantic.ts
@@ -13,6 +13,21 @@ import { SEMANTIC_THRESHOLDS } from '../config/thresholds';
 import { extractSectionText } from '../extractors/resume-text-extractor';
 import { scoreSkillListMatch } from '../skill-match';
 
+/**
+ * Map a cosine similarity onto 0-1 using the range embeddings actually produce.
+ *
+ * Was `(cos + 1) / 2`, which assumes the value can reach -1. Between two real
+ * documents it does not: across the labelled benchmark this component spanned
+ * 61-84 out of 100 on strong, stretch and weak pairs alike, so 18.2% of the
+ * composite was spent on a 23-point range that could not separate a good match
+ * from a bad one (WP-59 S3b).
+ */
+function normalizeCosine(cosine: number): number {
+  const { cosine_floor, cosine_ceiling } = SEMANTIC_THRESHOLDS;
+  const scaled = (cosine - cosine_floor) / (cosine_ceiling - cosine_floor);
+  return Math.max(0, Math.min(1, scaled));
+}
+
 export class SemanticAnalyzer extends BaseAnalyzer {
   constructor() {
     super('semantic_relevance');
@@ -43,7 +58,7 @@ export class SemanticAnalyzer extends BaseAnalyzer {
           return {
             section: section.name,
             text: section.text,
-            similarity: (similarity + 1) / 2, // Normalize to 0-1
+            similarity: normalizeCosine(similarity),
           };
         })
       );

--- a/src/lib/ats/benchmark/runner.ts
+++ b/src/lib/ats/benchmark/runner.ts
@@ -9,8 +9,9 @@
 import { scoreResume } from '../core';
 import { generateFormatReport } from '../integration';
 import { BENCHMARK_CASES, type BandLabel, type BenchmarkCase } from './cases';
-import type { ATSScoreInput } from '../types';
+import type { ATSScoreInput, SubScoreKey, SubScores } from '../types';
 import { FIT_BANDS } from '../config/bands';
+import { SUB_SCORE_WEIGHTS } from '../config/weights';
 
 export interface BandThresholds {
   /** At or above this is 'strong'. */
@@ -45,6 +46,8 @@ export interface CaseResult {
   holdout: boolean;
   /** True when the semantic analyzer fell back, so this score is not trustworthy. */
   semanticDegraded: boolean;
+  /** The component readings behind `score`, for ceiling reporting (WP-59 S0). */
+  subscores: SubScores;
 }
 
 /** How many cases in a run were scored with a degraded semantic analyzer. */
@@ -53,10 +56,31 @@ export function degradedCount(results: CaseResult[]): number {
 }
 
 /**
- * The semantic analyzer returns exactly this when an embedding call fails.
- * A run where cases hit it is measuring a degraded scorer, not the scorer.
+ * Was this case scored with a broken semantic analyzer?
+ *
+ * This used to compare `subscores.semantic_relevance` against 50, the fallback
+ * the analyzer passes to `createFailedResult`. That value never reaches the
+ * subscores: `createFailedResult` also sets `confidence: 0`, and
+ * `aggregateScores` writes **0** for any analyzer with zero confidence and
+ * redistributes its weight across the rest. So a totally degraded run reported
+ * `degradedCount() === 0` and `requireCleanRun` waved it through — the guard
+ * that exists to stop anyone calibrating against numbers the scorer never
+ * really produced could not see the degradation it was written for (WP-59 S0).
+ *
+ * Detect it from the scorer's own warning instead of from a magic value, so
+ * this cannot drift again when a fallback constant changes.
  */
-const SEMANTIC_FALLBACK = 50;
+function isSemanticDegraded(result: {
+  subscores: SubScores;
+  metadata: { warnings: string[] };
+}): boolean {
+  const failed = result.metadata.warnings.some(
+    warning => warning.startsWith('Some analyzers failed') && warning.includes('semantic_relevance')
+  );
+  // Belt and braces: a zero on a real document is not physically possible —
+  // cosine similarity between two non-empty texts is never exactly 0.
+  return failed || result.subscores.semantic_relevance === 0;
+}
 
 export async function scoreCase(testCase: BenchmarkCase): Promise<number> {
   return (await scoreCaseDetailed(testCase)).score;
@@ -64,7 +88,7 @@ export async function scoreCase(testCase: BenchmarkCase): Promise<number> {
 
 export async function scoreCaseDetailed(
   testCase: BenchmarkCase
-): Promise<{ score: number; semanticDegraded: boolean }> {
+): Promise<{ score: number; semanticDegraded: boolean; subscores: SubScores }> {
   const input: ATSScoreInput = {
     resume_original_text: testCase.resumeText,
     resume_optimized_text: testCase.resumeText,
@@ -83,7 +107,8 @@ export async function scoreCaseDetailed(
   const result = await scoreResume(input);
   return {
     score: result.ats_score_optimized,
-    semanticDegraded: result.subscores.semantic_relevance === SEMANTIC_FALLBACK,
+    semanticDegraded: isSemanticDegraded(result),
+    subscores: result.subscores,
   };
 }
 
@@ -98,7 +123,7 @@ export async function runBenchmark(
   const scores = await Promise.all(cases.map(scoreCaseDetailed));
 
   return cases.map((testCase, i) => {
-    const { score, semanticDegraded } = scores[i];
+    const { score, semanticDegraded, subscores } = scores[i];
     const predicted = bandFor(score, thresholds);
     return {
       id: testCase.id,
@@ -109,6 +134,7 @@ export async function runBenchmark(
       falseWeak: predicted === 'weak' && testCase.label !== 'weak',
       holdout: Boolean(testCase.holdout),
       semanticDegraded,
+      subscores,
     };
   });
 }
@@ -122,6 +148,89 @@ export interface BenchmarkSummary {
   falseWeakRate: number;
   strongReached: boolean;
   scoresByLabel: Record<BandLabel, number[]>;
+  /** Highest composite any case reached. The engine's observed ceiling (WP-59 S0). */
+  observedCeiling: number;
+  /** Per-component observed range across every case. See `subscoreStats` below. */
+  subscoreStats: SubscoreStats;
+}
+
+/**
+ * What each component actually does across the whole labelled set (WP-59 S0).
+ *
+ * The composite is a weighted sum, so its reachable maximum is the weighted sum
+ * of the components' reachable maxima — not 100. A component whose `max` sits
+ * well below 100, or whose `min` equals its `max`, is spending its weight
+ * without ever earning it, and every résumé pays for that regardless of quality.
+ *
+ * This exists because the ceiling was previously argued from reading the code.
+ * Reading the code finds a constant; only running the set shows how much of the
+ * scale that constant costs. Record this before changing any analyzer, and
+ * again after, so a change can be shown to have removed a deflation rather than
+ * added an inflation.
+ */
+export type SubscoreStats = Record<
+  SubScoreKey,
+  { min: number; mean: number; max: number; /** max === min: the component never moved. */ constant: boolean }
+>;
+
+export function summariseSubscores(results: CaseResult[]): SubscoreStats {
+  const keys = Object.keys(results[0]?.subscores ?? {}) as SubScoreKey[];
+  const stats = {} as SubscoreStats;
+
+  for (const key of keys) {
+    const values = results
+      .map(r => r.subscores[key])
+      .filter((v): v is number => typeof v === 'number' && Number.isFinite(v));
+
+    if (values.length === 0) {
+      stats[key] = { min: NaN, mean: NaN, max: NaN, constant: false };
+      continue;
+    }
+
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    stats[key] = {
+      min,
+      max,
+      mean: values.reduce((sum, v) => sum + v, 0) / values.length,
+      constant: max === min,
+    };
+  }
+
+  return stats;
+}
+
+/** A human-readable ceiling report, for pasting into a PR body or a work log. */
+export function formatCeilingReport(results: CaseResult[]): string {
+  const stats = summariseSubscores(results);
+  const rows = (Object.keys(stats) as SubScoreKey[]).map(key => {
+    const { min, mean, max, constant } = stats[key];
+    const weight = SUB_SCORE_WEIGHTS[key];
+    // What this component contributes at its best, in final-score points.
+    const headroom = ((100 - max) * weight).toFixed(2);
+    return [
+      key.padEnd(22),
+      `w=${(weight * 100).toFixed(1)}%`.padStart(8),
+      `min=${min.toFixed(1)}`.padStart(10),
+      `mean=${mean.toFixed(1)}`.padStart(11),
+      `max=${max.toFixed(1)}`.padStart(10),
+      `unreachable=${headroom}pts`.padStart(20),
+      constant ? '  CONSTANT' : '',
+    ].join(' ');
+  });
+
+  const ceiling = Math.max(...results.map(r => r.score));
+  const theoretical = (Object.keys(stats) as SubScoreKey[]).reduce(
+    (sum, key) => sum + stats[key].max * SUB_SCORE_WEIGHTS[key],
+    0
+  );
+
+  return [
+    ...rows,
+    '',
+    `observed composite ceiling across ${results.length} cases: ${ceiling}`,
+    `weighted sum of per-component maxima:                     ${theoretical.toFixed(1)}`,
+  ].join('\n');
 }
 
 export function summarise(results: CaseResult[]): BenchmarkSummary {
@@ -140,6 +249,8 @@ export function summarise(results: CaseResult[]): BenchmarkSummary {
     falseWeakRate: shouldNotBeWeak.length === 0 ? 0 : falseWeakCount / shouldNotBeWeak.length,
     strongReached: results.some(r => r.label === 'strong' && r.predicted === 'strong'),
     scoresByLabel,
+    observedCeiling: results.length === 0 ? 0 : Math.max(...results.map(r => r.score)),
+    subscoreStats: summariseSubscores(results),
   };
 }
 

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -141,6 +141,29 @@ export const SEMANTIC_THRESHOLDS = {
 
   /** Maximum semantic score when keyword_exact is low */
   capped_semantic_max: 70,
+
+  /**
+   * Cosine similarity anchors for the 0-100 scale (WP-59 S3b).
+   *
+   * The analyzer used to map cosine with `(cos + 1) / 2`, the textbook
+   * transform for a value that can legitimately reach -1. Embeddings of two
+   * real documents never go near -1: measured across the 32-case benchmark the
+   * component spanned only **61 to 84**, on cases a human labelled strong,
+   * stretch AND weak. Eighteen percent of the composite was carrying a
+   * 23-point usable range, so it could neither reward a genuine match nor
+   * distinguish one from a poor one — and its floor of 61 is what made the
+   * semantic-vs-keyword gap penalty fire on essentially every low-keyword
+   * resume.
+   *
+   * These anchor the scale to the range embeddings actually produce here:
+   * `floor` is two documents with nothing in common, `ceiling` is a resume that
+   * reads like the job description. Values outside are clamped.
+   *
+   * Anything that changes these changes the scale, and the bands in
+   * config/bands.ts must be re-derived in the same change.
+   */
+  cosine_floor: 0.10,
+  cosine_ceiling: 0.70,
 } as const;
 
 /**

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -109,6 +109,21 @@ export const KEYWORD_THRESHOLDS = {
 
   /** N-gram sizes to extract (3-6 words) */
   ngram_sizes: [3, 4, 5, 6],
+
+  /**
+   * Technologies short enough to be deleted by `min_keyword_length`.
+   *
+   * `tokenize` and `skillCoverage` both drop tokens under 3 characters, so a
+   * job requiring Go, AI, ML, QA, UX, BI or CI never measured whether the
+   * candidate had it — the requirement was removed before matching rather than
+   * scored as missing. Single letters (`r`, `c`) stay out: lowercased and
+   * word-bounded they match far too much ordinary prose to be evidence of a
+   * skill (WP-59 S3c).
+   */
+  short_skill_tokens: new Set([
+    'go', 'js', 'ts', 'ai', 'ml', 'qa', 'ux', 'ui', 'bi', 'ci', 'cd', 'nlp',
+    'etl', 'api', 'aws', 'gcp', 'sql', 'php', 'ios',
+  ]),
 } as const;
 
 /**
@@ -138,13 +153,52 @@ export const METRICS_THRESHOLDS = {
   /** Ideal metrics per role */
   ideal_metrics_per_role: 2,
 
-  /** Patterns that count as metrics */
+  /**
+   * Patterns that count as a quantified achievement.
+   *
+   * The first five are the original set. Between them they require a `%`, a
+   * `$`, a `#`, an `x` or an uppercase K/M/B — so every ordinary quantity a
+   * real engineer writes counted as NO metric at all:
+   *
+   *   "reduced p99 latency from 800ms to 120ms"   -> 0 metrics
+   *   "led a team of 12 engineers"                -> 0 metrics
+   *   "served 3 million requests per day"         -> 0 metrics
+   *   "cut deploy time from 40 minutes to 6"      -> 0 metrics
+   *
+   * `metrics_presence` hard-clamps to 0 when nothing matches, so those resumes
+   * forfeited the whole 11.4% weight. Measured across the 32-case benchmark the
+   * component meaned 5.3 out of 100 — on fixtures written to contain metrics
+   * (WP-59 S3d).
+   *
+   * The additions all require a number bound to a UNIT or a countable noun, or
+   * an explicit before/after. A bare integer still does not count, so years
+   * ("2019"), phone numbers and street numbers stay out.
+   *
+   * This changes what counts as a metric the candidate ALREADY WROTE. It does
+   * not touch `stripFabricatedMetrics`, which stops the optimizer inventing
+   * figures, and must stay exactly as strict as it is.
+   */
   metric_patterns: [
     /\d+%/,           // Percentages: 25%
     /\$[\d,]+/,       // Dollar amounts: $50,000
     /#\d+/,           // Numbers: #1 ranking
-    /\d+x/,           // Multipliers: 3x increase
-    /\d+[KMB]/,       // Abbreviated: 5K, 2M, 1B
+    /\d+\s*x\b/i,     // Multipliers: 3x increase
+    /\d+\s*[KMB]\b/,  // Abbreviated: 5K, 2M, 1B
+
+    // Magnitude words: "3 million requests", "250 thousand users"
+    /\b\d[\d,.]*\s*(?:million|billion|thousand|mn|bn)\b/i,
+
+    // Durations and latencies: "800ms", "40 minutes", "3 weeks"
+    /\b\d[\d,.]*\s*(?:ms|milliseconds?|s(?:ec(?:onds?)?)?|min(?:utes?)?|hrs?|hours?|days?|weeks?|months?|quarters?)\b/i,
+
+    // Data and throughput: "2TB", "500 rps", "1.2GB"
+    /\b\d[\d,.]*\s*(?:[kmgt]b|rps|qps|tps|iops|fps)\b/i,
+
+    // Counted things a resume actually claims
+    /\b\d[\d,.]*\s*(?:users?|customers?|clients?|accounts?|engineers?|developers?|people|reports?|requests?|queries|transactions?|records?|rows?|teams?|projects?|stores?|markets?|countries|languages?|integrations?|services?|microservices?|endpoints?)\b/i,
+
+    // Explicit before/after, the clearest impact claim of all
+    /\bfrom\s+\d[\d,.]*\s*\S*\s+to\s+\d/i,
   ],
 } as const;
 

--- a/src/lib/ats/config/thresholds.ts
+++ b/src/lib/ats/config/thresholds.ts
@@ -30,6 +30,17 @@ export const PENALTY_THRESHOLDS = {
 /**
  * Thresholds for generating suggestions
  */
+/**
+ * All four gain thresholds below were set against `estimateImpact`'s old output,
+ * which multiplied an already-final-scale number by 100 and clamped it to 15
+ * (WP-59 S1). On that scale every suggestion read 15, so `min_gain: 3` filtered
+ * nothing and `quick_win_effort_threshold: 8` promoted everything.
+ *
+ * With the units corrected, real per-suggestion gains are 0.4-3.8 final-score
+ * points. Carrying the old numbers forward would have silently emptied the
+ * suggestions list — 3 is above almost every honest value — which is why they
+ * move in the same change rather than in a follow-up.
+ */
 export const SUGGESTION_THRESHOLDS = {
   /** Sub-scores below this are "urgent" (red zone) */
   urgent_threshold: 50,
@@ -37,14 +48,21 @@ export const SUGGESTION_THRESHOLDS = {
   /** Sub-scores below this generate normal suggestions (yellow zone) */
   normal_threshold: 70,
 
-  /** Minimum estimated gain to show a suggestion (filter noise) */
-  min_gain: 3,
+  /** Minimum estimated gain, in final-score points, to show a suggestion. */
+  min_gain: 0.5,
 
   /** Maximum suggestions to return (avoid overwhelming user) */
   max_suggestions: 10,
 
-  /** Minimum score difference to mark as "quick win" */
-  quick_win_effort_threshold: 8,
+  /** Minimum estimated gain, in final-score points, to mark as "quick win". */
+  quick_win_effort_threshold: 1.5,
+
+  /**
+   * Minimum estimated gain, in final-score points, for the UI's "high impact"
+   * grouping. Lives here rather than as a literal in each component, so the
+   * grouping cannot drift away from the scale the estimator actually produces.
+   */
+  high_impact_threshold: 2,
 } as const;
 
 /**

--- a/src/lib/ats/extractors/jd-extractor.ts
+++ b/src/lib/ats/extractors/jd-extractor.ts
@@ -47,11 +47,28 @@ export function extractJobData(jobText: string, existingExtraction?: Partial<Job
  * Extract job title from text (look for common patterns)
  */
 function extractJobTitle(text: string): string {
-  // Common patterns for job titles in JDs
+  // Common patterns for job titles in JDs.
+  //
+  // All three original patterns depend on Latin script and on capitalisation.
+  // Hebrew has no case, so a Hebrew job description returned '' — which sent
+  // title_alignment to its "no target title" constant of 50 for EVERY Hebrew
+  // job, and left the {targetTitle} placeholder uninterpolated in the diagnosis
+  // bullets the user reads. The Hebrew patterns below anchor on the hiring
+  // verbs instead of on capitalisation (WP-59 S3e).
+  //
+  // Same approach as the resume-side extractor in title-alignment.ts: add
+  // script-specific patterns rather than loosening the Latin ones, which would
+  // start matching ordinary prose.
   const patterns = [
     /(?:position|role|title|job):\s*([^\n]+)/i,
     /we are (?:looking for|hiring|seeking) (?:a|an)\s+([^\n.]+)/i,
     /^([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,4})\s*$/m,  // Capitalized multi-word title
+
+    // Hebrew labelled forms: משרה / תפקיד / דרוש / דרושה followed by the role.
+    /(?:משרה|תפקיד|התפקיד|דרוש|דרושה|דרוש\/ה|מחפשים|מגייסים)\s*[:\-]?\s*([^\n]{2,60})/,
+
+    // Hebrew "we are looking for a ..." without a label.
+    /(?:אנחנו|אנו)\s+(?:מחפשים|מגייסים)\s+([^\n.]{2,60})/,
   ];
 
   for (const pattern of patterns) {

--- a/src/lib/ats/extractors/skill-phrase-extractor.ts
+++ b/src/lib/ats/extractors/skill-phrase-extractor.ts
@@ -1,6 +1,28 @@
 import { KEYWORD_THRESHOLDS } from '../config/thresholds';
-import { normalizeText, tokenize } from '../utils/text-utils';
+import { normalizeText, tokenize, isShortSkillToken } from '../utils/text-utils';
 
+/**
+ * Words that describe HAVING a skill rather than naming one.
+ *
+ * These were stripped only from the FRONT of a clause, so anything that
+ * survived into the middle became part of the "requirement" a resume then had
+ * to match. Measured on a candidate holding every skill a job asked for,
+ * `keyword_exact` read 45.8 against 80.0 for a human's list of the same skills,
+ * because the atomizer emitted these as must-haves (WP-59 S3c):
+ *
+ *   "Experience building and operating distributed systems"  -> `building`
+ *   "Strong background in PostgreSQL"                        -> `background postgresql`
+ *   "Hands-on experience with Kubernetes"                    -> `hands experience`
+ *   "Proficiency with Go"                                    -> `proficiency`
+ *   "Familiarity with Terraform and infrastructure as code"  -> `familiarity`
+ *
+ * Six of twelve extracted requirements were unmatchable by construction. Worse,
+ * they are shown to the user as things missing from their resume — people were
+ * being told to add "proficiency" to their CV.
+ *
+ * They are now removed wherever they appear, and a clause that reduces to
+ * nothing but noise is dropped rather than emitted as a bare filler word.
+ */
 const LEADING_NOISE = new Set([
   'develop', 'build', 'lead', 'manage', 'conduct', 'maintain', 'identify',
   'support', 'drive', 'create', 'design', 'execute', 'deliver', 'own', 'scale',
@@ -11,7 +33,49 @@ const LEADING_NOISE = new Set([
   'understanding', 'experience', 'years', 'including', 'various', 'related',
   'relevant', 'existing', 'potential', 'complex', 'work', 'working',
   'minimum', 'highly', 'desirable', 'naturally', 'curious', 'continually',
+  // Added WP-59 S3c — every one of these was observed as an emitted "skill".
+  'proficiency', 'proficient', 'familiarity', 'familiar', 'background',
+  'hands', 'expertise', 'exposure', 'comfort', 'comfortable', 'fluency',
+  'fluent', 'passion', 'passionate', 'desire', 'willingness', 'willing',
+  'building', 'operating', 'managing', 'leading', 'developing', 'designing',
+  'great', 'good', 'prior', 'previous', 'several', 'multiple',
+  'plus', 'bonus', 'advantage', 'required', 'preferred', 'must', 'nice',
 ]);
+
+/**
+ * The same class of filler in Hebrew.
+ *
+ * Needed as soon as `normalizeText` stopped deleting Hebrew outright: Hebrew
+ * requirements now survive into the atomizer, and without this they would
+ * atomize into filler phrases exactly as the English ones did — trading one
+ * source of unmatchable requirements for another.
+ */
+const HEBREW_NOISE = new Set([
+  'ניסיון', 'ידע', 'יכולת', 'הבנה', 'היכרות', 'שליטה', 'שנות', 'שנים',
+  'חובה', 'יתרון', 'לפחות', 'גבוהה', 'גבוה', 'מעולה', 'טובה', 'טוב',
+  'עם', 'של', 'על', 'את', 'או', 'וכן', 'גם', 'כולל', 'רלוונטי', 'מוכח',
+  'שפת', 'שפה', 'תחום', 'סביבת', 'עבודה', 'צוות', 'חברה', 'משרה',
+]);
+
+/** Hebrew one-letter proclitics: and / the / in / to / from / that / like. */
+const HEBREW_PROCLITICS = 'והבלמשכ';
+
+function isNoiseToken(token: string): boolean {
+  if (LEADING_NOISE.has(token) || HEBREW_NOISE.has(token) || CONNECTORS.has(token)) {
+    return true;
+  }
+
+  // Hebrew glues "in", "the" and "of" onto the following word, so the filler
+  // arrives inflected: בשפת ("in the language of"), בניסיון ("in experience").
+  // Listing every inflection would be endless; test the stem instead. Without
+  // this, `בשפת go` survived as a two-token requirement that a resume saying Go
+  // could not satisfy, because one of the two tokens was pure filler.
+  if (token.length > 3 && HEBREW_PROCLITICS.includes(token[0])) {
+    return HEBREW_NOISE.has(token.slice(1));
+  }
+
+  return false;
+}
 
 const TRAILING_BOILERPLATE =
   /\b(is highly desirable|with a track record of success|you are|you can|you have|a true)\b/gi;
@@ -33,6 +97,7 @@ const CONNECTORS = new Set([
   'on', 'by', 'at', 'from', 'is', 'are', 'be', 'will', 'you', 'we', 'they',
   'them', 'its', 'plus', 'etc', 'via', 'per', 'end', 'able', 'other', 'both',
   'all', 'any', 'using', 'use', 'well', 'more', 'most', 'than', 'then', 'new',
+  'another', 'language', 'languages',
 ]);
 
 const CLAUSE_SPLIT =
@@ -94,26 +159,23 @@ export function extractSkillPhrases(requirements: string[]): string[] {
 
     for (const clause of normalizeText(raw).split(CLAUSE_SPLIT)) {
       const tokens = tokenize(clause).filter(Boolean);
-      let start = 0;
 
-      while (
-        start < tokens.length &&
-        (LEADING_NOISE.has(tokens[start]) ||
-          CONNECTORS.has(tokens[start]) ||
-          tokens[start].length < KEYWORD_THRESHOLDS.min_keyword_length)
-      ) {
-        start += 1;
-      }
+      // Noise is dropped wherever it sits, not only at the front. Leaving it in
+      // the middle is what produced `background postgresql` — a two-token
+      // requirement that a resume saying "PostgreSQL" could never satisfy,
+      // because coverage needs 60% of the tokens and one of the two was a word
+      // no resume would ever contain.
+      const kept = tokens.filter(
+        (token) =>
+          !isNoiseToken(token) &&
+          (token.length >= KEYWORD_THRESHOLDS.min_keyword_length || isShortSkillToken(token)),
+      );
 
-      const kept = tokens
-        .slice(start)
-        .filter(
-          (token) =>
-            !CONNECTORS.has(token) &&
-            token.length >= KEYWORD_THRESHOLDS.min_keyword_length,
-        );
-
+      // A clause that was ALL filler names no skill. Emitting its leftovers as
+      // a requirement is what put `proficiency` and `familiarity` in front of
+      // users as gaps in their resume.
       if (kept.length === 0) continue;
+
       const phrase = kept.slice(0, 3).join(' ');
       if (!isJunkSkillPhrase(phrase)) {
         phrases.add(phrase);

--- a/src/lib/ats/scorers/penalties.ts
+++ b/src/lib/ats/scorers/penalties.ts
@@ -35,14 +35,22 @@ export function applyPenalties(
   // The component still carries the signal, and the suggestion generator still
   // tells the user to add quantified achievements.
 
-  // Penalty 2: Title/seniority mismatch
-  if (subscores.title_alignment < 40) {
-    penalizedScore -= PENALTY_THRESHOLDS.title_mismatch_penalty;
-    appliedPenalties.push({
-      reason: 'Job title and seniority mismatch',
-      amount: PENALTY_THRESHOLDS.title_mismatch_penalty,
-    });
-  }
+  // Penalty 2 (withdrawn 2026-08-19, WP-59 S3e): "title/seniority mismatch".
+  //
+  // Same double-charge WP-45 D2 removed for metrics. title_alignment is already
+  // a weighted component at 11.4%, and a mismatch lowers it directly — then this
+  // subtracted 3 more for the same fact.
+  //
+  // Worse, the trigger fired hardest on measurements that were not mismatches at
+  // all. The analyzer returns a CONSTANT 50 when the job description has no
+  // extractable title and a CONSTANT 20 when it cannot parse titles out of the
+  // resume — and 20 is below the 40 threshold, so every resume the text-path
+  // extractor could not read was charged a mismatch penalty for a comparison
+  // that never happened. Measured across the benchmark, title_alignment has a
+  // minimum of 16, so this fired on real cases.
+  //
+  // The component still carries the signal, and the seniority check inside it is
+  // unchanged.
 
   // Penalty 3: High format risk
   if (subscores.format_parseability < PENALTY_THRESHOLDS.format_risk_threshold) {
@@ -53,15 +61,22 @@ export function applyPenalties(
     });
   }
 
-  // Penalty 4: Semantic-keyword gap (suspicious)
-  const semanticKeywordGap = subscores.semantic_relevance - subscores.keyword_exact;
-  if (semanticKeywordGap > PENALTY_THRESHOLDS.semantic_keyword_gap_threshold) {
-    penalizedScore -= PENALTY_THRESHOLDS.semantic_keyword_gap_penalty;
-    appliedPenalties.push({
-      reason: 'High semantic score but low keyword match (suspicious)',
-      amount: PENALTY_THRESHOLDS.semantic_keyword_gap_penalty,
-    });
-  }
+  // Penalty 4 (withdrawn 2026-08-19, WP-59 S3b): "high semantic, low keyword".
+  //
+  // The third instance of the same double-charge, and the most exact. The
+  // semantic analyzer caps itself at `capped_semantic_max` (70) whenever
+  // keyword_exact is below `keyword_cap_threshold` (40). This then subtracted 5
+  // more whenever semantic minus keyword exceeded 30 — which, at a capped 70, is
+  // true precisely when keyword_exact is below 40. The identical condition,
+  // charged twice, by two mechanisms that did not know about each other.
+  //
+  // The cap is the better of the two and stays: it bounds the inflation at
+  // source instead of subtracting from the total afterwards, and it leaves the
+  // subscore honest for anything reading the components directly.
+  //
+  // (This was doubly wrong before S3b, because semantic could not go below 61 —
+  // so a resume with genuinely poor keyword coverage was guaranteed to trip the
+  // 30-point gap no matter how unrelated it actually was.)
 
   // Ensure score stays in valid range
   penalizedScore = Math.max(0, Math.min(100, penalizedScore));

--- a/src/lib/ats/skill-match.ts
+++ b/src/lib/ats/skill-match.ts
@@ -3,7 +3,7 @@
  * Matches at the requirement-phrase level, not only individual tokens.
  */
 
-import { normalizeText, tokenize } from './utils/text-utils';
+import { normalizeText, tokenize, isShortSkillToken } from './utils/text-utils';
 import { KEYWORD_THRESHOLDS } from './config/thresholds';
 
 const STOP_WORDS = new Set([
@@ -18,16 +18,44 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/**
+ * Hebrew one-letter proclitics: and / the / in / to / from / that / like.
+ *
+ * Hebrew attaches "in", "the" and "and" directly to the noun, so a job asking
+ * for בפיתוח ("in development") and a resume saying פיתוח ("development") are
+ * the same requirement written two ways and never match as strings.
+ */
+const HEBREW_PROCLITIC = '[\\u05D5\\u05D4\\u05D1\\u05DC\\u05DE\\u05E9\\u05DB]?';
+const STARTS_HEBREW = /^[\u0590-\u05FF]/;
+
 function containsWholePhrase(normalizedResume: string, normalizedPhrase: string): boolean {
   if (!normalizedPhrase) return false;
-  const pattern = new RegExp(`(^|[^a-z0-9])${escapeRegExp(normalizedPhrase)}([^a-z0-9]|$)`);
+
+  // Word boundaries must be Unicode-aware. `[^a-z0-9]` treats every Hebrew
+  // character as a boundary, so "פיתוח" matched INSIDE "בפיתוח" — and equally
+  // inside any longer word that merely contained those letters. That is
+  // substring matching dressed up as whole-word matching, and it inflates
+  // keyword_exact for every non-Latin script (WP-59 S3c).
+  const boundary = '[^\\p{L}\\p{N}]';
+
+  // Having made the boundary strict, allow the ONE thing it now wrongly
+  // excludes: a leading Hebrew particle on the first word of the phrase.
+  const prefix = STARTS_HEBREW.test(normalizedPhrase) ? HEBREW_PROCLITIC : '';
+
+  const pattern = new RegExp(
+    `(^|${boundary})${prefix}${escapeRegExp(normalizedPhrase)}(${boundary}|$)`,
+    'u'
+  );
   return pattern.test(normalizedResume);
 }
 
+/** Long enough to be evidence, or a known short technology name. */
+function isScorableToken(word: string): boolean {
+  return word.length >= KEYWORD_THRESHOLDS.min_keyword_length || isShortSkillToken(word);
+}
+
 function significantTokens(text: string): string[] {
-  return tokenize(text).filter(
-    (word) => word.length >= KEYWORD_THRESHOLDS.min_keyword_length && !STOP_WORDS.has(word)
-  );
+  return tokenize(text).filter((word) => isScorableToken(word) && !STOP_WORDS.has(word));
 }
 
 /**
@@ -42,7 +70,7 @@ export function skillMatchesResume(skill: string, resumeText: string): boolean {
   }
 
   // Whole-phrase match (handles "Node.js", "machine learning", etc.)
-  if (normalizedSkill.length >= KEYWORD_THRESHOLDS.min_keyword_length) {
+  if (isScorableToken(normalizedSkill)) {
     if (containsWholePhrase(normalizedResume, normalizedSkill)) {
       return true;
     }
@@ -76,10 +104,7 @@ export function skillCoverage(skill: string, resumeText: string): number {
     return 0;
   }
 
-  if (
-    normalizedSkill.length >= KEYWORD_THRESHOLDS.min_keyword_length &&
-    containsWholePhrase(normalizedResume, normalizedSkill)
-  ) {
+  if (isScorableToken(normalizedSkill) && containsWholePhrase(normalizedResume, normalizedSkill)) {
     return 1;
   }
 

--- a/src/lib/ats/suggestions/__tests__/impact-estimator.test.ts
+++ b/src/lib/ats/suggestions/__tests__/impact-estimator.test.ts
@@ -1,0 +1,90 @@
+/**
+ * WP-59 S1 — a suggestion may not promise more than applying it can deliver.
+ *
+ * The defect these tests pin: `estimateImpact` multiplied `subscoreGap × weight`
+ * — already a final-score number — by 100, then clamped to 15. Every real value
+ * is under 4, so the clamp caught all of them and every suggestion in the
+ * product displayed exactly 15. Three of them read "+15 / +15 / +15" beside an
+ * apply that could move the score by seven.
+ *
+ * The property worth defending is not a particular number. It is that the sum
+ * of what we promise stays inside the score's remaining headroom, and that no
+ * single suggestion promises more than its component's weight can pay.
+ */
+
+import { estimateImpact, estimateTotalImpact } from '../impact-estimator';
+import { SUB_SCORE_WEIGHTS } from '../../config/weights';
+import { SUGGESTION_THRESHOLDS } from '../../config/thresholds';
+import type { SubScoreKey } from '../../types';
+
+const WEIGHTED_KEYS = (Object.keys(SUB_SCORE_WEIGHTS) as SubScoreKey[]).filter(
+  key => SUB_SCORE_WEIGHTS[key] > 0
+);
+
+describe('estimateImpact units', () => {
+  it('returns final-score points, not sub-score points', () => {
+    // 20 sub-score points on a component weighted 25% is worth 5 points of the
+    // composite. Not 500, and not a clamped 15.
+    expect(estimateImpact('keyword_exact', 45, 20)).toBeCloseTo(5, 5);
+  });
+
+  it('never exceeds the component weight times the room it has left', () => {
+    for (const key of WEIGHTED_KEYS) {
+      for (const currentScore of [0, 25, 50, 75, 90, 100]) {
+        for (const templateGain of [4, 8, 12, 15]) {
+          const gain = estimateImpact(key, currentScore, templateGain);
+          const ceiling = (100 - currentScore) * SUB_SCORE_WEIGHTS[key];
+          expect(gain).toBeLessThanOrEqual(ceiling + 0.05);
+        }
+      }
+    }
+  });
+
+  it('does not pin every suggestion to one value', () => {
+    // The symptom that made the 100x error invisible: the clamp collapsed the
+    // whole range onto a single number. If this ever goes back to 1, the
+    // estimator has stopped estimating.
+    const distinct = new Set(
+      WEIGHTED_KEYS.map(key => estimateImpact(key, 40, 12))
+    );
+    expect(distinct.size).toBeGreaterThan(1);
+  });
+
+  it('promises nothing on a component with no room left', () => {
+    expect(estimateImpact('keyword_exact', 100, 15)).toBe(0);
+  });
+
+  it('stays above the display floor for a genuinely worthwhile fix', () => {
+    // Guards the other direction: if the thresholds and the estimator ever drift
+    // apart again, the highest-weight component's advice would be filtered out
+    // of the product entirely and nobody would see a suggestions list.
+    const bestCase = estimateImpact('keyword_exact', 30, 15);
+    expect(bestCase).toBeGreaterThanOrEqual(SUGGESTION_THRESHOLDS.min_gain);
+  });
+});
+
+describe('estimateTotalImpact', () => {
+  it('cannot promise more than the score has headroom for', () => {
+    const suggestions = Array.from({ length: 10 }, () => ({ estimated_gain: 3.5 }));
+    expect(estimateTotalImpact(suggestions, 80)).toBeLessThanOrEqual(20);
+  });
+
+  it('sums honestly when there is room', () => {
+    expect(estimateTotalImpact([{ estimated_gain: 2.5 }, { estimated_gain: 1.5 }], 50)).toBeCloseTo(4, 5);
+  });
+
+  it('a full suggestion set cannot claim the old flat 30', () => {
+    // One maximum-strength suggestion on every weighted component at once —
+    // the most the estimator can ever promise. The weights sum to 1, so the
+    // honest total converges on the template gain itself (~15), give or take
+    // per-suggestion rounding. The previous implementation advertised 30 as a
+    // "realistic maximum"; the real one is half that, and only when every
+    // component simultaneously has room for a 15-point repair.
+    const suggestions = WEIGHTED_KEYS.map(key => ({
+      estimated_gain: estimateImpact(key, 50, 15),
+    }));
+    const total = estimateTotalImpact(suggestions, 50);
+    expect(total).toBeGreaterThan(10);
+    expect(total).toBeLessThan(30);
+  });
+});

--- a/src/lib/ats/suggestions/generator.ts
+++ b/src/lib/ats/suggestions/generator.ts
@@ -165,7 +165,11 @@ function expandKeywordSuggestion(suggestion: Suggestion): Suggestion[] {
     return [suggestion];
   }
 
-  const gainPerKeyword = Math.max(1, Math.round(suggestion.estimated_gain / keywords.length));
+  // Split the parent's gain across the keywords, never inflate it. The old
+  // `Math.max(1, ...)` floor turned one 15-point promise into twenty 1-point
+  // promises — expansion was manufacturing score out of arithmetic. Flooring to
+  // one decimal guarantees the parts sum to no more than the whole (WP-59 S1).
+  const gainPerKeyword = Math.floor((suggestion.estimated_gain / keywords.length) * 10) / 10;
 
   return keywords.map((keyword) => ({
     id: `keyword_exact:${slugifyKeyword(keyword)}`,

--- a/src/lib/ats/suggestions/impact-estimator.ts
+++ b/src/lib/ats/suggestions/impact-estimator.ts
@@ -1,19 +1,37 @@
 /**
  * Impact Estimator
  *
- * Estimates the score gain from applying a suggestion
+ * Estimates the score gain from applying a suggestion.
  */
 
 import type { SubScoreKey } from '../types';
 import { SUB_SCORE_WEIGHTS } from '../config/weights';
 
+/** Round to one decimal. Gains are small enough that integers erase them. */
+function toDisplayPoints(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
 /**
- * Estimate impact of fixing a gap
+ * Estimate the impact of fixing a gap, in FINAL SCORE points.
  *
- * Takes into account:
- * - Current score gap
- * - Sub-score weight in final score
- * - Baseline template gain
+ * The unit chain matters and used to be wrong (WP-59 S1):
+ *
+ *   maxPossibleGain  is in SUB-SCORE points   (0-100 on one component)
+ *   weight           is a fraction            (0.09 - 0.25)
+ *   product          is in FINAL SCORE points — already, with no scaling
+ *
+ * The previous implementation multiplied that product by 100 and then clamped
+ * the result to 15. Every real value is between 0.36 and 3.75 (template gains
+ * run 4-15, weights 0.09-0.25), so multiplying by 100 pushed every single
+ * suggestion past the clamp and every single one displayed as exactly 15. That
+ * is the "+15 / +15 / +15" a user sees beside an apply that moves the score by
+ * seven — the clamp is what made the bug invisible, because a wrong number that
+ * varied would have been noticed years ago.
+ *
+ * There is no display scaling here now. If a suggestion is worth two points,
+ * it says two points, and the sum of what we promise is a number apply can
+ * actually deliver.
  */
 export function estimateImpact(
   subscore: SubScoreKey,
@@ -22,28 +40,32 @@ export function estimateImpact(
 ): number {
   const weight = SUB_SCORE_WEIGHTS[subscore];
 
-  // Calculate potential gain in this sub-score
-  const gap = 100 - currentScore;
+  // How much room this component has left, and how much the advice can close.
+  const gap = Math.max(0, 100 - currentScore);
   const maxPossibleGain = Math.min(gap, templateGain);
 
-  // Impact on final score = sub-score gain × weight
-  const finalScoreImpact = maxPossibleGain * weight;
-
-  // Scale to 0-15 range for display
-  return Math.round(Math.min(15, finalScoreImpact * 100));
+  return toDisplayPoints(maxPossibleGain * weight);
 }
 
 /**
- * Estimate total impact if all suggestions applied
+ * Estimate the total impact if every suggestion is applied.
+ *
+ * Previously capped at a flat 30 "realistic maximum", which was neither
+ * measured nor reachable — and, sitting downstream of a 100x per-suggestion
+ * error, it was the second thing hiding the first. The honest ceiling is the
+ * headroom the score actually has: a resume at 67 cannot gain 40 points.
  */
 export function estimateTotalImpact(
-  suggestions: Array<{ estimated_gain: number }>
+  suggestions: Array<{ estimated_gain: number }>,
+  currentScore?: number
 ): number {
-  // Sum all gains, but cap at realistic maximum
   const totalGain = suggestions.reduce((sum, s) => sum + s.estimated_gain, 0);
 
-  // Cap at 30 points (realistic maximum improvement)
-  return Math.min(30, totalGain);
+  if (typeof currentScore === 'number' && Number.isFinite(currentScore)) {
+    return toDisplayPoints(Math.min(totalGain, Math.max(0, 100 - currentScore)));
+  }
+
+  return toDisplayPoints(totalGain);
 }
 
 /**

--- a/src/lib/ats/utils/text-utils.ts
+++ b/src/lib/ats/utils/text-utils.ts
@@ -8,23 +8,60 @@ import type { NormalizedText } from '../types';
 import { KEYWORD_THRESHOLDS } from '../config/thresholds';
 
 /**
- * Normalize text for comparison
+ * Normalize text for comparison.
+ *
+ * Unicode-aware. `\w` is ASCII-only in JavaScript without the `u` flag, so
+ * `[^\w\s]` treated every Hebrew, Arabic, Cyrillic and accented-Latin character
+ * as punctuation and replaced it with a space. This function is the entry point
+ * for `tokenize`, `skillMatchesResume`, `skillCoverage` and `extractSkillPhrases`
+ * — which is to say for `keyword_exact`, 25% of the composite.
+ *
+ * The effect on a Hebrew resume scored against a Hebrew job:
+ *
+ *   'מהנדס תוכנה בכיר עם ניסיון ב Kubernetes ו PostgreSQL'
+ *     -> 'kubernetes postgresql'
+ *
+ * Every Hebrew word deleted, and a requirement expressed only in Hebrew
+ * normalized to the empty string — so `skillCoverage` returned 0 for it no
+ * matter what the resume said. A Hebrew job description was effectively scored
+ * on its English technology names alone (WP-59 S3c).
+ *
+ * `title_alignment` and `section_completeness` were repaired for this in WP-45
+ * and carry their own Unicode-aware normalizers; the shared one they did not use
+ * was left behind. Keep `\p{L}\p{N}` and the `u` flag here.
  */
 export function normalizeText(text: string): string {
   return text
     .toLowerCase()
-    .replace(/[^\w\s]/g, ' ')  // Replace punctuation with spaces
-    .replace(/\s+/g, ' ')       // Collapse multiple spaces
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')  // Replace punctuation with spaces
+    .replace(/\s+/g, ' ')                 // Collapse multiple spaces
     .trim();
 }
 
 /**
- * Tokenize text into words (filtered by minimum length)
+ * Tokenize text into words (filtered by minimum length).
+ *
+ * Tokens shorter than `minLength` survive when they are known technologies.
+ * The plain length filter silently deleted Go, AI, ML, QA, UX, BI and CI from
+ * both job requirements and resumes — a job asking for Go never measured
+ * whether the candidate had it.
  */
 export function tokenize(text: string, minLength: number = KEYWORD_THRESHOLDS.min_keyword_length): string[] {
   return normalizeText(text)
     .split(/\s+/)
-    .filter(word => word.length >= minLength);
+    .filter(word => word.length >= minLength || isShortSkillToken(word));
+}
+
+/**
+ * Known short technology names, which the minimum-length filter would drop.
+ *
+ * Deliberately excludes single letters (`r`, `c`) and anything that is a common
+ * English word on its own. `go` is included because it is a real and frequent
+ * backend requirement — it was the founder's own case — and it is checked with
+ * whole-word boundaries, so `go-to` is the only realistic false positive.
+ */
+export function isShortSkillToken(token: string): boolean {
+  return KEYWORD_THRESHOLDS.short_skill_tokens.has(token);
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
   "exclude": [
     "node_modules",
     ".next",
-    "resume-builder-ai/**",
+    ".claude/worktrees/**", "resume-builder-ai/**",
     "scripts/scripts/**",
     "supabase/**"
   ]


### PR DESCRIPTION
## Why

The founder could not get the Match Check above 85 while recording a demo, and concluded — correctly — that on that particular résumé/JD pair 85 is not honestly reachable. This packet asks the wider question: what can the engine reach for *anyone*, and where does the score leak?

## The finding that killed the starting hypothesis

**The engine was never ceiling-bound.** First live benchmark, 25 labelled cases, composite spread **44 → 93**. 85 was already reachable on clean input. The problem is that production input never reaches the state benchmark input is in.

So this is not a recalibration. It is a repair of what the components measure.

## Component ranges, before → after

```
component             weight     before (min/mean/max)    after (min/mean/max)
keyword_exact          25.0%      0.0 / 51.0 / 100.0       0.0 / 51.7 / 100.0
semantic_relevance     18.2%     61.0 / 73.6 /  84.0      21.0 / 67.9 /  95.0
format_parseability    15.9%     85.0 / 85.0 /  85.0      85.0 / 85.0 /  85.0  CONSTANT
title_alignment        11.4%     16.0 / 57.5 / 100.0      16.0 / 57.5 / 100.0
metrics_presence       11.4%      0.0 /  5.3 / 100.0       0.0 /  5.3 / 100.0
section_completeness    9.1%    100.0 /100.0 / 100.0     100.0 /100.0 / 100.0  CONSTANT
recency_fit             9.1%     70.0 / 78.8 /  97.0      70.0 / 79.0 /  97.0
```

## Commits

**S0 — measure the ceiling.** Per-component min/mean/max reporting. Also fixes the instrument: `createFailedResult` sets confidence 0, `aggregateScores` overwrites the subscore with 0 and redistributes the weight, so the semantic analyzer's 50 fallback never survives — and the degradation guard compared against that 50. `degradedCount()` returned 0 on a *fully* degraded run. The shipped 57/42 bands could have been derived from a run missing 18.2% of the score.

**S1 — stop over-promising.** `estimateImpact` multiplied an already-final-scale number by 100 and clamped to 15. Every real value is 0.36–3.75, so every suggestion displayed exactly 15. The clamp is what hid it.

**S2 — free/optimize parity.** 25% of the score was computed two different ways depending on which screen you were on. Also closes a hole where a scraper miss scored the résumé against an *empty* job.

**S3c/S3d — score what the job asks for.** `normalizeText` used `[^\w\s]`, and JS `\w` without `u` is ASCII-only, so **every Hebrew character was replaced with a space**. A Hebrew JD was scored on its English technology names alone. The atomizer emitted `proficiency`, `familiarity`, `building`, `background postgresql` as must-haves — six of twelve unmatchable, each shown to users as a gap in their CV. `min_keyword_length` deleted Go, AI, ML, QA, UX outright. Metrics required a `%`/`$`/`#`/`x`/`KMB` symbol, so `800ms`, `12 engineers`, `3 million requests` all counted as zero.

**S3e/S3b — semantic range and the last two double-charges.** `(cos + 1) / 2` assumes cosine can reach -1; between real documents it does not, so 18.2% of the composite carried a 23-point range. Hebrew JDs had no extractable title. Both remaining penalties withdrawn — each fired hardest on measurements that were not findings (a title penalty for a comparison that never happened; a gap penalty on the identical condition the semantic cap already handles).

## Measured, on a candidate holding every skill the job asks for

| | before | after |
|---|---|---|
| English pair, `keyword_exact` | 45.8 | **81.5** |
| Hebrew pair, `keyword_exact` | no requirements extracted at all | **88.9** |

## Verification

- `npx jest src/lib/ats` — **185 passed, 18 suites**
- `npx eslint` over all 21 changed TS files — **0 errors, 0 warnings**
- Live calibration benchmark run at every stage
- Secret-scan hook standalone, exit 0

## The bands are now stale, and are deliberately NOT moved

The live benchmark fails three tests:

1. `re-derives the thresholds the product actually ships` — **the repo's own tripwire, working as designed.** On the new scale the sweep derives **strong >= 65, stretch >= 46** against the shipped 57/42.
2. `does not misband a Hebrew pair` — same fact: a stretch pair crosses the stale 57.
3. `the shipped bands separate the labelled set well` — **predates this branch.** Fails identically on `main` (accuracy `0.7894736842105263`), confirmed by stashing.

Moving the bands now would mean re-cutting thresholds against labels the fixture author wrote, which `cases.ts` itself says must not be done. **Story 4 needs independent labels before any band ships.**

Safety gates that did hold: false-Weak count **1 → 0**, and `leaves weak pairs weak under any threshold the sweep can pick` still passes. Nothing here rescues a labelled-weak pair.

These are `describeLive`, gated on `OPENAI_API_KEY`, so CI without a key skips them.

## Deliberately not done

No change to `stripFabricatedMetrics` or the never-invent-tools rule. The recording take stays 59 → 67; that pair's gap is real. Every change removes an unintended deflation; none adds uplift, minimum scores, or positive-clamped deltas.

## Known blind spot

S3c/S3d are **invisible to the benchmark** — its fixtures already supply clean single-word requirements and contain almost no quantities. Their gains are measured on realistic sentence-shaped input instead. The fixtures need sentence-shaped cases before those paths are guarded end to end.

## Still open

- **S3a** — `format_parseability` constant 85 (~2.4 pts) and the `[^\x00-\x7F]` odd-glyph test that flags every non-ASCII résumé as damaged
- **`section_completeness` constant 100** — 9.1% of weight measuring nothing
- **Aggregator writes 0 for a failed analyzer**, so any embedding hiccup in production silently reweights a user's score and stores a 0 subscore
- **Story 4** — independent labels, then re-derive bands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
